### PR TITLE
Rebrand Slide Studio as CarouselBot

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#f2f1ed" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#121310" media="(prefers-color-scheme: dark)" />
-    <title>Page not found · Slide Studio</title>
+    <title>Page not found · CarouselBot</title>
     <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <header class="app-header">
-      <a class="brand not-found-brand" href="/" aria-label="Return to Slide Studio">
+      <a class="brand not-found-brand" href="/" aria-label="Return to CarouselBot">
         <span class="brand-mark" aria-hidden="true"></span>
         <span class="brand-copy">
-          <strong>Slide Studio</strong>
-          <small>TikTok image maker</small>
+          <strong>CarouselBot</strong>
+          <small>AI carousel maker</small>
         </span>
       </a>
     </header>

--- a/README.md
+++ b/README.md
@@ -1,47 +1,53 @@
-# Slide Studio
+# CarouselBot
 
-A focused, local-first web editor for creating TikTok slideshow images.
+A focused, local-first editor for creating social carousel images.
 
-**Live:** [slides-editor.pages.dev](https://slides-editor.pages.dev)
+**Canonical site:** [carousel.bot](https://carousel.bot)
 
-Everything runs in the browser. Photos and projects stay in IndexedDB on your device — nothing is uploaded.
+Everything runs in the browser. Photos and projects stay in IndexedDB on the user's device; nothing is uploaded to an application backend.
 
 ## AI agent control
 
-The open-source local MCP companion lets Claude Code, Codex, Hermes, OpenCode, OpenClaw, and any stdio MCP client edit the hosted browser tab live. There is no hosted relay: the agent, image files, and companion stay on the user's computer.
+The open-source local MCP companion lets Claude Code, Codex, Hermes, OpenCode, OpenClaw, and any stdio MCP client edit the browser tab live. There is no hosted relay: the agent, image files, and companion stay on the user's computer.
 
 ```bash
-npx slides-studio-mcp@latest setup
+npx carouselbot@latest setup
 ```
 
-Open [slides-editor.pages.dev](https://slides-editor.pages.dev) in your normal browser and click **Connect AI** after the agent starts the companion. The MCP includes required visual-design guidance and can create projects/slides, edit every text and image property, manage assets/layers/history, return temporary rendered previews to the agent, and export PNG files locally.
+Open [carousel.bot](https://carousel.bot) in a normal local browser and click **Connect AI** after the agent starts the companion. The MCP can create projects and slides, edit text and image properties, manage assets and history, render temporary previews for visual inspection, and export PNG files locally.
 
-The npm package is only a distribution surface. Its complete source, skill, guidance, and tests live under `packages/mcp/` in this repository.
+The npm package is only a distribution surface. Its source, skill, guidance, and tests live under `packages/mcp/` in this repository. Existing `slides-studio-mcp` installations are supported by the compatibility package under `packages/slides-studio-mcp/`.
 
 ## What it does
 
-- Creates projects that persist in the browser with IndexedDB
-- Uploads multiple PNG, JPEG, WebP, GIF, SVG, or AVIF photos
-- Crops every photo to TikTok's portrait 9:16 format with drag and zoom controls
-- Shows full slide compositions in the sidebar and supports drag-to-reorder
-- Keeps a project-wide asset library so extra photos can be reused on any slide
-- Adds photo overlays by dragging an uploaded asset onto the main image, then resizing (aspect ratio locked) or rotating
-- Adds multiline text layers that can be dragged and resized
-- Offers text color presets plus a live color wheel with synchronized hex and RGB values
-- Includes clean text, adjustable outlines, per-line rounded backgrounds, and full-box backgrounds
-- Offers white or black background treatments
-- Toggles a semi-transparent TikTok UI placement preview that is never exported
-- Uses the official open-source TikTok Sans font
-- Shares one slide or every slide at once as full-resolution PNGs, with text and image layers included
-- Downloads the selected slide as a 1080 × 1920 PNG
+- Persists projects locally with IndexedDB
+- Uploads multiple PNG, JPEG, WebP, GIF, SVG, or AVIF images
+- Crops photos to portrait 9:16 with drag and zoom controls
+- Maintains a reusable project asset library
+- Adds movable and resizable text and image layers
+- Supports text color, outlines, per-line backgrounds, and full-box backgrounds
+- Provides a TikTok placement preview that is never exported
+- Shares or downloads full-resolution 1080 × 1920 PNGs
+- Allows local AI agents to edit through a loopback-only MCP companion
 
-## Run it locally
+## Run locally
 
 ```bash
+npm install
 npm start
 ```
 
 Then open [http://localhost:4173](http://localhost:4173).
+
+## Test
+
+```bash
+npm run test:migration
+npm run test:migration:browser
+npm run test:mcp
+npm run test:mcp:browser:local
+npm run build
+```
 
 ## Deploy to Cloudflare
 
@@ -51,15 +57,15 @@ This project uses Cloudflare Pages Direct Upload. The deployment contains only t
 npm run deploy
 ```
 
-The public site is [slides-editor.pages.dev](https://slides-editor.pages.dev).
+The production deploy command is intentionally main-only. Experimental branches can use the persistent development environment with `npm run deploy:dev`.
 
-The production deploy command is intentionally main-only. Experimental branches can use the separate isolated Pages test project.
+The current Pages project name and legacy `slides-editor.pages.dev` hostname are intentionally retained during the domain migration. See [docs/REBRAND_ROLLOUT.md](docs/REBRAND_ROLLOUT.md) before changing GitHub, npm, Cloudflare, or DNS.
 
-To publish the current checkout to the persistent dev environment without touching production:
+## Domain migration
 
-```bash
-npm run deploy:dev
-```
+The old and new domains have separate browser storage. The legacy origin therefore remains an application page long enough to read its IndexedDB and copy projects to `carousel.bot` through a token-bound, origin-checked `postMessage` protocol. Projects are transferred one at a time, acknowledged by the new origin, and never deleted from the old origin.
+
+Migration rollout flags live in `app-config.js`. They default to a non-forwarding grace period so a code deployment cannot silently strand browser data.
 
 ## License
 

--- a/agent-commands.js
+++ b/agent-commands.js
@@ -1,4 +1,4 @@
-const SLIDE_STUDIO_AGENT_PROTOCOL = 3;
+const CAROUSELBOT_AGENT_PROTOCOL = 3;
 const AGENT_TEXT_ROLE_SIZES = { title: 104, subtitle: 76, body: 60, caption: 48 };
 const AGENT_TEXT_VERTICAL_SAFETY_PADDING = 0.36;
 
@@ -60,7 +60,7 @@ function agentInspect({ projectId, slideId, includeAllProjects = true } = {}) {
   const project = state.projects.find((item) => item.id === (projectId || state.activeProjectId)) || null;
   const slide = project?.slides.find((item) => item.id === (slideId || state.activeSlideId)) || null;
   return {
-    protocolVersion: SLIDE_STUDIO_AGENT_PROTOCOL,
+    protocolVersion: CAROUSELBOT_AGENT_PROTOCOL,
     activeProjectId: state.activeProjectId,
     activeSlideId: state.activeSlideId,
     view: { canvasZoom: state.canvasZoom, showTikTokOverlay: state.showTikTokOverlay },
@@ -101,7 +101,7 @@ function agentNextFrame() {
 
 async function agentMedia(mediaId) {
   if (!mediaId) return null;
-  const media = await window.slideStudioLocalMcpBridge.fetchMedia(mediaId);
+  const media = await window.carouselBotLocalMcpBridge.fetchMedia(mediaId);
   const imageData = await fileToDataUrl(media.file);
   const dimensions = await getImageDimensions(imageData);
   return { imageData, ...dimensions, name: media.name };
@@ -266,7 +266,7 @@ async function agentRender(project, slide, { width = 540, format = "png", qualit
   };
 }
 
-async function executeSlideStudioAgentOperation(operation) {
+async function executeCarouselBotAgentOperation(operation) {
   if (!operation || typeof operation.type !== "string") throw new Error("Operation type is required.");
 
   if (operation.type === "editor.inspect") {
@@ -274,7 +274,7 @@ async function executeSlideStudioAgentOperation(operation) {
     return agentInspect(operation);
   }
   if (operation.type === "ui.notify") {
-    window.slideStudioLocalMcpBridge?.notify(operation.message, operation.tone);
+    window.carouselBotLocalMcpBridge?.notify(operation.message, operation.tone);
     return { shown: true, message: String(operation.message) };
   }
 
@@ -604,8 +604,9 @@ async function executeSlideStudioAgentOperation(operation) {
   throw new Error(`Unsupported agent operation: ${operation.type}`);
 }
 
-window.slideStudioAgent = {
-  protocolVersion: SLIDE_STUDIO_AGENT_PROTOCOL,
-  execute: executeSlideStudioAgentOperation,
+window.carouselBotAgent = {
+  protocolVersion: CAROUSELBOT_AGENT_PROTOCOL,
+  execute: executeCarouselBotAgentOperation,
   inspect: agentInspect,
 };
+window.slideStudioAgent = window.carouselBotAgent;

--- a/app-config.js
+++ b/app-config.js
@@ -1,0 +1,26 @@
+(function configureCarouselBot(global) {
+  const parameters = new URLSearchParams(global.location.search);
+  const isLocal = ["127.0.0.1", "localhost"].includes(global.location.hostname);
+  const localPort = global.location.port ? `:${global.location.port}` : "";
+  const localLegacyOrigin = `http://127.0.0.1${localPort}`;
+  const previewCanonicalPort = parameters.get("__carouselbotCanonicalPort");
+  const sourceOrigin = (() => { try { return new URL(parameters.get("from")).origin; } catch { return null; } })();
+  const localSource = sourceOrigin && ["127.0.0.1", "localhost"].includes(new URL(sourceOrigin).hostname) ? sourceOrigin : null;
+  const isLocalLegacyPreview = isLocal && parameters.get("__carouselbotMigrationPreview") === "legacy";
+  const isLocalReceiver = isLocal && Boolean(localSource);
+  const localCanonicalOrigin = previewCanonicalPort
+    ? `http://127.0.0.1:${previewCanonicalPort}`
+    : `http://localhost${localPort}`;
+
+  global.CAROUSELBOT_CONFIG = Object.freeze({
+    canonicalOrigin: isLocalLegacyPreview ? localCanonicalOrigin : isLocalReceiver ? global.location.origin : "https://carousel.bot",
+    legacyOrigins: Object.freeze(isLocalLegacyPreview ? [localLegacyOrigin] : isLocalReceiver ? [localSource] : ["https://slides-editor.pages.dev"]),
+    migration: Object.freeze({
+      enabled: true,
+      autoForwardEmptyLegacyStorage: false,
+      transferQueryParameter: "carouselbotMigration",
+      sourceQueryParameter: "from",
+      projectTimeoutMs: 30_000,
+    }),
+  });
+})(window);

--- a/app.js
+++ b/app.js
@@ -1,8 +1,10 @@
-const DB_NAME = "slide-studio-db";
+const APP_CONFIG = window.CAROUSELBOT_CONFIG;
+const domainMigration = window.CarouselBotDomainMigration.createController(window, APP_CONFIG);
+const DB_NAME = domainMigration.isLegacyOrigin ? "slide-studio-db" : "carouselbot-db";
 const DB_VERSION = 1;
 const STORE_NAME = "projects";
-const PROJECT_CHANNEL_NAME = "slide-studio-projects-v1";
-const PROJECT_SYNC_STORAGE_KEY = "slide-studio:project-change";
+const PROJECT_CHANNEL_NAME = "carouselbot-projects-v1";
+const PROJECT_SYNC_STORAGE_KEY = "carouselbot:project-change";
 const DESIGN_WIDTH = 1080;
 const OUTPUT_WIDTH = 1080;
 const OUTPUT_HEIGHT = 1920;
@@ -11,8 +13,10 @@ const DEFAULT_OUTLINE_WIDTH = 12;
 const OUTLINE_RATIO = 0.17;
 const TEXT_WEIGHT = 500;
 const TEXT_LINE_HEIGHT = 1.12;
-const CLIPBOARD_LAYER_TYPE = "application/x-slide-studio-layer";
-const CLIPBOARD_STORAGE_KEY = "slide-studio-layer-clipboard";
+const CLIPBOARD_LAYER_TYPE = "application/x-carouselbot-layer";
+const LEGACY_CLIPBOARD_LAYER_TYPE = "application/x-slide-studio-layer";
+const CLIPBOARD_STORAGE_KEY = "carouselbot-layer-clipboard";
+const LEGACY_CLIPBOARD_STORAGE_KEY = "slide-studio-layer-clipboard";
 const HISTORY_LIMIT = 200;
 const BOX_TEXT_LINE_HEIGHT = 1.12;
 const BOX_LINE_HEIGHT = 1.42;
@@ -322,6 +326,36 @@ function putProject(project, { expectedRevision = null, broadcast = true } = {})
     transaction.onerror = () => { if (!conflict) reject(transaction.error); };
     transaction.onabort = () => reject(conflict || transaction.error || new Error("Project save was aborted."));
   });
+}
+
+async function importMigratedProject(project) {
+  const incoming = structuredClone(project);
+  const result = await new Promise((resolve, reject) => {
+    const transaction = state.db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    let outcome = "invalid";
+    const read = store.get(incoming.id);
+    read.onerror = () => reject(read.error);
+    read.onsuccess = () => {
+      outcome = domainMigration.migrationResult(read.result || null, incoming);
+      if (outcome === "invalid") {
+        transaction.abort();
+        return;
+      }
+      if (outcome !== "skipped") store.put(incoming);
+    };
+    transaction.oncomplete = () => resolve(outcome);
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(outcome === "invalid"
+      ? new Error(`Project ${incoming.id || "unknown"} is not a valid CarouselBot project.`)
+      : transaction.error || new Error("Project import was aborted."));
+  });
+  if (result === "skipped") return result;
+  announceProjectChange("project.updated", incoming);
+  const index = state.projects.findIndex((item) => item.id === incoming.id);
+  if (index >= 0) state.projects[index] = incoming;
+  else state.projects.push(incoming);
+  return result;
 }
 
 function deleteProjectFromDb(projectId, { expectedRevision = null, broadcast = true } = {}) {
@@ -951,7 +985,7 @@ function renderHeader({ editor = false } = {}) {
     <header class="app-header${editor ? " app-header--editor" : ""}">
       <a class="brand" href="/" data-action="home" aria-label="Go to projects">
         <span class="brand-mark" aria-hidden="true"></span>
-        <span class="brand-copy"><strong>Slide Studio</strong><small>TikTok image maker</small></span>
+        <span class="brand-copy"><strong>CarouselBot</strong><small>AI carousel maker</small></span>
       </a>
       ${editor && project ? `
         <div class="project-identity">
@@ -971,10 +1005,34 @@ function renderHeader({ editor = false } = {}) {
             ${icon("download")} <span>PNG</span>
           </button>
         ` : `${agentConnectButton}<button class="button button--primary" type="button" data-action="new-project">New project</button>`}
-        <a class="icon-button github-link" href="https://github.com/alexgusevski/tiktokslideeditor" target="_blank" rel="noopener noreferrer" aria-label="Open Slide Studio on GitHub" title="Open GitHub repository"><img class="github-mark" src="/assets/Octicons-mark-github.svg" alt="" /></a>
+        <a class="icon-button github-link" href="https://github.com/alexgusevski/carouselbot" target="_blank" rel="noopener noreferrer" aria-label="Open CarouselBot on GitHub" title="Open GitHub repository"><img class="github-mark" src="/assets/Octicons-mark-github.svg" alt="" /></a>
       </div>
     </header>
   `;
+}
+
+function renderLegacyMigrationNotice(projects) {
+  if (!domainMigration.isLegacyOrigin || !domainMigration.config.enabled) return "";
+  const completed = domainMigration.completedMigration();
+  const count = projects.length;
+  const pending = domainMigration.hasPendingProjects(projects);
+  const detail = completed && !pending
+    ? `A copy of ${completed.projectCount} ${completed.projectCount === 1 ? "project" : "projects"} was sent to carousel.bot. Your originals are still safe here.`
+    : count
+      ? `${completed ? "Projects changed since your last copy. " : ""}We found ${count} ${count === 1 ? "project" : "projects"} in this browser. Copy them securely to the new domain; nothing will be deleted here.`
+      : "This browser has no projects to copy. Open the new CarouselBot home to get started.";
+  return `
+    <section class="migration-notice" aria-labelledby="migration-notice-title">
+      <div>
+        <p class="eyebrow">New name, new home</p>
+        <h2 id="migration-notice-title">Slide Studio is now CarouselBot.</h2>
+        <p data-migration-status>${escapeHtml(detail)}</p>
+      </div>
+      <div class="migration-actions">
+        ${pending ? `<button class="button button--primary" type="button" data-action="migrate-projects">${completed ? "Copy changed projects" : `Copy ${count === 1 ? "my project" : `my ${count} projects`}`}</button>` : ""}
+        <a class="button button--quiet" href="${escapeHtml(domainMigration.config.canonicalOrigin)}" target="_blank" rel="noopener">Open carousel.bot</a>
+      </div>
+    </section>`;
 }
 
 function renderDashboard() {
@@ -982,10 +1040,11 @@ function renderDashboard() {
   state.activeProjectId = null;
   state.activeSlideId = null;
   clearLayerSelection();
-  document.title = "Slide Studio";
+  document.title = "CarouselBot";
   const sortedProjects = [...state.projects].sort((a, b) => b.updatedAt - a.updatedAt);
   app.innerHTML = `
     ${renderHeader()}
+    ${renderLegacyMigrationNotice(sortedProjects)}
     <main class="dashboard">
       <section class="dashboard-hero">
         <div>
@@ -1095,7 +1154,7 @@ function clearProjectCover(projectId) {
 function renderEditor() {
   const project = activeProject();
   if (!project) return renderDashboard();
-  document.title = `${project.name} · Slide Studio`;
+  document.title = `${project.name} · CarouselBot`;
   if (!activeSlide() && project.slides[0]) state.activeSlideId = project.slides[0].id;
   const previousSlideList = app.querySelector(".slide-list");
   if (previousSlideList) {
@@ -1622,6 +1681,7 @@ function createProject() {
 
 function bindDashboardEvents() {
   bindGlobalActions();
+  app.querySelector('[data-action="migrate-projects"]')?.addEventListener("click", migrateLegacyProjects);
   app.querySelectorAll('[data-action="new-project"]').forEach((button) => button.addEventListener("click", createProject));
   app.querySelectorAll("[data-project-id]").forEach((link) => {
     link.addEventListener("click", (event) => {
@@ -1639,6 +1699,28 @@ function bindDashboardEvents() {
       showProjectMenu(event, link.dataset.projectId);
     });
   });
+}
+
+async function migrateLegacyProjects(event) {
+  const button = event.currentTarget;
+  const status = app.querySelector("[data-migration-status]");
+  button.disabled = true;
+  button.textContent = "Opening CarouselBot…";
+  try {
+    const summary = await domainMigration.start([...state.projects], {
+      onProgress: ({ completed, total }) => {
+        button.textContent = `Copying ${completed} of ${total}…`;
+        if (status) status.textContent = "Keep both tabs open while your projects and images are copied.";
+      },
+    });
+    if (status) status.textContent = `Copied ${summary.projectCount} ${summary.projectCount === 1 ? "project" : "projects"} to carousel.bot. Your originals are still safe here.`;
+    button.textContent = "Projects copied";
+  } catch (error) {
+    console.error(error);
+    if (status) status.textContent = error.message;
+    button.disabled = false;
+    button.textContent = "Try again";
+  }
 }
 
 function bindGlobalActions() {
@@ -1661,7 +1743,7 @@ function bindEditorEvents() {
   const title = app.querySelector(".project-title-input");
   title?.addEventListener("input", () => {
     activeProject().name = title.value || "New Project";
-    document.title = `${activeProject().name} · Slide Studio`;
+    document.title = `${activeProject().name} · CarouselBot`;
     scheduleSave();
   });
 
@@ -2616,7 +2698,7 @@ function reorderSlide(sourceId, targetId, placement) {
 }
 
 function bindSlideReordering() {
-  const slideType = "application/x-slide-studio-slide";
+  const slideType = "application/x-carouselbot-slide";
   const buttons = [...app.querySelectorAll(".slide-thumb[data-slide-id]")];
   buttons.forEach((button) => {
     button.addEventListener("contextmenu", (event) => {
@@ -4099,6 +4181,7 @@ function rememberCopiedLayer(copied) {
   state.copiedLayer = copied;
   try {
     localStorage.setItem(CLIPBOARD_STORAGE_KEY, JSON.stringify(copied));
+    localStorage.setItem(LEGACY_CLIPBOARD_STORAGE_KEY, JSON.stringify(copied));
   } catch (error) {
     console.warn("Could not share the copied layer with other tabs.", error);
   }
@@ -4106,7 +4189,8 @@ function rememberCopiedLayer(copied) {
 
 function storedCopiedLayer(token) {
   try {
-    const copied = parseCopiedLayer(localStorage.getItem(CLIPBOARD_STORAGE_KEY));
+    const copied = parseCopiedLayer(localStorage.getItem(CLIPBOARD_STORAGE_KEY))
+      || parseCopiedLayer(localStorage.getItem(LEGACY_CLIPBOARD_STORAGE_KEY));
     return copied?.token === token ? copied : null;
   } catch {
     return null;
@@ -4128,7 +4212,8 @@ function handleLayerCopy(event) {
   rememberCopiedLayer(copied);
   event.preventDefault();
   event.clipboardData?.setData(CLIPBOARD_LAYER_TYPE, JSON.stringify(copied));
-  event.clipboardData?.setData("text/plain", `slide-studio-layer:${token}`);
+  event.clipboardData?.setData(LEGACY_CLIPBOARD_LAYER_TYPE, JSON.stringify(copied));
+  event.clipboardData?.setData("text/plain", `carouselbot-layer:${token}`);
   toast(copies.length === 1
     ? `${copies[0].kind === "overlay" ? "Asset" : "Text"} copied`
     : `${copies.length} layers copied`);
@@ -4136,11 +4221,13 @@ function handleLayerCopy(event) {
 
 function copiedLayerFromClipboard(clipboardData) {
   if (!clipboardData) return null;
-  const clipboardLayer = parseCopiedLayer(clipboardData.getData(CLIPBOARD_LAYER_TYPE));
-  let token = clipboardLayer?.token || clipboardData.getData(CLIPBOARD_LAYER_TYPE);
+  const clipboardLayer = parseCopiedLayer(clipboardData.getData(CLIPBOARD_LAYER_TYPE))
+    || parseCopiedLayer(clipboardData.getData(LEGACY_CLIPBOARD_LAYER_TYPE));
+  let token = clipboardLayer?.token || clipboardData.getData(CLIPBOARD_LAYER_TYPE) || clipboardData.getData(LEGACY_CLIPBOARD_LAYER_TYPE);
   if (!token) {
     const text = clipboardData.getData("text/plain");
-    if (text.startsWith("slide-studio-layer:")) token = text.slice("slide-studio-layer:".length);
+    if (text.startsWith("carouselbot-layer:")) token = text.slice("carouselbot-layer:".length);
+    else if (text.startsWith("slide-studio-layer:")) token = text.slice("slide-studio-layer:".length);
   }
   if (!token) return null;
   if (token === state.copiedLayer?.token) return state.copiedLayer;
@@ -4348,6 +4435,24 @@ async function init() {
     state.projects = [];
     toast("Browser storage is unavailable. Projects won’t persist.");
   }
+  window.addEventListener("carouselbot:migration-complete", async (event) => {
+    state.projects = await getAllProjects();
+    renderDashboard();
+    const { imported = 0, updated = 0, skipped = 0 } = event.detail || {};
+    toast(`Projects ready: ${imported} copied, ${updated} updated${skipped ? `, ${skipped} already current` : ""}.`);
+  });
+  try {
+    domainMigration.registerImporter(importMigratedProject);
+  } catch (error) {
+    console.error(error);
+    toast(error.message);
+  }
+  if (domainMigration.isLegacyOrigin
+    && domainMigration.config.autoForwardEmptyLegacyStorage
+    && !domainMigration.hasPendingProjects(state.projects)) {
+    window.location.replace(domainMigration.config.canonicalOrigin);
+    return;
+  }
   renderCurrentRoute();
   window.addEventListener("popstate", renderCurrentRoute);
   window.addEventListener("pageshow", () => {
@@ -4438,4 +4543,6 @@ function refreshDashboardProjects() {
   return dashboardRefreshPromise;
 }
 
-window.slideStudioReady = init();
+window.carouselBotDomainMigration = domainMigration;
+window.carouselBotReady = init();
+window.slideStudioReady = window.carouselBotReady;

--- a/docs/REBRAND_ROLLOUT.md
+++ b/docs/REBRAND_ROLLOUT.md
@@ -1,0 +1,130 @@
+# CarouselBot rebrand rollout
+
+This repository is prepared for the move from Slide Studio to CarouselBot without applying any production changes. Treat the steps below as an ordered release runbook. Do not skip the compatibility release or the browser-storage grace period.
+
+## Prepared identities
+
+| Surface | New identity | Legacy identity retained for compatibility |
+| --- | --- | --- |
+| Product | CarouselBot | Slide Studio appears only in migration copy |
+| Canonical site | `https://carousel.bot` | `https://slides-editor.pages.dev` |
+| GitHub | `alexgusevski/carouselbot` | GitHub repository redirect |
+| npm package | `carouselbot` | `slides-studio-mcp` shim |
+| CLI binary | `carouselbot` | `slides-studio-mcp` |
+| MCP config key | `carouselbot` | setup removes `slide-studio` |
+| Agent skill | `carouselbot` | existing installed skill is left untouched |
+
+The Cloudflare Pages project remains named `slides-editor` during migration. Its name is an internal deployment identifier, and retaining it keeps the legacy `pages.dev` origin available to read its IndexedDB. Do not delete or recreate that project during the migration.
+
+## Why the legacy origin must keep serving JavaScript
+
+IndexedDB is isolated by origin. The old page must execute under `https://slides-editor.pages.dev` to read projects created there. A network-level redirect would run before that JavaScript and strand the old data.
+
+The prepared transfer flow:
+
+1. Shows a migration notice only on configured legacy origins.
+2. Opens the canonical origin from a user click.
+3. Binds the two tabs with a random one-time token and exact origin checks.
+4. Copies one complete project at a time, including image data.
+5. Acknowledges each successful IndexedDB write before sending the next project.
+6. Skips an incoming project when the canonical origin already has an equal or newer revision.
+7. Leaves every legacy project untouched.
+
+The transfer configuration lives in `app-config.js`. `autoForwardEmptyLegacyStorage` is intentionally `false` in the prepared branch.
+
+For local manual QA, run `npm start` and open `http://127.0.0.1:4173/?__carouselbotMigrationPreview=legacy`. The transfer button opens `http://localhost:4173`, providing two real browser origins without contacting production. The automated browser test uses two isolated localhost ports instead.
+
+## Phase 0 — reserve names
+
+Complete these before public announcement:
+
+- Confirm `carouselbot` is still available on npm.
+- Confirm `alexgusevski/carouselbot` is still available on GitHub.
+- Publish or otherwise reserve the npm name through the normal release process.
+- Verify control of `carousel.bot` in the Cloudflare account that owns the Pages project.
+
+## Phase 1 — compatibility release on the old package
+
+The primary package version and compatibility package version must match. Publish in this order:
+
+```bash
+npm install
+npm test
+npm run mcp:pack
+npm run mcp:pack:legacy
+npm publish --workspace carouselbot
+npm publish --workspace slides-studio-mcp
+```
+
+Then mark the old package as renamed without unpublishing it:
+
+```bash
+npm deprecate slides-studio-mcp "Slide Studio is now CarouselBot. Existing installs remain compatible; new installs should use carouselbot."
+```
+
+Before publishing, confirm the npm trusted-publisher or token configuration permits the new package and that provenance is present on the resulting release.
+
+The compatibility release must be available before the website is served from `carousel.bot`, because older package versions do not allow the new browser origin.
+
+## Phase 2 — rename GitHub
+
+Rename `alexgusevski/tiktokslideeditor` to `alexgusevski/carouselbot` in GitHub settings. GitHub should retain ordinary repository and Git transport redirects. After renaming:
+
+```bash
+git remote set-url origin https://github.com/alexgusevski/carouselbot.git
+git remote -v
+```
+
+Do not create a new repository using the old name; doing so would take over GitHub's redirect. Verify the raw README URL used by the in-app MCP setup prompt after the rename.
+
+## Phase 3 — attach the domain without redirecting the old origin
+
+1. Add `carousel.bot` as a full Cloudflare DNS zone in the same account as the Pages project.
+2. Review every record Cloudflare imported or discovered. If DNSSEC is enabled at Spaceship, disable it before changing nameservers; stale DS records can make the domain unreachable.
+3. In Spaceship, replace all current authoritative nameservers with the exact Cloudflare nameservers assigned to the new zone. The registration remains at Spaceship.
+4. Wait for the Cloudflare zone to become active. Afterward, re-enable DNSSEC through Cloudflare and publish the new DS record at Spaceship if DNSSEC is desired.
+5. On the existing `slides-editor` Pages project, use **Custom domains → Set up a domain** to add the apex `carousel.bot`. Do not create only a manual DNS record: Pages must know about the hostname so routing and TLS are provisioned correctly.
+6. Wait for the Pages custom domain and certificate to become active, then verify HTTPS from an uncached browser or `curl`.
+7. Add `www.carousel.bot` to Pages and redirect it to `https://carousel.bot` if the `www` hostname is desired.
+8. Do **not** create a Bulk Redirect for `slides-editor.pages.dev` yet.
+
+Verify both origins serve the same release and that the MCP companion accepts both origins.
+
+## Phase 4 — one-week migration grace period
+
+Deploy the prepared application while `autoForwardEmptyLegacyStorage` remains `false`.
+
+Test with a real browser profile that contains representative legacy projects:
+
+- The old origin reads `slide-studio-db` and shows the number of projects found.
+- Clicking the transfer button opens `carousel.bot` without a pop-up warning after the user gesture.
+- Text, backgrounds, image assets, slide order, revisions, and project IDs match.
+- Repeating the transfer skips equal/newer canonical records instead of overwriting them.
+- Closing either tab produces a useful retry message.
+- MCP connections work from both origins.
+
+Keep the old editor functional throughout the grace period. The notice says “copy,” not “move,” because no legacy data is deleted.
+
+## Phase 5 — automatic forwarding after the grace period
+
+After the grace period, change this flag and deploy normally:
+
+```js
+autoForwardEmptyLegacyStorage: true
+```
+
+The old origin will then forward browsers that have no legacy projects or have completed migration. Browsers that still contain unmigrated projects continue to see the copy prompt.
+
+Keep this JavaScript bridge available for several months. A blanket Cloudflare Bulk Redirect is only safe after intentionally ending self-service migration. If one is eventually added, preserve query strings and path suffixes and retain a separately reachable migration page for late users.
+
+## Rollback
+
+- Domain: detach `carousel.bot` from Pages or restore its prior DNS records. The legacy Pages origin remains deployable.
+- Website: set `autoForwardEmptyLegacyStorage` back to `false` and redeploy.
+- npm: undeprecate the old range if necessary. Do not unpublish either package.
+- MCP: both old and new environment-variable names, origins, resource URIs, headers, daemon directories, runtime globals, and clipboard formats remain supported.
+- Browser projects: migration only copies data, so the legacy IndexedDB remains a recovery source.
+
+## Post-migration cleanup
+
+Do not remove compatibility aliases in a patch release. Any eventual removal should be announced and released as a major version after telemetry and support history show that the legacy origin and package are no longer in meaningful use.

--- a/domain-migration.js
+++ b/domain-migration.js
@@ -1,0 +1,263 @@
+(function initializeCarouselBotDomainMigration(global) {
+  "use strict";
+
+  const MESSAGE = Object.freeze({
+    ready: "carouselbot:migration-ready",
+    project: "carouselbot:migration-project",
+    projectImported: "carouselbot:migration-project-imported",
+    finish: "carouselbot:migration-finish",
+    complete: "carouselbot:migration-complete",
+    error: "carouselbot:migration-error",
+  });
+  const PROTOCOL_VERSION = 1;
+  const COMPLETED_STORAGE_KEY = "carouselbot:migration-completed";
+
+  function normalizedOrigin(value) {
+    try {
+      return new URL(value).origin;
+    } catch {
+      return null;
+    }
+  }
+
+  function normalizeConfig(config = {}) {
+    const canonicalOrigin = normalizedOrigin(config.canonicalOrigin);
+    const legacyOrigins = [...new Set((config.legacyOrigins || []).map(normalizedOrigin).filter(Boolean))];
+    if (!canonicalOrigin) throw new Error("CarouselBot migration requires a valid canonical origin.");
+    if (!legacyOrigins.length) throw new Error("CarouselBot migration requires at least one legacy origin.");
+    return Object.freeze({
+      canonicalOrigin,
+      legacyOrigins: Object.freeze(legacyOrigins),
+      enabled: config.migration?.enabled !== false,
+      autoForwardEmptyLegacyStorage: config.migration?.autoForwardEmptyLegacyStorage === true,
+      transferQueryParameter: config.migration?.transferQueryParameter || "carouselbotMigration",
+      sourceQueryParameter: config.migration?.sourceQueryParameter || "from",
+      projectTimeoutMs: Number(config.migration?.projectTimeoutMs) || 30_000,
+    });
+  }
+
+  function validProject(project) {
+    return Boolean(
+      project
+      && typeof project === "object"
+      && typeof project.id === "string"
+      && project.id.length > 0
+      && project.id.length <= 256
+      && typeof project.name === "string"
+      && Array.isArray(project.slides)
+      && Array.isArray(project.assets || []),
+    );
+  }
+
+  function migrationResult(existing, incoming) {
+    if (!validProject(incoming)) return "invalid";
+    if (!existing) return "imported";
+    const existingUpdatedAt = Number(existing.updatedAt) || 0;
+    const incomingUpdatedAt = Number(incoming.updatedAt) || 0;
+    const existingRevision = Number(existing.revision) || 0;
+    const incomingRevision = Number(incoming.revision) || 0;
+    return incomingUpdatedAt > existingUpdatedAt || (incomingUpdatedAt === existingUpdatedAt && incomingRevision > existingRevision)
+      ? "updated"
+      : "skipped";
+  }
+
+  function createController(browser = global, rawConfig = browser.CAROUSELBOT_CONFIG) {
+    const config = normalizeConfig(rawConfig);
+    const currentOrigin = normalizedOrigin(browser.location?.origin);
+    const isLegacyOrigin = config.legacyOrigins.includes(currentOrigin);
+    const isCanonicalOrigin = currentOrigin === config.canonicalOrigin;
+    const url = new URL(browser.location.href);
+    const receiverToken = url.searchParams.get(config.transferQueryParameter);
+    const receiverSourceOrigin = normalizedOrigin(url.searchParams.get(config.sourceQueryParameter));
+    let importer = null;
+    let receiverSummary = { imported: 0, updated: 0, skipped: 0 };
+    let activeTransfer = null;
+
+    function post(target, targetOrigin, message) {
+      target.postMessage({ protocolVersion: PROTOCOL_VERSION, ...message }, targetOrigin);
+    }
+
+    function messageMatches(event, source, origin, token) {
+      return event.source === source
+        && event.origin === origin
+        && event.data?.protocolVersion === PROTOCOL_VERSION
+        && event.data?.token === token;
+    }
+
+    function transferUrl(token) {
+      const target = new URL("/", config.canonicalOrigin);
+      target.searchParams.set(config.transferQueryParameter, token);
+      target.searchParams.set(config.sourceQueryParameter, currentOrigin);
+      return target.href;
+    }
+
+    function completedMigration() {
+      if (!isLegacyOrigin) return null;
+      try {
+        return JSON.parse(browser.localStorage.getItem(COMPLETED_STORAGE_KEY) || "null");
+      } catch {
+        return null;
+      }
+    }
+
+    function hasPendingProjects(projects) {
+      if (!isLegacyOrigin || !projects.length) return false;
+      const completed = completedMigration();
+      if (!Array.isArray(completed?.projectVersions)) return true;
+      const copied = new Map(completed.projectVersions.map((project) => [project.id, project]));
+      return projects.some((project) => {
+        const previous = copied.get(project.id);
+        return !previous
+          || Number(project.updatedAt) !== Number(previous.updatedAt)
+          || Number(project.revision || 0) !== Number(previous.revision || 0);
+      });
+    }
+
+    function rememberCompletedMigration(summary) {
+      try {
+        browser.localStorage.setItem(COMPLETED_STORAGE_KEY, JSON.stringify({ ...summary, completedAt: new Date().toISOString() }));
+      } catch { /* A completed transfer remains valid when localStorage is unavailable. */ }
+    }
+
+    function clearProjectTimer() {
+      if (!activeTransfer?.timer) return;
+      browser.clearTimeout(activeTransfer.timer);
+      activeTransfer.timer = null;
+    }
+
+    function rejectTransfer(error) {
+      if (!activeTransfer) return;
+      clearProjectTimer();
+      const { reject } = activeTransfer;
+      activeTransfer = null;
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+
+    function armProjectTimeout() {
+      clearProjectTimer();
+      activeTransfer.timer = browser.setTimeout(() => rejectTransfer(new Error("The project transfer timed out. Keep both tabs open and try again.")), config.projectTimeoutMs);
+    }
+
+    function sendNextProject() {
+      if (!activeTransfer) return;
+      const { popup, projects, token, index } = activeTransfer;
+      if (popup.closed) {
+        rejectTransfer(new Error("The CarouselBot tab was closed before the transfer finished."));
+        return;
+      }
+      if (index >= projects.length) {
+        post(popup, config.canonicalOrigin, { type: MESSAGE.finish, token, total: projects.length });
+        armProjectTimeout();
+        return;
+      }
+      post(popup, config.canonicalOrigin, {
+        type: MESSAGE.project,
+        token,
+        index,
+        total: projects.length,
+        project: projects[index],
+      });
+      armProjectTimeout();
+    }
+
+    function handleLegacyMessage(event) {
+      if (!activeTransfer || !messageMatches(event, activeTransfer.popup, config.canonicalOrigin, activeTransfer.token)) return;
+      if (event.data.type === MESSAGE.ready && activeTransfer.index === 0) {
+        sendNextProject();
+        return;
+      }
+      if (event.data.type === MESSAGE.projectImported && event.data.index === activeTransfer.index) {
+        clearProjectTimer();
+        activeTransfer.results.push({ projectId: event.data.projectId, status: event.data.status });
+        activeTransfer.index += 1;
+        activeTransfer.onProgress?.({ completed: activeTransfer.index, total: activeTransfer.projects.length, projectId: event.data.projectId, status: event.data.status });
+        sendNextProject();
+        return;
+      }
+      if (event.data.type === MESSAGE.complete) {
+        clearProjectTimer();
+        const { resolve, projects, results, popup } = activeTransfer;
+        const summary = {
+          projectCount: projects.length,
+          results,
+          destination: config.canonicalOrigin,
+          projectVersions: projects.map(({ id, updatedAt, revision }) => ({ id, updatedAt: Number(updatedAt) || 0, revision: Number(revision) || 0 })),
+        };
+        rememberCompletedMigration(summary);
+        activeTransfer = null;
+        popup.focus?.();
+        resolve(summary);
+        return;
+      }
+      if (event.data.type === MESSAGE.error) rejectTransfer(new Error(event.data.message || "CarouselBot could not import the project."));
+    }
+
+    async function handleCanonicalMessage(event) {
+      if (!importer || !receiverToken || !receiverSourceOrigin || !config.legacyOrigins.includes(receiverSourceOrigin)) return;
+      if (!messageMatches(event, browser.opener, receiverSourceOrigin, receiverToken)) return;
+      if (event.data.type === MESSAGE.project) {
+        try {
+          if (!validProject(event.data.project)) throw new Error("The legacy project data is invalid.");
+          const status = await importer(event.data.project);
+          if (!Object.hasOwn(receiverSummary, status)) throw new Error(`Unknown import status: ${status}`);
+          receiverSummary[status] += 1;
+          post(browser.opener, receiverSourceOrigin, {
+            type: MESSAGE.projectImported,
+            token: receiverToken,
+            index: event.data.index,
+            projectId: event.data.project.id,
+            status,
+          });
+        } catch (error) {
+          post(browser.opener, receiverSourceOrigin, { type: MESSAGE.error, token: receiverToken, message: error.message });
+        }
+        return;
+      }
+      if (event.data.type === MESSAGE.finish) {
+        post(browser.opener, receiverSourceOrigin, { type: MESSAGE.complete, token: receiverToken, summary: receiverSummary });
+        const cleanUrl = new URL(browser.location.href);
+        cleanUrl.searchParams.delete(config.transferQueryParameter);
+        cleanUrl.searchParams.delete(config.sourceQueryParameter);
+        browser.history.replaceState({}, "", `${cleanUrl.pathname}${cleanUrl.search}${cleanUrl.hash}`);
+        browser.dispatchEvent(new browser.CustomEvent("carouselbot:migration-complete", { detail: receiverSummary }));
+      }
+    }
+
+    browser.addEventListener("message", isLegacyOrigin ? handleLegacyMessage : handleCanonicalMessage);
+
+    return Object.freeze({
+      config,
+      isLegacyOrigin,
+      isCanonicalOrigin,
+      isMigrationReceiver: Boolean(isCanonicalOrigin && receiverToken && config.legacyOrigins.includes(receiverSourceOrigin)),
+      completedMigration,
+      hasPendingProjects,
+      migrationResult,
+      registerImporter(callback) {
+        if (!this.isMigrationReceiver) return false;
+        if (typeof callback !== "function") throw new TypeError("Migration importer must be a function.");
+        if (!browser.opener) throw new Error("The legacy editor tab is no longer available. Start the transfer again from the old domain.");
+        importer = callback;
+        post(browser.opener, receiverSourceOrigin, { type: MESSAGE.ready, token: receiverToken });
+        return true;
+      },
+      start(projects, { onProgress } = {}) {
+        if (!config.enabled || !isLegacyOrigin) return Promise.reject(new Error("Project migration is only available on a configured legacy origin."));
+        if (activeTransfer) return Promise.reject(new Error("A project migration is already running."));
+        const transferable = projects.filter(validProject);
+        if (transferable.length !== projects.length) return Promise.reject(new Error("One or more projects cannot be transferred safely."));
+        const token = browser.crypto.randomUUID();
+        const popup = browser.open(transferUrl(token), `carouselbot-project-migration-${token}`);
+        if (!popup) return Promise.reject(new Error("Your browser blocked the CarouselBot tab. Allow pop-ups for this transfer and try again."));
+        return new Promise((resolve, reject) => {
+          activeTransfer = { token, popup, projects: transferable, index: 0, results: [], onProgress, resolve, reject, timer: null };
+          armProjectTimeout();
+        });
+      },
+    });
+  }
+
+  const api = Object.freeze({ MESSAGE, PROTOCOL_VERSION, COMPLETED_STORAGE_KEY, normalizeConfig, validProject, migrationResult, createController });
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else global.CarouselBotDomainMigration = api;
+})(typeof window === "object" ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -7,9 +7,15 @@
     <meta name="theme-color" content="#121310" media="(prefers-color-scheme: dark)" />
     <meta
       name="description"
-      content="A simple local editor for making TikTok slideshow images."
+      content="Create polished social carousels locally in your browser, with optional AI editing through the CarouselBot MCP companion."
     />
-    <title>Slide Studio</title>
+    <meta property="og:site_name" content="CarouselBot" />
+    <meta property="og:title" content="CarouselBot — AI carousel maker" />
+    <meta property="og:description" content="Create polished social carousels locally in your browser." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://carousel.bot" />
+    <link rel="canonical" href="https://carousel.bot" />
+    <title>CarouselBot</title>
     <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/styles.css?v=dev" />
   </head>
@@ -24,6 +30,8 @@
       </svg>
     </template>
 
+    <script src="/app-config.js?v=dev" defer></script>
+    <script src="/domain-migration.js?v=dev" defer></script>
     <script src="/app.js?v=dev" defer></script>
     <script src="/agent-commands.js?v=dev" defer></script>
     <script src="/local-mcp-bridge.js?v=dev" defer></script>

--- a/local-mcp-bridge.js
+++ b/local-mcp-bridge.js
@@ -1,5 +1,5 @@
 const LOCAL_MCP_BRIDGE_URL = (() => {
-  if (window.__SLIDE_STUDIO_MCP_BRIDGE_URL) return window.__SLIDE_STUDIO_MCP_BRIDGE_URL;
+  if (window.__CAROUSELBOT_MCP_BRIDGE_URL || window.__SLIDE_STUDIO_MCP_BRIDGE_URL) return window.__CAROUSELBOT_MCP_BRIDGE_URL || window.__SLIDE_STUDIO_MCP_BRIDGE_URL;
   const localPort = new URLSearchParams(location.search).get("__mcpBridgePort");
   if (["127.0.0.1", "localhost"].includes(location.hostname) && /^\d{2,5}$/.test(localPort || "")) return `http://127.0.0.1:${localPort}`;
   return "http://127.0.0.1:43117";
@@ -10,14 +10,14 @@ const LOCAL_MCP_REQUEST_TIMEOUT_MS = 8_000;
 const LOCAL_MCP_EVENT_REQUEST_TIMEOUT_MS = 1_500;
 const LOCAL_MCP_POLL_INTERVAL_MS = 250;
 const LOCAL_MCP_NOTIFICATION_DURATION_MS = 6_300;
-const LOCAL_MCP_CONNECTION_KEY = "slide-studio:mcp-connected";
-const LOCAL_MCP_EDITOR_KEY = "slide-studio:mcp-editor-id";
-const LOCAL_MCP_ACTIVITY_CHANNEL = "slide-studio:mcp-activity";
-const LOCAL_MCP_AGENT_PROMPT = "Read https://raw.githubusercontent.com/alexgusevski/tiktokslideeditor/refs/heads/main/packages/mcp/README.md and install and configure the Slide Studio MCP and skill for this agent. Do not stop for a restart: if native MCP tools are not available in this session, use the documented CLI fallback so you can operate Slide Studio immediately. When you’re done, reply concisely with: “I’m done and ready to test the connection.”";
+const LOCAL_MCP_CONNECTION_KEYS = ["carouselbot:mcp-connected", "slide-studio:mcp-connected"];
+const LOCAL_MCP_EDITOR_KEYS = ["carouselbot:mcp-editor-id", "slide-studio:mcp-editor-id"];
+const LOCAL_MCP_ACTIVITY_CHANNEL = "carouselbot:mcp-activity";
+const LOCAL_MCP_AGENT_PROMPT = "Read https://raw.githubusercontent.com/alexgusevski/carouselbot/refs/heads/main/packages/mcp/README.md and install and configure the CarouselBot MCP and skill for this agent. Do not stop for a restart: if native MCP tools are not available in this session, use the documented CLI fallback so you can operate CarouselBot immediately. When you’re done, reply concisely with: “I’m done and ready to test the connection.”";
 
 function localMcpConnectionWasRemembered() {
   try {
-    return localStorage.getItem(LOCAL_MCP_CONNECTION_KEY) === "1";
+    return LOCAL_MCP_CONNECTION_KEYS.some((key) => localStorage.getItem(key) === "1");
   } catch {
     return false;
   }
@@ -25,22 +25,25 @@ function localMcpConnectionWasRemembered() {
 
 function localMcpRememberConnection() {
   try {
-    localStorage.setItem(LOCAL_MCP_CONNECTION_KEY, "1");
+    LOCAL_MCP_CONNECTION_KEYS.forEach((key) => localStorage.setItem(key, "1"));
   } catch { /* The live connection still works when storage is unavailable. */ }
 }
 
 function localMcpForgetConnection() {
   try {
-    localStorage.removeItem(LOCAL_MCP_CONNECTION_KEY);
+    LOCAL_MCP_CONNECTION_KEYS.forEach((key) => localStorage.removeItem(key));
   } catch { /* The live connection can still be stopped. */ }
 }
 
 function localMcpEditorId() {
   try {
-    const existing = sessionStorage.getItem(LOCAL_MCP_EDITOR_KEY);
-    if (existing) return existing;
+    const existing = LOCAL_MCP_EDITOR_KEYS.map((key) => sessionStorage.getItem(key)).find(Boolean);
+    if (existing) {
+      LOCAL_MCP_EDITOR_KEYS.forEach((key) => sessionStorage.setItem(key, existing));
+      return existing;
+    }
     const created = crypto.randomUUID();
-    sessionStorage.setItem(LOCAL_MCP_EDITOR_KEY, created);
+    LOCAL_MCP_EDITOR_KEYS.forEach((key) => sessionStorage.setItem(key, created));
     return created;
   } catch {
     return crypto.randomUUID();
@@ -332,7 +335,7 @@ async function localMcpConnectFromClick() {
   try {
     const health = await localMcpRequest("/health");
     if (!health.ok) throw new Error(`Local companion returned ${health.status}`);
-    await window.slideStudioReady;
+    await window.carouselBotReady;
     localMcpBridgeState.shouldReconnect = true;
     await localMcpHandshake();
     localMcpRememberConnection();
@@ -378,16 +381,16 @@ async function localMcpHandshake() {
   localMcpBridgeState.sessionToken = null;
   const response = await localMcpSendJson("/connect", {
     editorId: localMcpBridgeState.editorId,
-    protocolVersion: window.slideStudioAgent.protocolVersion,
+    protocolVersion: window.carouselBotAgent.protocolVersion,
     pageUrl: location.href,
     pageOrigin: location.origin,
     visibilityState: document.visibilityState,
     hasFocus: document.hasFocus(),
-    state: window.slideStudioAgent.inspect({ includeAllProjects: false }),
+    state: window.carouselBotAgent.inspect({ includeAllProjects: false }),
   });
   const result = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(result.error || `Bridge returned ${response.status}`);
-  if (result.protocolVersion !== window.slideStudioAgent.protocolVersion) throw new Error("The website and local companion versions are incompatible. Update the npm package and reload this page.");
+  if (result.protocolVersion !== window.carouselBotAgent.protocolVersion) throw new Error("The website and local companion versions are incompatible. Update the npm package and reload this page.");
   localMcpBridgeState.sessionToken = result.sessionToken;
   localMcpBridgeState.agents = result.agents || [];
   localMcpBridgeState.editSessions = result.editSessions || [];
@@ -468,7 +471,7 @@ async function localMcpPollWithReconnect() {
 
 async function localMcpResumeRememberedConnection() {
   if (!localMcpBridgeState.connectionRemembered || localMcpBridgeState.connected || localMcpBridgeState.reconnectLoopRunning) return;
-  await window.slideStudioReady;
+  await window.carouselBotReady;
   if (localMcpBridgeState.connected || localMcpBridgeState.connecting || localMcpBridgeState.reconnectLoopRunning) return;
   localMcpBridgeState.shouldReconnect = true;
   localMcpBridgeState.connecting = true;
@@ -500,15 +503,15 @@ async function localMcpPoll() {
     localMcpAddEvent(`Tool call: ${event.toolName}`);
     localMcpBroadcastActivity(event.label || "Editing the current slide…", "agent", event.agent);
     try {
-      const result = await window.slideStudioAgent.execute(event.operation);
-      await localMcpSendJson("/result", { editorId: localMcpBridgeState.editorId, requestId: event.requestId, ok: true, result, state: window.slideStudioAgent.inspect({ includeAllProjects: false }) });
+      const result = await window.carouselBotAgent.execute(event.operation);
+      await localMcpSendJson("/result", { editorId: localMcpBridgeState.editorId, requestId: event.requestId, ok: true, result, state: window.carouselBotAgent.inspect({ includeAllProjects: false }) });
       localMcpAddEvent(`Applied: ${event.toolName}`);
       if (event.toolName === "create_project") {
         const projectName = String(result?.name || event.operation?.name || "New project").trim().slice(0, 160);
         localMcpBroadcastActivity(`Created ${projectName}`, "success", event.agent, { dashboardOnly: true });
       }
     } catch (error) {
-      await localMcpSendJson("/result", { editorId: localMcpBridgeState.editorId, requestId: event.requestId, ok: false, error: error.message, state: window.slideStudioAgent.inspect({ includeAllProjects: false }) });
+      await localMcpSendJson("/result", { editorId: localMcpBridgeState.editorId, requestId: event.requestId, ok: false, error: error.message, state: window.carouselBotAgent.inspect({ includeAllProjects: false }) });
       localMcpAddEvent(`Failed: ${event.toolName}`);
       localMcpNotify(error.message, "error", event.agent);
     }
@@ -519,7 +522,7 @@ async function localMcpFetchMedia(mediaId) {
   const response = await localMcpRequest(`/media/${encodeURIComponent(mediaId)}?editorId=${encodeURIComponent(localMcpBridgeState.editorId)}`);
   if (!response.ok) throw new Error((await response.json().catch(() => ({}))).error || "Could not read local image.");
   const blob = await response.blob();
-  const name = decodeURIComponent(response.headers.get("X-Slide-Studio-Filename") || "image");
+  const name = decodeURIComponent(response.headers.get("X-CarouselBot-Filename") || response.headers.get("X-Slide-Studio-Filename") || "image");
   return { file: new File([blob], name, { type: blob.type }), name };
 }
 
@@ -544,7 +547,7 @@ window.addEventListener("beforeunload", () => {
 window.addEventListener("focus", localMcpActivateVisibleEditor);
 document.addEventListener("visibilitychange", localMcpActivateVisibleEditor);
 
-window.slideStudioLocalMcpBridge = {
+window.carouselBotLocalMcpBridge = {
   open: localMcpOpenModal,
   connect: localMcpConnectFromClick,
   disconnect: localMcpDisconnectFromClick,
@@ -552,3 +555,4 @@ window.slideStudioLocalMcpBridge = {
   notify: localMcpNotify,
   getState: () => ({ ...localMcpBridgeState, lastFocusedElement: undefined }),
 };
+window.slideStudioLocalMcpBridge = window.carouselBotLocalMcpBridge;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "slide-studio",
+  "name": "carouselbot-web",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "slide-studio",
+      "name": "carouselbot-web",
       "version": "1.0.0",
       "license": "MIT",
       "workspaces": [
@@ -1248,6 +1248,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/carouselbot": {
+      "resolved": "packages/mcp",
+      "link": true
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -1538,7 +1542,7 @@
       }
     },
     "node_modules/slides-studio-mcp": {
-      "resolved": "packages/mcp",
+      "resolved": "packages/slides-studio-mcp",
       "link": true
     },
     "node_modules/supports-color": {
@@ -1712,15 +1716,28 @@
       }
     },
     "packages/mcp": {
-      "name": "slides-studio-mcp",
-      "version": "0.1.0",
+      "name": "carouselbot",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0",
         "zod": "^4.4.3"
       },
       "bin": {
-        "slides-studio-mcp": "src/cli.mjs"
+        "carouselbot": "src/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/slides-studio-mcp": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "carouselbot": "0.2.0"
+      },
+      "bin": {
+        "slides-studio-mcp": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,26 +1,30 @@
 {
-  "name": "slide-studio",
+  "name": "carouselbot-web",
   "version": "1.0.0",
   "private": true,
   "workspaces": [
     "packages/*"
   ],
-  "description": "Local-first web editor for TikTok slideshow images",
-  "homepage": "https://slides-editor.pages.dev",
+  "description": "Local-first carousel editor with an optional MCP companion",
+  "homepage": "https://carousel.bot",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alexgusevski/tiktokslideeditor.git"
+    "url": "git+https://github.com/alexgusevski/carouselbot.git"
   },
   "bugs": {
-    "url": "https://github.com/alexgusevski/tiktokslideeditor/issues"
+    "url": "https://github.com/alexgusevski/carouselbot/issues"
   },
   "scripts": {
     "start": "node server.mjs",
     "dev": "node server.mjs",
     "mcp": "node packages/mcp/src/cli.mjs serve",
     "mcp:doctor": "node packages/mcp/src/cli.mjs doctor",
-    "mcp:pack": "npm pack --workspace slides-studio-mcp",
+    "mcp:pack": "npm pack --workspace carouselbot",
+    "mcp:pack:legacy": "npm pack --workspace slides-studio-mcp",
+    "test:migration": "node --test test/*.test.cjs",
+    "test:migration:browser": "node scripts/test-domain-migration-browser.mjs",
+    "test": "npm run test:migration && npm run test:mcp",
     "test:mcp": "node --test packages/mcp/test/*.test.mjs",
     "test:mcp:browser": "node scripts/test-mcp-browser-local.mjs --deployed --shared-daemon",
     "test:mcp:browser:local": "node scripts/test-mcp-browser-local.mjs",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,62 +1,62 @@
-# Slide Studio MCP
+# CarouselBot MCP
 
-Local-first MCP companion for the hosted [Slide Studio editor](https://slides-editor.pages.dev). It exposes complete project, slide, text, image, layer, history, rendering, and export controls to any stdio MCP client while the editor remains in the browser.
-
-```bash
-npx slides-studio-mcp@latest setup
-```
-
-If an agent is doing the setup itself, it should select its current client and run non-interactively:
+Local-first MCP companion for the hosted [CarouselBot editor](https://carousel.bot). It exposes project, slide, text, image, layer, history, rendering, and export controls to any stdio MCP client while the editor remains in the browser.
 
 ```bash
-npx slides-studio-mcp@latest setup --client=codex --yes
+npx carouselbot@latest setup
 ```
 
-Replace `codex` with `claude`, `hermes`, `opencode`, or `openclaw` for the agent doing the setup. OpenCode prints the version-appropriate JSON to merge into its config. Other detected clients are configured through their official CLI.
+For non-interactive agent setup, select the current client explicitly:
+
+```bash
+npx carouselbot@latest setup --client=codex --yes
+```
+
+Replace `codex` with `claude`, `hermes`, `opencode`, or `openclaw`. OpenCode prints version-appropriate JSON to merge into its config. Other detected clients are configured through their official CLI.
 
 ## Use it immediately without restarting
 
-Some clients do not add a newly configured MCP server to the tool catalog of the already-running session. The same validated tool surface is available through the package CLI, so the current agent can continue immediately:
+The same validated tool surface is available through the package CLI when a running agent cannot refresh its native MCP tools:
 
 ```bash
-npx -y slides-studio-mcp@latest call get_design_guidance
-npx -y slides-studio-mcp@latest call list_editors
-npx -y slides-studio-mcp@latest call begin_edit_session --json '{"editorId":"EDITOR_ID","purpose":"Build my deck"}'
-npx -y slides-studio-mcp@latest call create_project --json '{"editSessionId":"SESSION_ID","name":"My presentation"}'
+npx -y carouselbot@latest call get_design_guidance
+npx -y carouselbot@latest call list_editors
+npx -y carouselbot@latest call begin_edit_session --json '{"editorId":"EDITOR_ID","purpose":"Build my deck"}'
+npx -y carouselbot@latest call create_project --json '{"editSessionId":"SESSION_ID","name":"My presentation"}'
 ```
 
-Every MCP tool name and JSON argument shape works with `call`. The CLI-only `list_tools` helper lists all names compactly, or returns schemas for the requested names. The CLI automatically applies the guidance gate for each invocation and prints compact JSON. `render_slide` writes image output to a temporary `previewPath` instead of dumping base64 into the terminal.
+Every MCP tool name and JSON argument shape works with `call`. The CLI-only `list_tools` helper lists names compactly or returns selected schemas. `render_slide` writes image output to a temporary `previewPath` instead of dumping base64 into the terminal.
 
-Always use `list_editors` to check the browser connection. Do not open Slide Studio or click **Connect AI** through a sandboxed, remote, or agent-controlled browser: that is a different browser session and may not have access to the user's local companion. If no editor is listed, ask the user to open the editor in their normal browser on the same computer and connect there, then retry `list_editors`.
+Always use `list_editors` to check the browser connection. Do not open CarouselBot or click **Connect AI** through a sandboxed, remote, or agent-controlled browser: that is a different browser session and may not reach the local companion.
 
-Browser reconnection is automatic. For a transient `EDITOR_DISCONNECTED`, `EDITOR_RELOADED`, dropped browser request, or newly empty editor list, wait briefly and retry `list_editors`; do not restart a healthy daemon. Use `restart` only for an explicit companion protocol mismatch or when `doctor` reports that the daemon itself is unhealthy. Restarting invalidates current browser session tokens and should not be used as generic connection recovery.
-
-Hermes can refresh native tools without restarting by running `/reload-mcp`, then `/reload-skills`. Claude may still need a new session to register a newly added plain stdio server, but its current session can use the CLI fallback instead of stopping.
+Browser reconnection is automatic. Retry transient disconnects; use `restart` only for an explicit protocol mismatch or failed daemon health check. Hermes can refresh native tools with `/reload-mcp` and `/reload-skills`. Claude may need a new session to register a newly added server, but the CLI fallback works immediately.
 
 The companion binds only to `127.0.0.1`. There is no hosted relay: projects remain in browser IndexedDB and local images remain on the user's computer.
 
 Any MCP client can launch it with:
 
 ```bash
-npx -y slides-studio-mcp@latest serve
+npx -y carouselbot@latest serve
 ```
 
 Useful commands:
 
 ```bash
-npx slides-studio-mcp@latest setup --dry-run
-npx slides-studio-mcp@latest doctor
-npx slides-studio-mcp@latest restart
+npx carouselbot@latest setup --dry-run
+npx carouselbot@latest doctor
+npx carouselbot@latest restart
 ```
 
-`restart` gracefully replaces an outdated local companion. Reload the real browser editor afterward; current MCP clients automatically recover their daemon registration.
+## Existing Slide Studio installations
+
+`slides-studio-mcp` remains as a compatibility package and delegates to CarouselBot. Existing MCP configurations therefore continue to launch, while running `carouselbot setup` replaces the visible `slide-studio` config key with `carouselbot`.
+
+The new companion accepts both `https://carousel.bot` and the legacy `https://slides-editor.pages.dev` origin during migration. Legacy environment variables beginning with `SLIDE_STUDIO_` and the old daemon state directory remain supported.
 
 ## Parallel agents and browser tabs
 
 Call `begin_edit_session` before editing and pass its `editSessionId` to all operations. A session atomically reserves one browser tab and one project, follows that tab instead of global focus, and expires after inactivity. Always call `end_edit_session` when finished.
 
-For parallel editing, the parent agent must reserve a different connected editor for each editing worker and pass that worker its `editorId`, `editSessionId`, and `projectId`. The daemon rejects conflicting claims with `EDITOR_BUSY` or `PROJECT_BUSY`. It also records a sanitized local audit available through `list_recent_operations`; it never records slide text, prompts, file paths, or image bytes.
+For parallel editing, reserve a different connected editor for each worker. The daemon rejects conflicting claims with `EDITOR_BUSY` or `PROJECT_BUSY` and records a sanitized local audit through `list_recent_operations`; it never records slide text, prompts, file paths, or image bytes.
 
 Browser writes use revision-checked IndexedDB transactions and cross-tab synchronization. A stale tab cannot replace a newer project snapshot; it reloads the canonical copy and returns `STALE_PROJECT` so the agent can inspect and retry.
-
-Open the editor in the user's normal local browser, click **Connect AI**, and call `get_design_guidance` before editing. The server provides `render_slide` so agents can inspect actual pixels without permanently storing previews.

--- a/packages/mcp/guidance/design.md
+++ b/packages/mcp/guidance/design.md
@@ -1,4 +1,4 @@
-# Slide Studio design guidance
+# CarouselBot design guidance
 
 Read this before creating or editing slides. Use it as a compact quality bar, then inspect the rendered slide instead of assuming code values look good.
 

--- a/packages/mcp/skill/carouselbot/SKILL.md
+++ b/packages/mcp/skill/carouselbot/SKILL.md
@@ -1,30 +1,30 @@
 ---
-name: slide-studio
-description: Create, edit, visually inspect, and export Slide Studio carousel slides through the local Slide Studio MCP companion.
+name: carouselbot
+description: Create, edit, visually inspect, and export CarouselBot slides through the local CarouselBot MCP companion.
 ---
 
-# Slide Studio
+# CarouselBot
 
-Use the Slide Studio MCP tools for all presentation changes. The hosted browser editor is the live visual surface; local files and rendered images pass only through the local companion.
+Use the CarouselBot MCP tools for all carousel changes. The hosted browser editor is the live visual surface; local files and rendered images pass only through the local companion.
 
 Before using any browser or making edits, call `list_editors`. A registered editor is the user's real browser tab and is the only browser surface the agent should use.
 
-- If an editor is listed, use the MCP tools against it. Do not open Slide Studio or click **Connect AI** with browser automation.
+- If an editor is listed, use the MCP tools against it. Do not open CarouselBot or click **Connect AI** with browser automation.
 - Sandboxed, remote, and agent-controlled browser sessions are separate from the user's local browser and usually cannot reach the local companion. Never use one to test or establish the connection.
 - If no editor is listed, ask the user to open the editor in their normal browser on the same computer, click **Connect AI**, and accept the browser permission. Then retry `list_editors`.
 - A loaded MCP server and a connected browser editor are different states. Determine browser connectivity only from `list_editors`, not from a sandbox browser or the agent's tool catalog.
 
 Browser reconnection is automatic. After `EDITOR_DISCONNECTED`, `EDITOR_RELOADED`, a dropped browser request, or an empty `list_editors` result that follows a working connection, wait briefly and retry `list_editors` several times. Do not restart the companion for a transient browser disconnect: restarting invalidates every browser session and makes recovery slower. If the editor does not return, ask the user to keep or reload the real editor tab; preserve completed project work and begin a new edit session after it reconnects.
 
-Run `npx -y slides-studio-mcp@latest restart` only when the MCP explicitly reports an outdated companion protocol or `doctor` reports that the daemon itself is unhealthy. After a necessary restart, ask the user to reload their real editor tab and retry `list_editors`.
+Run `npx -y carouselbot@latest restart` only when the MCP explicitly reports an outdated companion protocol or `doctor` reports that the daemon itself is unhealthy. After a necessary restart, ask the user to reload their real editor tab and retry `list_editors`.
 
 If the native MCP tools are not registered in the current session, do not stop or ask for a restart. Use the same validated tools through the local CLI fallback:
 
 ```bash
-npx -y slides-studio-mcp@latest call get_design_guidance
-npx -y slides-studio-mcp@latest call list_editors
-npx -y slides-studio-mcp@latest call list_tools --json '{"names":["add_slide","add_text"]}'
-npx -y slides-studio-mcp@latest call create_project --json '{"name":"My presentation"}'
+npx -y carouselbot@latest call get_design_guidance
+npx -y carouselbot@latest call list_editors
+npx -y carouselbot@latest call list_tools --json '{"names":["add_slide","add_text"]}'
+npx -y carouselbot@latest call create_project --json '{"name":"My presentation"}'
 ```
 
 Every tool accepts the same JSON arguments as MCP. Use `list_tools` without arguments for compact discovery or pass `{"names":[...]}` to retrieve selected schemas. Prefer `apply_operations` for batches. `render_slide` writes its returned image to a temporary local `previewPath`; inspect that file and remove the temporary directory after the review. Hermes can load the native tools in place with `/reload-mcp` and refresh this skill with `/reload-skills`.
@@ -46,8 +46,8 @@ With only one agent and one editor, the server can create an implicit session fo
 
 Inspect the assigned editor before editing and keep the returned IDs and revision. Work on the assigned project and slide. Pass `expectedRevision` for sensitive mutations. If `STALE_PROJECT` is returned, the browser has reloaded the canonical IndexedDB copy; inspect again and retry with current IDs. Prefer `apply_operations` for compact related changes while preserving logical order.
 
-Use readable role-based type ranges: title `92–124`, subtitle `68–84`, body `54–68`, caption `44–52`. Do not solve dense copy by dropping below the body range; shorten it or split it across slides. `add_text` and `update_text` automatically preserve width and fit height around every wrapped line with safe padding, so do not waste calls on render-fit-render loops. For highlighted text, prefer `style: "boxed"` with `backgroundShape: "lines"`. Use `backgroundShape: "full"` only for a deliberate card. Call `fit_text_boxes` with `mode: "both"` only when you intentionally want the width to shrink too.
+Use readable role-based type ranges: title `92–124`, subtitle `68–84`, body `54–68`, caption `44–52`. Do not solve dense copy by dropping below the body range; shorten it or split it across slides. `add_text` and `update_text` automatically preserve width and fit height around every wrapped line with safe padding. For highlighted text, prefer `style: "boxed"` with `backgroundShape: "lines"`. Use `backgroundShape: "full"` only for a deliberate card. Call `fit_text_boxes` with `mode: "both"` only when you intentionally want the width to shrink too.
 
-After each meaningful composition or after a short batch, call `render_slide` and inspect the returned image. Fix clipping, spacing, contrast, unsafe TikTok-overlay placement, and weak hierarchy before claiming the slide is finished. Use `export_slide` or `export_project` only when local files are requested; do not overwrite existing files unless authorized.
+After each meaningful composition or after a short batch, call `render_slide` and inspect the returned image. Fix clipping, spacing, contrast, unsafe overlay placement, and weak hierarchy before claiming the slide is finished. Use `export_slide` or `export_project` only when local files are requested; do not overwrite existing files unless authorized.
 
 Edits follow the latest changed slide only when their project is already visible. Creating or editing another project must not take over the user's current browser view. `open_project` and `set_view` intentionally navigate, so call them only when the user asks to see that project. Other tabs synchronize project cards and project state through local browser storage. Use `show_notification` only for short, useful status messages.

--- a/packages/mcp/src/agent-identity.mjs
+++ b/packages/mcp/src/agent-identity.mjs
@@ -13,6 +13,7 @@ const GENERIC_CLIENT_NAMES = new Set([
   "mcp",
   "mcp agent",
   "mcp client",
+  "carouselbot cli fallback",
   "slide studio cli fallback",
 ]);
 
@@ -27,7 +28,7 @@ export function isGenericAgentName(value) {
 }
 
 export function detectHostAgent(explicitName = null, environment = process.env, runtime = process) {
-  const configured = canonicalAgentName(explicitName || environment.SLIDE_STUDIO_AGENT);
+  const configured = canonicalAgentName(explicitName || environment.CAROUSELBOT_AGENT || environment.SLIDE_STUDIO_AGENT);
   if (configured) return configured;
   const environmentKeys = Object.keys(environment).filter((key) => environment[key]).join(" ");
   const evidence = [

--- a/packages/mcp/src/call.mjs
+++ b/packages/mcp/src/call.mjs
@@ -16,7 +16,7 @@ async function stdinText() {
 
 async function parseArguments(arguments_) {
   const [toolName, ...rest] = arguments_;
-  if (!toolName) throw new Error("Usage: slides-studio-mcp call <tool> [--json '{\"key\":\"value\"}']");
+  if (!toolName) throw new Error("Usage: carouselbot call <tool> [--json '{\"key\":\"value\"}']");
   const inline = rest.find((value) => value.startsWith("--json="));
   const flagIndex = rest.indexOf("--json");
   const raw = inline?.slice("--json=".length)
@@ -37,7 +37,7 @@ async function printableResult(toolName, result) {
   const image = result.content?.find((item) => item.type === "image" && item.data);
   if (!image) return result.structuredContent ?? { content: result.content || [] };
   const extension = image.mimeType === "image/jpeg" ? "jpg" : "png";
-  const directory = await mkdtemp(join(tmpdir(), "slide-studio-preview-"));
+  const directory = await mkdtemp(join(tmpdir(), "carouselbot-preview-"));
   const previewPath = join(directory, `slide.${extension}`);
   await writeFile(previewPath, Buffer.from(image.data, "base64"));
   return { ...(result.structuredContent || {}), previewPath, temporary: true };
@@ -100,7 +100,7 @@ export async function runCall(arguments_) {
   child.stderr.on("data", (chunk) => { errors = `${errors}${chunk}`.slice(-4000); });
   const rpc = createRpc(child);
   try {
-    await rpc.request("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "Slide Studio CLI fallback", version: "1" } });
+    await rpc.request("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "CarouselBot CLI fallback", version: "1" } });
     rpc.notify("notifications/initialized");
     if (toolName === "list_tools") {
       const listed = await rpc.request("tools/list");

--- a/packages/mcp/src/cli.mjs
+++ b/packages/mcp/src/cli.mjs
@@ -36,7 +36,7 @@ async function main() {
     return;
   }
   if (command === "help" || command === "--help" || command === "-h") {
-    process.stdout.write(`Slide Studio MCP ${PACKAGE_VERSION}\n\nUsage:\n  slides-studio-mcp serve [--agent=claude|codex|hermes|opencode|openclaw]\n  slides-studio-mcp setup [--client=claude,codex,hermes,opencode,openclaw] [--yes] [--dry-run]\n  slides-studio-mcp call <tool> [--json '{"key":"value"}'] [--stdin]\n  slides-studio-mcp doctor\n  slides-studio-mcp restart\n  slides-studio-mcp version\n`);
+    process.stdout.write(`CarouselBot MCP ${PACKAGE_VERSION}\n\nUsage:\n  carouselbot serve [--agent=claude|codex|hermes|opencode|openclaw]\n  carouselbot setup [--client=claude,codex,hermes,opencode,openclaw] [--yes] [--dry-run]\n  carouselbot call <tool> [--json '{"key":"value"}'] [--stdin]\n  carouselbot doctor\n  carouselbot restart\n  carouselbot version\n`);
     return;
   }
   throw new Error(`Unknown command: ${command}`);

--- a/packages/mcp/src/companion.mjs
+++ b/packages/mcp/src/companion.mjs
@@ -34,7 +34,7 @@ async function healthyState() {
   try {
     const result = await daemonRequest(state, "/internal/health");
     if (result.protocolVersion !== PROTOCOL_VERSION) {
-      const error = new Error(`Local companion ${result.version || "unknown"} uses protocol ${result.protocolVersion}; ${PACKAGE_VERSION} requires protocol ${PROTOCOL_VERSION}. Run \`npx -y slides-studio-mcp@latest restart\`, then reload the editor.`);
+      const error = new Error(`Local companion ${result.version || "unknown"} uses protocol ${result.protocolVersion}; ${PACKAGE_VERSION} requires protocol ${PROTOCOL_VERSION}. Run \`npx -y carouselbot@latest restart\`, then reload the editor.`);
       error.code = "EPROTOCOL";
       throw error;
     }
@@ -60,7 +60,7 @@ async function ensureDaemon() {
     const state = await healthyState();
     if (state) return state;
   }
-  throw new Error("Could not start the local Slide Studio companion. Run `npx slides-studio-mcp doctor` for details.");
+  throw new Error("Could not start the local CarouselBot companion. Run `npx carouselbot doctor` for details.");
 }
 
 export async function createCompanion(initialName = "MCP agent", initialVersion = null) {

--- a/packages/mcp/src/config.mjs
+++ b/packages/mcp/src/config.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,21 +9,29 @@ export const PACKAGE_NAME = PACKAGE_JSON.name;
 export const PACKAGE_VERSION = PACKAGE_JSON.version;
 export const PROTOCOL_VERSION = 3;
 export const BRIDGE_HOST = "127.0.0.1";
-export const BRIDGE_PORT = Number(process.env.SLIDE_STUDIO_BRIDGE_PORT) || 43117;
+export const BRIDGE_PORT = Number(process.env.CAROUSELBOT_BRIDGE_PORT || process.env.SLIDE_STUDIO_BRIDGE_PORT) || 43117;
 export const BRIDGE_URL = `http://${BRIDGE_HOST}:${BRIDGE_PORT}`;
-export const EDITOR_URL = "https://slides-editor.pages.dev";
-export const ALLOWED_ORIGINS = new Set((process.env.SLIDE_STUDIO_ALLOWED_ORIGINS || [
+export const EDITOR_URL = "https://carousel.bot";
+export const LEGACY_EDITOR_URL = "https://slides-editor.pages.dev";
+export const ALLOWED_ORIGINS = new Set((process.env.CAROUSELBOT_ALLOWED_ORIGINS || process.env.SLIDE_STUDIO_ALLOWED_ORIGINS || [
   EDITOR_URL,
+  LEGACY_EDITOR_URL,
   "http://127.0.0.1:4173",
   "http://localhost:4173",
 ].join(",")).split(",").map((value) => value.trim()).filter(Boolean));
 export const GUIDANCE_PATH = join(PACKAGE_ROOT, "guidance", "design.md");
 
 function defaultStateDirectory() {
-  if (process.env.SLIDE_STUDIO_STATE_DIR) return process.env.SLIDE_STUDIO_STATE_DIR;
-  if (platform() === "win32") return join(process.env.LOCALAPPDATA || homedir(), "SlideStudioMCP");
-  if (platform() === "darwin") return join(homedir(), "Library", "Caches", "SlideStudioMCP");
-  return join(process.env.XDG_RUNTIME_DIR || join(homedir(), ".cache"), "slides-studio-mcp");
+  if (process.env.CAROUSELBOT_STATE_DIR || process.env.SLIDE_STUDIO_STATE_DIR) return process.env.CAROUSELBOT_STATE_DIR || process.env.SLIDE_STUDIO_STATE_DIR;
+  const legacy = platform() === "win32"
+    ? join(process.env.LOCALAPPDATA || homedir(), "SlideStudioMCP")
+    : platform() === "darwin"
+      ? join(homedir(), "Library", "Caches", "SlideStudioMCP")
+      : join(process.env.XDG_RUNTIME_DIR || join(homedir(), ".cache"), "slides-studio-mcp");
+  if (existsSync(legacy)) return legacy;
+  if (platform() === "win32") return join(process.env.LOCALAPPDATA || homedir(), "CarouselBot");
+  if (platform() === "darwin") return join(homedir(), "Library", "Caches", "CarouselBot");
+  return join(process.env.XDG_RUNTIME_DIR || join(homedir(), ".cache"), "carouselbot");
 }
 
 export const STATE_DIRECTORY = defaultStateDirectory();

--- a/packages/mcp/src/daemon.mjs
+++ b/packages/mcp/src/daemon.mjs
@@ -10,14 +10,14 @@ import {
 
 const MAX_JSON_BYTES = 40 * 1024 * 1024;
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
-const EDITOR_TTL_MS = Number(process.env.SLIDE_STUDIO_EDITOR_TTL_MS) || 60_000;
+const EDITOR_TTL_MS = Number(process.env.CAROUSELBOT_EDITOR_TTL_MS || process.env.SLIDE_STUDIO_EDITOR_TTL_MS) || 60_000;
 const CLIENT_TTL_MS = 45_000;
 const MEDIA_TTL_MS = 5 * 60_000;
 const COMMAND_TIMEOUT_MS = 90_000;
-const EDIT_SESSION_TTL_MS = Number(process.env.SLIDE_STUDIO_EDIT_SESSION_TTL_MS) || 5 * 60_000;
+const EDIT_SESSION_TTL_MS = Number(process.env.CAROUSELBOT_EDIT_SESSION_TTL_MS || process.env.SLIDE_STUDIO_EDIT_SESSION_TTL_MS) || 5 * 60_000;
 const MAX_AUDIT_EVENTS = 500;
 const MAX_AUDIT_BYTES = 2 * 1024 * 1024;
-const EVENT_POLL_TIMEOUT_MS = Number(process.env.SLIDE_STUDIO_EVENT_POLL_TIMEOUT_MS) || 500;
+const EVENT_POLL_TIMEOUT_MS = Number(process.env.CAROUSELBOT_EVENT_POLL_TIMEOUT_MS || process.env.SLIDE_STUDIO_EVENT_POLL_TIMEOUT_MS) || 500;
 const MAX_EVENT_POLL_TIMEOUT_MS = 5_000;
 const daemonSecret = randomBytes(32).toString("base64url");
 const editors = new Map();
@@ -32,7 +32,7 @@ let idleSince = null;
 let auditWrite = Promise.resolve();
 
 function log(message) {
-  process.stderr.write(`[slide-studio-daemon] ${message}\n`);
+  process.stderr.write(`[carouselbot-daemon] ${message}\n`);
 }
 
 function editorHasInflightCommand(editorId) {
@@ -157,7 +157,7 @@ function claimProject(session, projectId) {
 
 function beginEditSession(client, { editorId, projectId, purpose }) {
   const connected = activeEditors();
-  if (!connected.length) throw codedError("NO_EDITOR", "No Slide Studio editor is connected. Open the test editor in the user's normal browser and click Connect AI.");
+  if (!connected.length) throw codedError("NO_EDITOR", "No CarouselBot editor is connected. Open the editor in the user's normal browser and click Connect AI.");
   let editor = editorId ? connected.find((item) => item.id === editorId) : null;
   if (editorId && !editor) throw codedError("EDITOR_DISCONNECTED", `Editor is not connected: ${editorId}`);
   if (!editor) {
@@ -173,7 +173,7 @@ function beginEditSession(client, { editorId, projectId, purpose }) {
   const now = Date.now();
   const session = {
     id: randomUUID(), editorId: editor.id, projectId: projectId || null,
-    purpose: String(purpose || "Edit Slide Studio").slice(0, 160), owner: publicClient(client),
+    purpose: String(purpose || "Edit CarouselBot").slice(0, 160), owner: publicClient(client),
     creatorClientId: client.id, lastClientId: client.id, implicit: false, createdAt: now, lastSeen: now,
   };
   editSessions.set(session.id, session);
@@ -189,7 +189,7 @@ function browserCors(origin) {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Authorization, Content-Type",
-    "Access-Control-Expose-Headers": "X-Slide-Studio-Filename",
+    "Access-Control-Expose-Headers": "X-CarouselBot-Filename, X-Slide-Studio-Filename",
     "Access-Control-Allow-Private-Network": "true",
     "Access-Control-Max-Age": "600",
     "Cache-Control": "no-store",
@@ -301,7 +301,7 @@ function selectEditor(clientId) {
   const focused = focusedEditorId && connected.find((editor) => editor.id === focusedEditorId);
   if (focused) return focused;
   if (connected.length === 1) return connected[0];
-  if (!connected.length) throw new Error("No Slide Studio editor is connected. Open the test editor and click Connect AI.");
+  if (!connected.length) throw new Error("No CarouselBot editor is connected. Open the editor and click Connect AI.");
   throw new Error("Multiple editors are connected and none is selected. Call list_editors, then select_editor.");
 }
 
@@ -605,7 +605,7 @@ const server = createServer(async (request, response) => {
       const item = media.get(id);
       if (!item || item.expiresAt < Date.now()) return sendJson(response, 404, { error: "Local image transfer expired." }, cors);
       media.delete(id);
-      response.writeHead(200, { ...cors, "Content-Type": item.mimeType, "Content-Length": item.buffer.length, "X-Slide-Studio-Filename": encodeURIComponent(item.filename) });
+      response.writeHead(200, { ...cors, "Content-Type": item.mimeType, "Content-Length": item.buffer.length, "X-CarouselBot-Filename": encodeURIComponent(item.filename), "X-Slide-Studio-Filename": encodeURIComponent(item.filename) });
       response.end(item.buffer);
       return;
     }
@@ -628,7 +628,7 @@ async function acquireDaemonLock() {
       const lockPid = Number(await readFile(DAEMON_LOCK_PATH, "utf8"));
       if (!Number.isInteger(lockPid) || lockPid <= 0) throw Object.assign(new Error("Invalid daemon lock."), { code: "ESTALE" });
       process.kill(lockPid, 0);
-      const running = new Error(`Slide Studio daemon is already running or starting (pid ${lockPid}).`);
+      const running = new Error(`CarouselBot daemon is already running or starting (pid ${lockPid}).`);
       running.code = "EALREADY";
       throw running;
     } catch (checkError) {

--- a/packages/mcp/src/mcp-server.mjs
+++ b/packages/mcp/src/mcp-server.mjs
@@ -61,7 +61,7 @@ function operationLabel(toolName) {
     update_image: "Updating an image…", delete_layers: "Deleting layers…", duplicate_layers: "Duplicating layers…",
     reorder_layers: "Reordering layers…", undo: "Undoing the last edit…", redo: "Redoing the last edit…",
     set_view: "Updating the editor view…", render_slide: "Rendering the slide…",
-  })[toolName] || "Editing in Slide Studio…";
+  })[toolName] || "Editing in CarouselBot…";
 }
 
 async function browserOperation(companion, toolName, args) {
@@ -94,12 +94,12 @@ async function prepareOperation(companion, toolName, args) {
   return { type, ...operation };
 }
 
-export async function createSlideStudioMcpServer(companion) {
+export async function createCarouselBotMcpServer(companion) {
   const guidance = await readFile(GUIDANCE_PATH, "utf8");
   let guidanceRead = false;
   let identifiedAs = null;
   const server = new McpServer({ name: PACKAGE_NAME, version: PACKAGE_VERSION }, {
-    instructions: `First call list_editors and use the registered local browser tab. Never open or connect Slide Studio through a sandboxed agent browser. If no editor is listed, retry briefly because browser reconnection is automatic, then ask the user to open ${EDITOR_URL} in their normal browser and click Connect AI. Never restart a healthy companion for a transient editor disconnect; restart only for an explicit protocol mismatch or failed daemon health check. Before edits call get_design_guidance, then begin_edit_session; pass editSessionId to every edit and end it in cleanup. Parallel editing workers require distinct editor sessions. Use render_slide to inspect actual pixels.`,
+    instructions: `First call list_editors and use the registered local browser tab. Never open or connect CarouselBot through a sandboxed agent browser. If no editor is listed, retry briefly because browser reconnection is automatic, then ask the user to open ${EDITOR_URL} in their normal browser and click Connect AI. Never restart a healthy companion for a transient editor disconnect; restart only for an explicit protocol mismatch or failed daemon health check. Before edits call get_design_guidance, then begin_edit_session; pass editSessionId to every edit and end it in cleanup. Parallel editing workers require distinct editor sessions. Use render_slide to inspect actual pixels.`,
     capabilities: { tools: {}, resources: {} },
   });
 
@@ -128,19 +128,23 @@ export async function createSlideStudioMcpServer(companion) {
     });
   }
 
-  server.registerResource("slide-studio-design-guidance", "slide-studio://guidance/design", {
-    title: "Slide Studio design guidance", description: "Required visual-quality and text-box safety guidance.", mimeType: "text/markdown",
-  }, async (uri) => {
+  const readGuidanceResource = async (uri) => {
     guidanceRead = true;
     return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: guidance }] };
-  });
+  };
+  server.registerResource("carouselbot-design-guidance", "carouselbot://guidance/design", {
+    title: "CarouselBot design guidance", description: "Required visual-quality and text-box safety guidance.", mimeType: "text/markdown",
+  }, readGuidanceResource);
+  server.registerResource("slide-studio-design-guidance", "slide-studio://guidance/design", {
+    title: "CarouselBot design guidance (legacy URI)", description: "Backward-compatible alias for CarouselBot design guidance.", mimeType: "text/markdown",
+  }, readGuidanceResource);
 
   register("get_design_guidance", "Read the required compact design and clipping guidance. Call once before any mutation.", z.object({}).strict(), async () => {
     guidanceRead = true;
     return { __rawMcpResult: true, content: [{ type: "text", text: guidance }], structuredContent: { read: true } };
   }, { readOnlyHint: true, idempotentHint: true });
 
-  register("list_editors", "Check the user's real local browser connection and show which registered Slide Studio tab this session targets. Call this instead of opening a sandboxed browser.", z.object({}).strict(), () => companion.call("list_editors"), { readOnlyHint: true });
+  register("list_editors", "Check the user's real local browser connection and show which registered CarouselBot tab this session targets. Call this instead of opening a sandboxed browser.", z.object({}).strict(), () => companion.call("list_editors"), { readOnlyHint: true });
   register("select_editor", "Select a connected browser tab for this MCP session.", z.object({ editorId: id }).strict(), ({ editorId }) => companion.call("select_editor", { editorId }), { destructiveHint: false, idempotentHint: true });
   register("begin_edit_session", "Atomically reserve one browser tab and optionally one project for an editing agent. Use one session per parallel editing worker and pass editSessionId to every edit.", z.object({ editorId: optionalId, projectId: optionalId, purpose: z.string().min(1).max(160).optional() }).strict(), (args) => companion.call("begin_edit_session", args), { destructiveHint: false });
   register("end_edit_session", "Release a browser-tab/project reservation as soon as an editing task finishes or fails.", z.object({ editSessionId: id }).strict(), (args) => companion.call("end_edit_session", args), { destructiveHint: false, idempotentHint: true });
@@ -223,3 +227,5 @@ export async function createSlideStudioMcpServer(companion) {
 
   return server;
 }
+
+export const createSlideStudioMcpServer = createCarouselBotMcpServer;

--- a/packages/mcp/src/setup.mjs
+++ b/packages/mcp/src/setup.mjs
@@ -6,6 +6,8 @@ import { createInterface } from "node:readline/promises";
 import { EDITOR_URL, PACKAGE_NAME, PACKAGE_ROOT, PACKAGE_VERSION } from "./config.mjs";
 
 const supported = ["claude", "codex", "hermes", "opencode", "openclaw"];
+const serverName = "carouselbot";
+const legacyServerName = "slide-studio";
 
 function commandExists(command) {
   return spawnSync(command, ["--version"], { stdio: "ignore" }).error?.code !== "ENOENT";
@@ -17,17 +19,17 @@ function commandVersion(command) {
 }
 
 function shellCommand(client, specifier) {
-  if (client === "claude") return ["claude", "mcp", "add", "--scope", "user", "--transport", "stdio", "slide-studio", "--", "npx", "-y", specifier, "serve", "--agent=claude"];
-  if (client === "codex") return ["codex", "mcp", "add", "slide-studio", "--", "npx", "-y", specifier, "serve", "--agent=codex"];
-  if (client === "hermes") return ["hermes", "mcp", "add", "slide-studio", "--command", "npx", "--args", "-y", specifier, "serve", "--agent=hermes"];
-  if (client === "openclaw") return ["openclaw", "mcp", "add", "slide-studio", "--command", "npx", "--arg", "-y", "--arg", specifier, "--arg", "serve", "--arg", "--agent=openclaw"];
+  if (client === "claude") return ["claude", "mcp", "add", "--scope", "user", "--transport", "stdio", serverName, "--", "npx", "-y", specifier, "serve", "--agent=claude"];
+  if (client === "codex") return ["codex", "mcp", "add", serverName, "--", "npx", "-y", specifier, "serve", "--agent=codex"];
+  if (client === "hermes") return ["hermes", "mcp", "add", serverName, "--command", "npx", "--args", "-y", specifier, "serve", "--agent=hermes"];
+  if (client === "openclaw") return ["openclaw", "mcp", "add", serverName, "--command", "npx", "--arg", "-y", "--arg", specifier, "--arg", "serve", "--arg", "--agent=openclaw"];
   return null;
 }
 
-function removeCommand(client) {
-  if (client === "claude") return ["claude", "mcp", "remove", "--scope", "user", "slide-studio"];
-  if (["codex", "hermes", "openclaw"].includes(client)) return [client, "mcp", "remove", "slide-studio"];
-  return null;
+function removeCommands(client) {
+  if (client === "claude") return [serverName, legacyServerName].map((name) => ["claude", "mcp", "remove", "--scope", "user", name]);
+  if (["codex", "hermes", "openclaw"].includes(client)) return [serverName, legacyServerName].map((name) => [client, "mcp", "remove", name]);
+  return [];
 }
 
 function quote(value) {
@@ -37,16 +39,16 @@ function quote(value) {
 function openCodeSnippet(specifier, version = commandVersion("opencode")) {
   const server = { type: "local", command: ["npx", "-y", specifier, "serve", "--agent=opencode"] };
   return JSON.stringify(Number(version?.split(".")[0]) >= 2
-    ? { mcp: { servers: { "slide-studio": server } } }
-    : { mcp: { "slide-studio": { ...server, enabled: true } } }, null, 2);
+    ? { mcp: { servers: { [serverName]: server } } }
+    : { mcp: { [serverName]: { ...server, enabled: true } } }, null, 2);
 }
 
 async function installSkill() {
-  const source = join(PACKAGE_ROOT, "skill", "slide-studio");
+  const source = join(PACKAGE_ROOT, "skill", "carouselbot");
   const targets = [
-    join(homedir(), ".agents", "skills", "slide-studio"),
-    join(homedir(), ".claude", "skills", "slide-studio"),
-    join(homedir(), ".hermes", "skills", "slide-studio"),
+    join(homedir(), ".agents", "skills", "carouselbot"),
+    join(homedir(), ".claude", "skills", "carouselbot"),
+    join(homedir(), ".hermes", "skills", "carouselbot"),
   ];
   for (const target of targets) {
     await mkdir(target, { recursive: true });
@@ -66,7 +68,7 @@ export async function runSetup(arguments_) {
   const assumeYes = flags.has("--yes") || flags.has("-y");
   if (!clients.length) throw new Error("No supported agent CLI was detected. Use --client=claude,codex,hermes,opencode,openclaw or copy the generic stdio config below.");
 
-  process.stdout.write(`Slide Studio MCP ${PACKAGE_VERSION}\nDetected: ${clients.join(", ")}\nEditor: ${EDITOR_URL}\n\n`);
+  process.stdout.write(`CarouselBot MCP ${PACKAGE_VERSION}\nDetected: ${clients.join(", ")}\nEditor: ${EDITOR_URL}\n\n`);
   for (const client of clients) {
     const command = shellCommand(client, specifier);
     if (command) process.stdout.write(`${client}: ${command.map(quote).join(" ")}\n`);
@@ -78,7 +80,7 @@ export async function runSetup(arguments_) {
   let approved = assumeYes;
   if (!approved && process.stdin.isTTY) {
     const prompt = createInterface({ input: process.stdin, output: process.stdout });
-    const answer = await prompt.question("\nAdd Slide Studio to the detected agent configs and install its skill? [y/N] ");
+    const answer = await prompt.question("\nAdd CarouselBot to the detected agent configs and install its skill? [y/N] ");
     prompt.close();
     approved = /^y(?:es)?$/i.test(answer.trim());
   }
@@ -91,8 +93,7 @@ export async function runSetup(arguments_) {
   for (const client of clients) {
     const command = shellCommand(client, specifier);
     if (!command) continue;
-    const remove = removeCommand(client);
-    if (remove) spawnSync(remove[0], remove.slice(1), { stdio: "ignore" });
+    for (const remove of removeCommands(client)) spawnSync(remove[0], remove.slice(1), { stdio: "ignore" });
     const result = spawnSync(command[0], command.slice(1), { stdio: "inherit" });
     if (result.status === 0) configured.push(client);
     else process.stderr.write(`Could not configure ${client}; its command is printed above for manual setup.\n`);

--- a/packages/mcp/src/stdio-server.mjs
+++ b/packages/mcp/src/stdio-server.mjs
@@ -1,13 +1,13 @@
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { detectHostAgent } from "./agent-identity.mjs";
 import { createCompanion } from "./companion.mjs";
-import { createSlideStudioMcpServer } from "./mcp-server.mjs";
+import { createCarouselBotMcpServer } from "./mcp-server.mjs";
 
 export async function serveMcp({ agentName = null } = {}) {
   const companion = await createCompanion(detectHostAgent(agentName));
-  const handle = serveStdio(() => createSlideStudioMcpServer(companion), {
+  const handle = serveStdio(() => createCarouselBotMcpServer(companion), {
     legacy: "serve",
-    onerror: (error) => process.stderr.write(`[slides-studio-mcp] ${error.message}\n`),
+    onerror: (error) => process.stderr.write(`[carouselbot] ${error.message}\n`),
   });
   let closing = false;
   const close = async () => {

--- a/packages/mcp/test/agent-identity.test.mjs
+++ b/packages/mcp/test/agent-identity.test.mjs
@@ -3,17 +3,17 @@ import assert from "node:assert/strict";
 import { detectHostAgent, preferHostAgent } from "../src/agent-identity.mjs";
 
 test("detects Hermes from its bundled Node runtime without client cooperation", () => {
-  const runtime = { execPath: "/Users/person/.hermes/node/bin/node", argv: ["node", "slides-studio-mcp", "serve"] };
+  const runtime = { execPath: "/Users/person/.hermes/node/bin/node", argv: ["node", "carouselbot", "serve"] };
   assert.equal(detectHostAgent(null, {}, runtime), "Hermes");
 });
 
 test("explicit setup identity wins over runtime inference", () => {
-  const runtime = { execPath: "/usr/bin/node", argv: ["node", "slides-studio-mcp", "serve"] };
+  const runtime = { execPath: "/usr/bin/node", argv: ["node", "carouselbot", "serve"] };
   assert.equal(detectHostAgent("codex", { PATH: "/Users/person/.hermes/node/bin" }, runtime), "Codex");
 });
 
 test("generic MCP metadata does not erase the detected host agent", () => {
   assert.equal(preferHostAgent("mcp", "Hermes"), "Hermes");
-  assert.equal(preferHostAgent("Slide Studio CLI fallback", "Claude"), "Claude");
+  assert.equal(preferHostAgent("CarouselBot CLI fallback", "Claude"), "Claude");
   assert.equal(preferHostAgent("Codex Desktop", "Hermes"), "Codex");
 });

--- a/packages/mcp/test/cli-call.test.mjs
+++ b/packages/mcp/test/cli-call.test.mjs
@@ -11,9 +11,9 @@ const execute = promisify(execFile);
 const cli = fileURLToPath(new URL("../src/cli.mjs", import.meta.url));
 
 test("calls the validated MCP tool surface from the CLI without a client restart", async () => {
-  const stateDirectory = await mkdtemp(join(tmpdir(), "slide-studio-call-"));
+  const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-call-"));
   const port = 47000 + Math.floor(Math.random() * 1000);
-  const env = { ...process.env, SLIDE_STUDIO_STATE_DIR: stateDirectory, SLIDE_STUDIO_BRIDGE_PORT: String(port) };
+  const env = { ...process.env, CAROUSELBOT_STATE_DIR: stateDirectory, CAROUSELBOT_BRIDGE_PORT: String(port) };
   try {
     const { stdout } = await execute(process.execPath, [cli, "call", "list_editors"], { env, timeout: 15_000 });
     const result = JSON.parse(stdout);

--- a/packages/mcp/test/current-client.test.mjs
+++ b/packages/mcp/test/current-client.test.mjs
@@ -11,19 +11,19 @@ const cli = fileURLToPath(new URL("../src/cli.mjs", import.meta.url));
 const root = dirname(dirname(dirname(dirname(cli))));
 
 test("negotiates the current protocol through the official MCP v2 client", async () => {
-  const stateDirectory = await mkdtemp(join(tmpdir(), "slide-studio-current-"));
+  const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-current-"));
   const port = 46000 + Math.floor(Math.random() * 1000);
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [cli, "serve"],
     cwd: root,
-    env: Object.fromEntries(Object.entries({ ...process.env, SLIDE_STUDIO_STATE_DIR: stateDirectory, SLIDE_STUDIO_BRIDGE_PORT: String(port) }).filter(([, value]) => typeof value === "string")),
+    env: Object.fromEntries(Object.entries({ ...process.env, CAROUSELBOT_STATE_DIR: stateDirectory, CAROUSELBOT_BRIDGE_PORT: String(port) }).filter(([, value]) => typeof value === "string")),
     stderr: "pipe",
   });
   const client = new Client({ name: "official-v2-test", version: "1" });
   try {
     await client.connect(transport);
-    assert.equal(client.getServerVersion()?.name, "slides-studio-mcp");
+    assert.equal(client.getServerVersion()?.name, "carouselbot");
     const { tools } = await client.listTools();
     assert.ok(tools.some((tool) => tool.name === "render_slide"));
     const guidance = await client.callTool({ name: "get_design_guidance", arguments: {} });

--- a/packages/mcp/test/protocol.test.mjs
+++ b/packages/mcp/test/protocol.test.mjs
@@ -40,9 +40,9 @@ function createRpc(child) {
 }
 
 async function withServer(callback) {
-  const stateDirectory = await mkdtemp(join(tmpdir(), "slides-studio-mcp-test-"));
+  const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-test-"));
   const port = 44000 + Math.floor(Math.random() * 1000);
-  const env = { ...process.env, SLIDE_STUDIO_BRIDGE_PORT: String(port), SLIDE_STUDIO_STATE_DIR: stateDirectory };
+  const env = { ...process.env, CAROUSELBOT_BRIDGE_PORT: String(port), CAROUSELBOT_STATE_DIR: stateDirectory };
   const child = spawn(process.execPath, [cli.pathname, "serve"], { cwd: root, env, stdio: ["pipe", "pipe", "pipe"] });
   let errors = "";
   child.stderr.setEncoding("utf8");
@@ -62,7 +62,7 @@ async function withServer(callback) {
 test("serves a complete legacy-compatible stdio MCP surface", async () => {
   await withServer(async ({ rpc, errors }) => {
     const initialized = await rpc.request("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "protocol-test", version: "1" } });
-    assert.equal(initialized.result.serverInfo.name, "slides-studio-mcp");
+    assert.equal(initialized.result.serverInfo.name, "carouselbot");
     rpc.notify("notifications/initialized");
 
     const listed = await rpc.request("tools/list");
@@ -91,7 +91,7 @@ test("serves a complete legacy-compatible stdio MCP surface", async () => {
 
     const noBrowser = await rpc.request("tools/call", { name: "create_project", arguments: { name: "No browser" } });
     assert.equal(noBrowser.result.isError, true);
-    assert.match(noBrowser.result.content[0].text, /No Slide Studio editor is connected/);
+    assert.match(noBrowser.result.content[0].text, /No CarouselBot editor is connected/);
     assert.doesNotMatch(errors(), /Invalid JSON-RPC|stdout/i);
   });
 });
@@ -110,14 +110,15 @@ test("protects internal routes, origins, and protocol versions", async () => {
     const base = `http://127.0.0.1:${port}`;
     assert.equal((await fetch(`${base}/internal/health`)).status, 401);
     assert.equal((await fetch(`${base}/health`, { headers: { Origin: "https://attacker.example" } })).status, 403);
-    const preflight = await fetch(`${base}/health`, { method: "OPTIONS", headers: { Origin: "https://slides-editor.pages.dev", "Access-Control-Request-Private-Network": "true" } });
+    const preflight = await fetch(`${base}/health`, { method: "OPTIONS", headers: { Origin: "https://carousel.bot", "Access-Control-Request-Private-Network": "true" } });
     assert.equal(preflight.status, 204);
     assert.equal(preflight.headers.get("access-control-allow-private-network"), "true");
     const mismatch = await fetch(`${base}/connect`, {
       method: "POST",
-      headers: { Origin: "https://slides-editor.pages.dev", "Content-Type": "application/json" },
+      headers: { Origin: "https://carousel.bot", "Content-Type": "application/json" },
       body: JSON.stringify({ editorId: "test-editor", protocolVersion: 999 }),
     });
     assert.equal(mismatch.status, 409);
+    assert.equal((await fetch(`${base}/health`, { headers: { Origin: "https://slides-editor.pages.dev" } })).status, 200);
   });
 });

--- a/packages/mcp/test/shared-daemon.test.mjs
+++ b/packages/mcp/test/shared-daemon.test.mjs
@@ -5,16 +5,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 test("shares one daemon while preserving per-agent editor selection", async () => {
-  const stateDirectory = await mkdtemp(join(tmpdir(), "slide-studio-shared-"));
+  const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-shared-"));
   const port = 45000 + Math.floor(Math.random() * 1000);
-  process.env.SLIDE_STUDIO_STATE_DIR = stateDirectory;
-  process.env.SLIDE_STUDIO_BRIDGE_PORT = String(port);
-  process.env.SLIDE_STUDIO_EDITOR_TTL_MS = "120";
-  process.env.SLIDE_STUDIO_EVENT_POLL_TIMEOUT_MS = "2000";
+  process.env.CAROUSELBOT_STATE_DIR = stateDirectory;
+  process.env.CAROUSELBOT_BRIDGE_PORT = String(port);
+  process.env.CAROUSELBOT_EDITOR_TTL_MS = "120";
+  process.env.CAROUSELBOT_EVENT_POLL_TIMEOUT_MS = "2000";
   const { companionRestart, createCompanion } = await import(`../src/companion.mjs?shared=${port}`);
   const first = await createCompanion("Claude Code", "test");
   const second = await createCompanion("Codex", "test");
-  const origin = "https://slides-editor.pages.dev";
+  const origin = "https://carousel.bot";
   const base = `http://127.0.0.1:${port}`;
 
   async function connect(editorId) {
@@ -136,9 +136,9 @@ test("shares one daemon while preserving per-agent editor selection", async () =
     const state = await readFile(join(stateDirectory, `daemon-${port}.json`), "utf8").then(JSON.parse).catch(() => null);
     if (state?.pid) try { process.kill(state.pid, "SIGTERM"); } catch { /* Already stopped. */ }
     await rm(stateDirectory, { recursive: true, force: true });
-    delete process.env.SLIDE_STUDIO_STATE_DIR;
-    delete process.env.SLIDE_STUDIO_BRIDGE_PORT;
-    delete process.env.SLIDE_STUDIO_EDITOR_TTL_MS;
-    delete process.env.SLIDE_STUDIO_EVENT_POLL_TIMEOUT_MS;
+    delete process.env.CAROUSELBOT_STATE_DIR;
+    delete process.env.CAROUSELBOT_BRIDGE_PORT;
+    delete process.env.CAROUSELBOT_EDITOR_TTL_MS;
+    delete process.env.CAROUSELBOT_EVENT_POLL_TIMEOUT_MS;
   }
 });

--- a/packages/slides-studio-mcp/README.md
+++ b/packages/slides-studio-mcp/README.md
@@ -1,0 +1,11 @@
+# slides-studio-mcp compatibility package
+
+Slide Studio is now **CarouselBot**. This package remains available so existing MCP client configurations continue to work without interruption.
+
+New installations should use:
+
+```bash
+npx carouselbot@latest setup
+```
+
+Running any command through `slides-studio-mcp` delegates to the maintained `carouselbot` package. No project files, images, or prompts are sent to a hosted relay.

--- a/packages/slides-studio-mcp/bin/cli.mjs
+++ b/packages/slides-studio-mcp/bin/cli.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "carouselbot/cli";

--- a/packages/slides-studio-mcp/package.json
+++ b/packages/slides-studio-mcp/package.json
@@ -1,34 +1,28 @@
 {
-  "name": "carouselbot",
+  "name": "slides-studio-mcp",
   "version": "0.2.0",
-  "description": "Local-first MCP companion for the hosted CarouselBot editor",
+  "description": "Compatibility package for the renamed CarouselBot MCP",
   "type": "module",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alexgusevski/carouselbot.git",
-    "directory": "packages/mcp"
+    "directory": "packages/slides-studio-mcp"
   },
   "homepage": "https://carousel.bot",
   "bugs": "https://github.com/alexgusevski/carouselbot/issues",
   "bin": {
-    "carouselbot": "src/cli.mjs"
-  },
-  "exports": {
-    "./cli": "./src/cli.mjs"
+    "slides-studio-mcp": "bin/cli.mjs"
   },
   "files": [
-    "src",
-    "guidance",
-    "skill",
+    "bin",
     "README.md"
   ],
   "engines": {
     "node": ">=20"
   },
   "dependencies": {
-    "@modelcontextprotocol/server": "2.0.0",
-    "zod": "^4.4.3"
+    "carouselbot": "0.2.0"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,8 +9,10 @@ const output = join(root, "dist");
 await rm(output, { recursive: true, force: true });
 await mkdir(join(output, "assets"), { recursive: true });
 
-const [indexHtml, appSource, agentSource, bridgeSource, styleSource] = await Promise.all([
+const [indexHtml, configSource, migrationSource, appSource, agentSource, bridgeSource, styleSource] = await Promise.all([
   readFile(join(root, "index.html"), "utf8"),
+  readFile(join(root, "app-config.js"), "utf8"),
+  readFile(join(root, "domain-migration.js"), "utf8"),
   readFile(join(root, "app.js"), "utf8"),
   readFile(join(root, "agent-commands.js"), "utf8"),
   readFile(join(root, "local-mcp-bridge.js"), "utf8"),
@@ -18,6 +20,8 @@ const [indexHtml, appSource, agentSource, bridgeSource, styleSource] = await Pro
 ]);
 const assetVersion = createHash("sha256")
   .update(appSource)
+  .update(configSource)
+  .update(migrationSource)
   .update(agentSource)
   .update(bridgeSource)
   .update(styleSource)
@@ -26,6 +30,8 @@ const assetVersion = createHash("sha256")
 
 await Promise.all([
   writeFile(join(output, "index.html"), indexHtml.replaceAll("?v=dev", `?v=${assetVersion}`)),
+  copyFile(join(root, "app-config.js"), join(output, "app-config.js")),
+  copyFile(join(root, "domain-migration.js"), join(output, "domain-migration.js")),
   copyFile(join(root, "app.js"), join(output, "app.js")),
   copyFile(join(root, "agent-commands.js"), join(output, "agent-commands.js")),
   copyFile(join(root, "local-mcp-bridge.js"), join(output, "local-mcp-bridge.js")),

--- a/scripts/test-domain-migration-browser.mjs
+++ b/scripts/test-domain-migration-browser.mjs
@@ -1,0 +1,160 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+const root = new URL("..", import.meta.url);
+const webPort = 49000 + Math.floor(Math.random() * 500);
+const canonicalPort = webPort + 500;
+const debuggingPort = 19500 + Math.floor(Math.random() * 400);
+const legacyOrigin = `http://127.0.0.1:${webPort}`;
+const canonicalOrigin = `http://127.0.0.1:${canonicalPort}`;
+const legacyUrl = `${legacyOrigin}/?__carouselbotMigrationPreview=legacy&__carouselbotCanonicalPort=${canonicalPort}`;
+const chromePath = process.env.CHROME_PATH || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const profile = await mkdtemp(join(tmpdir(), "carouselbot-migration-browser-"));
+let diagnostics = "";
+
+const legacyWeb = spawn(process.execPath, ["server.mjs"], {
+  cwd: root,
+  env: { ...process.env, CAROUSELBOT_PORT: String(webPort) },
+  stdio: ["ignore", "ignore", "pipe"],
+});
+const canonicalWeb = spawn(process.execPath, ["server.mjs"], {
+  cwd: root,
+  env: { ...process.env, CAROUSELBOT_PORT: String(canonicalPort) },
+  stdio: ["ignore", "ignore", "pipe"],
+});
+const chrome = spawn(chromePath, [
+  "--headless=new", "--disable-background-networking", "--disable-component-update", "--disable-breakpad", "--disable-extensions", "--disable-popup-blocking",
+  "--disable-crash-reporter", "--noerrdialogs", "--no-first-run", "--no-default-browser-check",
+  "--window-size=1280,900", `--remote-debugging-port=${debuggingPort}`, `--user-data-dir=${profile}`, "about:blank",
+], { stdio: ["ignore", "ignore", "pipe"] });
+for (const child of [legacyWeb, canonicalWeb, chrome]) {
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => { diagnostics += chunk; });
+}
+
+function connectCdp(webSocketDebuggerUrl) {
+  const socket = new WebSocket(webSocketDebuggerUrl);
+  let id = 0;
+  const pending = new Map();
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data);
+    const waiter = pending.get(message.id);
+    if (!waiter) return;
+    pending.delete(message.id);
+    message.error ? waiter.reject(new Error(message.error.message)) : waiter.resolve(message.result);
+  });
+  return {
+    ready: new Promise((resolve, reject) => { socket.addEventListener("open", resolve, { once: true }); socket.addEventListener("error", reject, { once: true }); }),
+    send(method, params = {}) {
+      return new Promise((resolve, reject) => {
+        const commandId = ++id;
+        pending.set(commandId, { resolve, reject });
+        socket.send(JSON.stringify({ id: commandId, method, params }));
+      });
+    },
+    close() { socket.close(); },
+  };
+}
+
+async function json(path) {
+  const response = await fetch(`http://127.0.0.1:${debuggingPort}${path}`);
+  if (!response.ok) throw new Error(`DevTools returned ${response.status}`);
+  return response.json();
+}
+
+async function waitFor(callback, message, timeout = 20_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try {
+      const result = await callback();
+      if (result) return result;
+    } catch { /* The browser or page is still starting. */ }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`${message}\n${diagnostics.slice(-3000)}`);
+}
+
+async function evaluate(cdp, expression, { userGesture = false } = {}) {
+  const result = await cdp.send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true, userGesture });
+  if (result.exceptionDetails) throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text || "Browser evaluation failed");
+  return result.result?.value;
+}
+
+let legacyCdp;
+let canonicalCdp;
+try {
+  await waitFor(() => json("/json/list"), "Chrome DevTools did not start.");
+  const initial = (await json("/json/list")).find((target) => target.type === "page" && target.url === "about:blank");
+  if (!initial) throw new Error("Chrome did not expose its initial browser page.");
+  legacyCdp = connectCdp(initial.webSocketDebuggerUrl);
+  await legacyCdp.ready;
+  await legacyCdp.send("Runtime.enable");
+  await legacyCdp.send("Page.navigate", { url: legacyUrl });
+  await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not load.");
+
+  await evaluate(legacyCdp, `new Promise((resolve, reject) => {
+    const request = indexedDB.open("slide-studio-db", 1);
+    request.onupgradeneeded = () => request.result.createObjectStore("projects", { keyPath: "id" });
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const transaction = request.result.transaction("projects", "readwrite");
+      transaction.objectStore("projects").put({
+        id: "migration-browser-project", name: "Migration browser project", createdAt: 1, updatedAt: 2, revision: 3,
+        assets: [{ id: "asset-1", name: "Pixel", imageData: "data:image/png;base64,iVBORw0KGgo=", width: 1, height: 1 }],
+        slides: [{ id: "slide-1", name: "Slide 1", width: 1080, height: 1920, imageData: null, texts: [], overlays: [] }]
+      });
+      transaction.oncomplete = () => resolve(true);
+      transaction.onerror = () => reject(transaction.error);
+    };
+  })`);
+  await legacyCdp.send("Page.reload");
+  await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-action=\"migrate-projects\"]')?.textContent.includes('project')"), "Migration prompt did not find the legacy project.");
+  await evaluate(legacyCdp, `(() => {
+    document.querySelector('[data-action="migrate-projects"]').scrollIntoView({ block: "center" });
+    return true;
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const buttonRect = await evaluate(legacyCdp, `(() => {
+    const button = document.querySelector('[data-action="migrate-projects"]');
+    const rect = button.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    return { x, y, targetIsButton: document.elementFromPoint(x, y) === button };
+  })()`);
+  if (!buttonRect.targetIsButton) throw new Error(`Migration button could not be brought into the browser viewport: ${JSON.stringify(buttonRect)}`);
+  await legacyCdp.send("Input.dispatchMouseEvent", { type: "mousePressed", x: buttonRect.x, y: buttonRect.y, button: "left", clickCount: 1 });
+  await legacyCdp.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: buttonRect.x, y: buttonRect.y, button: "left", clickCount: 1 });
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const clickState = await evaluate(legacyCdp, `({
+    button: document.querySelector('[data-action="migrate-projects"]')?.textContent,
+    status: document.querySelector('[data-migration-status]')?.textContent,
+    config: window.CAROUSELBOT_CONFIG,
+  })`);
+  const targetUrls = (await json("/json/list")).map(({ url }) => url);
+
+  const canonicalTarget = await waitFor(async () => (await json("/json/list")).find((page) => page.url.startsWith(canonicalOrigin)), `CarouselBot migration tab did not open. Click state: ${JSON.stringify(clickState)}. Targets: ${JSON.stringify(targetUrls)}`);
+  canonicalCdp = connectCdp(canonicalTarget.webSocketDebuggerUrl);
+  await canonicalCdp.ready;
+  await canonicalCdp.send("Runtime.enable");
+  const imported = await waitFor(() => evaluate(canonicalCdp, `new Promise((resolve) => {
+    const request = indexedDB.open("carouselbot-db");
+    request.onerror = () => resolve(null);
+    request.onsuccess = () => {
+      const item = request.result.transaction("projects", "readonly").objectStore("projects").get("migration-browser-project");
+      item.onerror = () => resolve(null);
+      item.onsuccess = () => resolve(item.result || null);
+    };
+  })`), "Canonical IndexedDB did not receive the project.");
+  if (imported.name !== "Migration browser project" || imported.assets?.[0]?.id !== "asset-1") throw new Error("Migrated project data did not match the legacy record.");
+  await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-migration-status]')?.textContent.includes('Copied 1 project')"), "Legacy origin did not receive completion acknowledgement.");
+  process.stdout.write(`${JSON.stringify({ copied: true, legacyOrigin, canonicalOrigin, projectId: imported.id, assets: imported.assets.length })}\n`);
+} finally {
+  legacyCdp?.close();
+  canonicalCdp?.close();
+  chrome.kill("SIGTERM");
+  legacyWeb.kill("SIGTERM");
+  canonicalWeb.kill("SIGTERM");
+  await rm(profile, { recursive: true, force: true });
+}

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -7,16 +7,16 @@ const root = new URL("..", import.meta.url);
 const rootPath = root.pathname;
 const pageUrl = process.argv.includes("--deployed")
   ? "https://slides-editor.pages.dev"
-  : process.env.SLIDE_STUDIO_TEST_URL || "http://127.0.0.1:4173";
+  : process.env.CAROUSELBOT_TEST_URL || process.env.SLIDE_STUDIO_TEST_URL || "http://127.0.0.1:4173";
 const chromePath = process.env.CHROME_PATH || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 const debuggingPort = 19229;
-const profile = await mkdtemp(join(tmpdir(), "slide-studio-browser-"));
-const stateDirectory = await mkdtemp(join(tmpdir(), "slide-studio-daemon-"));
+const profile = await mkdtemp(join(tmpdir(), "carouselbot-browser-"));
+const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-daemon-"));
 const exportPath = join(profile, "agent-export.png");
 const projectExportDirectory = join(profile, "project-export");
 const sharedDaemon = process.argv.includes("--shared-daemon");
 const bridgePort = sharedDaemon ? 43117 : 48000 + Math.floor(Math.random() * 1000);
-const env = sharedDaemon ? process.env : { ...process.env, SLIDE_STUDIO_STATE_DIR: stateDirectory, SLIDE_STUDIO_BRIDGE_PORT: String(bridgePort) };
+const env = sharedDaemon ? process.env : { ...process.env, CAROUSELBOT_STATE_DIR: stateDirectory, CAROUSELBOT_BRIDGE_PORT: String(bridgePort) };
 const browserPageUrl = sharedDaemon ? pageUrl : `${pageUrl}${pageUrl.includes("?") ? "&" : "?"}__mcpBridgePort=${bridgePort}`;
 const web = new URL(pageUrl).hostname === "127.0.0.1"
   ? spawn(process.execPath, ["server.mjs"], { cwd: root, stdio: ["ignore", "pipe", "pipe"] })
@@ -209,11 +209,11 @@ try {
   await cdp.send("Runtime.enable");
   if (localPermissions.length) await cdp.send("Browser.grantPermissions", { permissions: localPermissions, origin: new URL(pageUrl).origin });
   await cdp.send("Page.navigate", { url: browserPageUrl });
-  await waitFor(() => evaluate(cdp, "document.readyState === 'complete' && Boolean(window.slideStudioAgent)"), "Editor scripts did not load.");
+  await waitFor(() => evaluate(cdp, "document.readyState === 'complete' && Boolean(window.carouselBotAgent)"), "Editor scripts did not load.");
   const initialConnection = await evaluate(cdp, `({
     buttonStatus: document.querySelector('[data-action="connect-agent"]')?.dataset.mcpStatus || "idle",
-    remembered: localStorage.getItem("slide-studio:mcp-connected"),
-    editorId: window.slideStudioLocalMcpBridge.getState().editorId
+    remembered: localStorage.getItem("carouselbot:mcp-connected"),
+    editorId: window.carouselBotLocalMcpBridge.getState().editorId
   })`);
   const initialEditors = (await tool("list_editors")).structuredContent.editors;
   if (initialConnection.buttonStatus !== "idle" || initialConnection.remembered !== null || initialEditors.some((editor) => editor.id === initialConnection.editorId)) {
@@ -229,7 +229,7 @@ try {
   if (statusAlignment?.justifySelf !== "start" || statusAlignment.justifyContent !== "flex-start" || statusAlignment.textAlign !== "left") throw new Error(`MCP connection status is not left-aligned: ${JSON.stringify(statusAlignment)}`);
   await evaluate(cdp, `document.querySelector('[data-local-mcp-connect]').click()`);
   await waitFor(async () => (await tool("list_editors")).structuredContent.editors.some((editor) => editor.id === initialConnection.editorId), "Editor did not connect.");
-  const remembered = await evaluate(cdp, `localStorage.getItem("slide-studio:mcp-connected")`);
+  const remembered = await evaluate(cdp, `localStorage.getItem("carouselbot:mcp-connected")`);
   if (remembered !== "1") throw new Error("Successful MCP connection was not remembered.");
   await cdp.send("Page.reload", { ignoreCache: true });
   await waitFor(() => evaluate(cdp, `document.readyState === "complete" && document.querySelector('[data-action="connect-agent"]')?.dataset.mcpStatus === "connected"`), "Remembered MCP connection did not resume after reload.");
@@ -240,7 +240,7 @@ try {
   editSessionId = editSession.id;
   await tool("show_notification", { message: "Hello from the full local MCP", tone: "success" });
   const agentNotification = await evaluate(cdp, `(() => {
-    window.slideStudioLocalMcpBridge.notify("Identity icon regression", "success", { name: "Codex browser test" });
+    window.carouselBotLocalMcpBridge.notify("Identity icon regression", "success", { name: "Codex browser test" });
     const item = [...document.querySelectorAll("#agent-activity-stack .agent-activity")].find((entry) => entry.textContent.includes("Identity icon regression"));
     return item ? { label: item.querySelector("strong")?.textContent, icon: item.querySelector(".agent-activity-icon img")?.getAttribute("src") } : null;
   })()`);
@@ -249,7 +249,7 @@ try {
   await evaluate(cdp, "document.querySelector('[data-action=\"home\"]')?.click()");
   await waitFor(() => evaluate(cdp, "Boolean(document.querySelector('.dashboard'))"), "Dashboard did not open.");
   await evaluate(cdp, `(() => {
-    window.__slideStudioOriginalRequestAnimationFrame = window.requestAnimationFrame;
+    window.__carouselBotOriginalRequestAnimationFrame = window.requestAnimationFrame;
     window.requestAnimationFrame = () => 0;
     return true;
   })()`);
@@ -258,8 +258,8 @@ try {
     createdProject = (await tool("create_project", { name: "Full MCP browser test" })).structuredContent;
   } finally {
     await evaluate(cdp, `(() => {
-      window.requestAnimationFrame = window.__slideStudioOriginalRequestAnimationFrame;
-      delete window.__slideStudioOriginalRequestAnimationFrame;
+      window.requestAnimationFrame = window.__carouselBotOriginalRequestAnimationFrame;
+      delete window.__carouselBotOriginalRequestAnimationFrame;
       return true;
     })()`);
   }
@@ -282,7 +282,7 @@ try {
     projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, text: "Built live by an AI agent",
     x: 0.1, y: 0.2, width: 0.8, height: 0.16, size: 82, style: "boxed", background: "black", backgroundShape: "lines", color: "#FFFFFF",
   })).structuredContent;
-  const imported = (await tool("import_asset", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, path: join(rootPath, "assets", "favicon.svg"), name: "Slide Studio mark" })).structuredContent;
+  const imported = (await tool("import_asset", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, path: join(rootPath, "assets", "favicon.svg"), name: "CarouselBot mark" })).structuredContent;
   const image = (await tool("add_image", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, assetId: imported.assetId, x: 0.34, y: 0.52, width: 0.32, rotation: 6 })).structuredContent;
   const batch = await tool("apply_operations", { operations: [
     { tool: "add_text", arguments: { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, text: "Claude · Codex · Hermes · OpenCode · OpenClaw", x: 0.1, y: 0.76, width: 0.8, height: 0.1, size: 44, style: "plain", color: "#25F4EE" } },
@@ -318,7 +318,7 @@ try {
     try {
       await tool("update_text", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, updates: [{ id: addedText.createdTextId, align }] });
     } catch (error) {
-      const browserState = await evaluate(cdp, `({ bridge: window.slideStudioLocalMcpBridge?.getState(), ready: document.readyState, visible: document.visibilityState })`).catch(() => null);
+      const browserState = await evaluate(cdp, `({ bridge: window.carouselBotLocalMcpBridge?.getState(), ready: document.readyState, visible: document.visibilityState })`).catch(() => null);
       const audit = await tool("list_recent_operations", { limit: 10 }).then((result) => result.structuredContent).catch(() => null);
       throw new Error(`${error.message}\nBrowser state: ${JSON.stringify(browserState)}\nRecent operations: ${JSON.stringify(audit)}`);
     }
@@ -380,7 +380,7 @@ try {
   await tool("update_project", { projectId: createdProject.projectId, name: "Full MCP verified" });
   await tool("end_edit_session", { editSessionId });
   editSessionId = null;
-  const pinnedView = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.slideStudioAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
+  const pinnedView = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.carouselBotAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
   editSessionId = (await tool("begin_edit_session", { editorId: testEditor.id, purpose: "Verify background project edits preserve the current view" })).structuredContent.id;
   const temporaryProject = (await tool("create_project", { name: "Temporary project" })).structuredContent;
   const temporarySlide = (await tool("add_slide", { projectId: temporaryProject.projectId, name: "Background edit", backgroundColor: "#18181B" })).structuredContent;
@@ -397,10 +397,10 @@ try {
   if (perLineLayer?.role !== "subtitle" || perLineLayer.size !== 76 || perLineLayer.backgroundShape !== "lines") throw new Error(`Role defaults or per-line preference failed: ${JSON.stringify(perLineLayer)}`);
   if (!autoFitText.fittedTextBox?.automatic || !autoFitUpdate.fittedTextBoxes?.[0]?.automatic || autoFitLayer.height <= autoFitBefore.height || autoFitLayer.y + autoFitLayer.height > 1.0001) throw new Error(`Automatic MCP text-height fitting failed: ${JSON.stringify({ autoFitText, autoFitBefore, autoFitUpdate, autoFitLayer })}`);
   if (fullBoxLayer?.role !== "body" || fullBoxLayer.size !== 60 || fullBoxLayer.height >= 0.48 || fitted.fittedTextBoxes?.[0]?.id !== fullBoxText.createdTextId) throw new Error(`Full-box content fitting failed: ${JSON.stringify({ fullBoxLayer, fitted })}`);
-  const preservedView = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.slideStudioAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
+  const preservedView = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.carouselBotAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
   if (JSON.stringify(preservedView) !== JSON.stringify(pinnedView)) throw new Error(`Background project edits changed the user's view: ${JSON.stringify({ pinnedView, preservedView })}`);
   await tool("delete_project", { projectId: temporaryProject.projectId });
-  const viewAfterBackgroundDelete = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.slideStudioAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
+  const viewAfterBackgroundDelete = await evaluate(cdp, `({ pathname: location.pathname, title: document.querySelector('.project-title-input')?.value, slideId: window.carouselBotAgent.inspect({ includeAllProjects: false }).activeSlideId })`);
   if (JSON.stringify(viewAfterBackgroundDelete) !== JSON.stringify(pinnedView)) throw new Error(`Deleting a background project changed the user's view: ${JSON.stringify({ pinnedView, viewAfterBackgroundDelete })}`);
   await tool("end_edit_session", { editSessionId });
   editSessionId = null;
@@ -428,7 +428,7 @@ try {
   if (stressEditors.length < 7) throw new Error(`Seven-tab transport stress setup connected only ${stressEditors.length} editors.`);
   const previousCoverUrl = await waitFor(() => evaluate(secondCdp, `document.querySelector('[data-project-cover-id="${createdProject.projectId}"] img[data-composite-cover="true"]')?.src || ""`), "The dashboard did not render its initial composed project cover.");
   await evaluate(secondCdp, `(() => {
-    window.__slideStudioOriginalRequestAnimationFrame = window.requestAnimationFrame;
+    window.__carouselBotOriginalRequestAnimationFrame = window.requestAnimationFrame;
     window.requestAnimationFrame = () => 0;
     return true;
   })()`);
@@ -448,8 +448,8 @@ try {
     })()`), "The dashboard did not refresh its composed cover while animation frames were paused.");
   } finally {
     await evaluate(secondCdp, `(() => {
-      window.requestAnimationFrame = window.__slideStudioOriginalRequestAnimationFrame;
-      delete window.__slideStudioOriginalRequestAnimationFrame;
+      window.requestAnimationFrame = window.__carouselBotOriginalRequestAnimationFrame;
+      delete window.__carouselBotOriginalRequestAnimationFrame;
       return true;
     })()`);
   }

--- a/server.mjs
+++ b/server.mjs
@@ -5,12 +5,14 @@ import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const host = "127.0.0.1";
-const port = Number(process.env.SLIDE_STUDIO_PORT) || 4173;
+const port = Number(process.env.CAROUSELBOT_PORT || process.env.SLIDE_STUDIO_PORT) || 4173;
 
 const files = new Map([
   ["/", ["index.html", "text/html; charset=utf-8"]],
   ["/index.html", ["index.html", "text/html; charset=utf-8"]],
   ["/styles.css", ["styles.css", "text/css; charset=utf-8"]],
+  ["/app-config.js", ["app-config.js", "text/javascript; charset=utf-8"]],
+  ["/domain-migration.js", ["domain-migration.js", "text/javascript; charset=utf-8"]],
   ["/app.js", ["app.js", "text/javascript; charset=utf-8"]],
   ["/agent-commands.js", ["agent-commands.js", "text/javascript; charset=utf-8"]],
   ["/local-mcp-bridge.js", ["local-mcp-bridge.js", "text/javascript; charset=utf-8"]],
@@ -52,5 +54,5 @@ const server = createServer(async (request, response) => {
 });
 
 server.listen(port, host, () => {
-  console.log(`Slide Studio is running at http://${host}:${port}`);
+  console.log(`CarouselBot is running at http://${host}:${port}`);
 });

--- a/styles.css
+++ b/styles.css
@@ -718,6 +718,54 @@ button:disabled {
   padding: 82px 0 100px;
 }
 
+.migration-notice {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  width: min(1160px, calc(100% - 48px));
+  padding: 24px 26px;
+  margin: 28px auto -34px;
+  gap: 28px;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel);
+  box-shadow: 8px 8px 0 color-mix(in srgb, var(--cyan) 45%, transparent), -3px -3px 0 color-mix(in srgb, var(--red) 40%, transparent);
+}
+
+.migration-notice .eyebrow {
+  margin-bottom: 8px;
+}
+
+.migration-notice h2 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 36px);
+  font-weight: 900;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.migration-notice [data-migration-status] {
+  max-width: 68ch;
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.migration-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.migration-actions .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
 .not-found {
   min-height: calc(100vh - 72px);
   display: grid;
@@ -3170,6 +3218,18 @@ input[type="range"]::-webkit-slider-thumb {
     width: min(100% - 28px, 1160px);
     padding-top: 54px;
   }
+
+  .migration-notice {
+    grid-template-columns: 1fr;
+    width: min(100% - 28px, 1160px);
+    margin-top: 18px;
+    margin-bottom: -24px;
+    gap: 18px;
+  }
+
+  .migration-actions {
+    flex-wrap: wrap;
+  }
 }
 
 @media (max-width: 640px) {
@@ -3218,6 +3278,14 @@ input[type="range"]::-webkit-slider-thumb {
 }
 
 @media (max-width: 560px) {
+  .migration-actions {
+    display: grid;
+  }
+
+  .migration-actions .button {
+    width: 100%;
+  }
+
   .header-actions [data-action="export"] {
     width: 42px;
     padding: 0;

--- a/test/domain-migration.test.cjs
+++ b/test/domain-migration.test.cjs
@@ -1,0 +1,89 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createController, normalizeConfig, validProject, migrationResult } = require("../domain-migration.js");
+
+const config = {
+  canonicalOrigin: "https://carousel.bot/path",
+  legacyOrigins: ["https://slides-editor.pages.dev/", "not a URL"],
+  migration: { projectTimeoutMs: 12_000 },
+};
+
+test("normalizes migration origins and rollout settings", () => {
+  const normalized = normalizeConfig(config);
+  assert.equal(normalized.canonicalOrigin, "https://carousel.bot");
+  assert.deepEqual(normalized.legacyOrigins, ["https://slides-editor.pages.dev"]);
+  assert.equal(normalized.projectTimeoutMs, 12_000);
+  assert.equal(normalized.autoForwardEmptyLegacyStorage, false);
+});
+
+test("accepts project records and rejects malformed payloads", () => {
+  assert.equal(validProject({ id: "project-1", name: "Launch", slides: [], assets: [] }), true);
+  assert.equal(validProject({ id: "project-1", name: "Launch", slides: "nope" }), false);
+  assert.equal(validProject({ id: "", name: "Launch", slides: [], assets: [] }), false);
+});
+
+test("never overwrites a newer project on the canonical origin", () => {
+  const incoming = { id: "project-1", name: "Launch", slides: [], assets: [], updatedAt: 20, revision: 3 };
+  assert.equal(migrationResult(null, incoming), "imported");
+  assert.equal(migrationResult({ ...incoming, updatedAt: 10 }, incoming), "updated");
+  assert.equal(migrationResult({ ...incoming, updatedAt: 30 }, incoming), "skipped");
+  assert.equal(migrationResult({ ...incoming, revision: 4 }, incoming), "skipped");
+  assert.equal(migrationResult({ ...incoming, revision: 2 }, incoming), "updated");
+});
+
+function linkedWindows() {
+  const listeners = (origin) => new Map([["message", []], ["carouselbot:migration-complete", []]]);
+  const storage = () => {
+    const values = new Map();
+    return { getItem: (key) => values.get(key) || null, setItem: (key, value) => values.set(key, value) };
+  };
+  const makeWindow = (origin) => ({
+    location: { origin, href: `${origin}/`, replace() {} },
+    localStorage: storage(),
+    crypto: { randomUUID: () => "migration-token" },
+    history: { replaceState() {} },
+    CustomEvent: class CustomEvent { constructor(type, init) { this.type = type; this.detail = init?.detail; } },
+    closed: false,
+    setTimeout,
+    clearTimeout,
+    focus() {},
+    _listeners: listeners(origin),
+    addEventListener(type, callback) { if (!this._listeners.has(type)) this._listeners.set(type, []); this._listeners.get(type).push(callback); },
+    dispatchEvent(event) { for (const callback of this._listeners.get(event.type) || []) callback(event); },
+  });
+  const legacy = makeWindow("https://slides-editor.pages.dev");
+  const canonical = makeWindow("https://carousel.bot");
+  legacy.open = (url) => { canonical.location.href = url; canonical.opener = legacy; return canonical; };
+  canonical.postMessage = (data, targetOrigin) => {
+    assert.equal(targetOrigin, canonical.location.origin);
+    queueMicrotask(() => canonical.dispatchEvent({ type: "message", data, origin: legacy.location.origin, source: legacy }));
+  };
+  legacy.postMessage = (data, targetOrigin) => {
+    assert.equal(targetOrigin, legacy.location.origin);
+    queueMicrotask(() => legacy.dispatchEvent({ type: "message", data, origin: canonical.location.origin, source: canonical }));
+  };
+  return { legacy, canonical };
+}
+
+test("copies and acknowledges projects one at a time across configured origins", async () => {
+  const { legacy, canonical } = linkedWindows();
+  const rawConfig = { ...config, canonicalOrigin: "https://carousel.bot", migration: { projectTimeoutMs: 1_000 } };
+  const legacyController = createController(legacy, rawConfig);
+  const projects = [
+    { id: "project-1", name: "One", slides: [], assets: [], updatedAt: 1 },
+    { id: "project-2", name: "Two", slides: [], assets: [], updatedAt: 2 },
+  ];
+  const progress = [];
+  const transfer = legacyController.start(projects, { onProgress: (value) => progress.push(value.completed) });
+  const canonicalController = createController(canonical, rawConfig);
+  const received = [];
+  canonicalController.registerImporter(async (project) => { received.push(project.id); return "imported"; });
+  const summary = await transfer;
+  assert.deepEqual(received, ["project-1", "project-2"]);
+  assert.deepEqual(progress, [1, 2]);
+  assert.equal(summary.projectCount, 2);
+  assert.equal(legacyController.completedMigration().destination, "https://carousel.bot");
+  assert.equal(legacyController.hasPendingProjects(projects), false);
+  assert.equal(legacyController.hasPendingProjects([{ ...projects[0], updatedAt: 3 }, projects[1]]), true);
+  assert.equal(legacyController.hasPendingProjects([...projects, { id: "project-3", name: "Three", slides: [], assets: [] }]), true);
+});

--- a/test/package-compatibility.test.cjs
+++ b/test/package-compatibility.test.cjs
@@ -1,0 +1,17 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFile } = require("node:fs/promises");
+const { join } = require("node:path");
+
+const root = join(__dirname, "..");
+
+test("legacy and canonical MCP packages publish matching versions", async () => {
+  const primary = JSON.parse(await readFile(join(root, "packages/mcp/package.json"), "utf8"));
+  const legacy = JSON.parse(await readFile(join(root, "packages/slides-studio-mcp/package.json"), "utf8"));
+  assert.equal(primary.name, "carouselbot");
+  assert.equal(legacy.name, "slides-studio-mcp");
+  assert.equal(legacy.version, primary.version);
+  assert.equal(legacy.dependencies[primary.name], primary.version);
+  assert.equal(primary.bin.carouselbot, "src/cli.mjs");
+  assert.equal(legacy.bin[legacy.name], "bin/cli.mjs");
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
+  // Keep this Pages project name until the legacy-origin IndexedDB migration is retired.
   "name": "slides-editor",
   "compatibility_date": "2026-08-18",
   "pages_build_output_dir": "./dist"


### PR DESCRIPTION
## Summary
- rebrand the product, repository references, and local MCP companion as CarouselBot
- add a safe copy-only project migration from the legacy Pages origin to carousel.bot
- publish-ready carouselbot package plus slides-studio-mcp compatibility shim
- add the staged Cloudflare, npm, and GitHub rollout runbook

## Verification
- npm test
- npm run test:migration:browser
- npm run test:mcp:browser:local
- npm run build
- npm pack dry runs for both packages