### PR TITLE
Harden repository supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @alexgusevski

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Stockholm
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/Stockholm
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Verification
+
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] No secrets, credentials, generated archives, or local state are included
+- [ ] New dependencies and GitHub Actions are necessary and pinned appropriately

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test and build (Node 24)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build the production bundle
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "19 4 * * 1"
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish npm packages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish with provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm-release
+
+    steps:
+      - name: Check out the released tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Verify release tag and package versions
+        run: node scripts/verify-release.mjs "${{ github.event.release.tag_name }}"
+
+      - name: Test release source
+        run: npm test
+
+      - name: Publish stable packages
+        if: ${{ !github.event.release.prerelease }}
+        run: |
+          npm publish --workspace carouselbot --access public --provenance --tag latest
+          npm publish --workspace slides-studio-mcp --access public --provenance --tag latest
+
+      - name: Publish prerelease packages
+        if: ${{ github.event.release.prerelease }}
+        run: |
+          npm publish --workspace carouselbot --access public --provenance --tag beta
+          npm publish --workspace slides-studio-mcp --access public --provenance --tag beta

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "37 5 * * 2"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Supply-chain analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard results to code scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: results.sarif
+
+      - name: Preserve Scorecard results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version of CarouselBot and its
+MCP packages.
+
+| Version | Supported |
+| --- | --- |
+| 0.2.x | Yes |
+| Earlier versions | No |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a suspected vulnerability. Use GitHub's
+[private vulnerability reporting](https://github.com/alexgusevski/carouselbot/security/advisories/new)
+so reports, reproduction steps, and proposed fixes remain confidential until a
+coordinated release is ready.
+
+Include the affected component and version, the expected impact, reproduction
+steps or a proof of concept, and any suggested mitigation. You should receive an
+initial acknowledgement within seven days and a status update at least every
+fourteen days while the report is active.
+
+Good-faith research that avoids privacy violations, data destruction, service
+degradation, and access beyond what is necessary to demonstrate the issue is
+welcome. We will not pursue action against researchers who follow this policy.

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const tag = process.argv[2];
+if (!tag) throw new Error("Usage: node scripts/verify-release.mjs <vVERSION>");
+
+const paths = [
+  join(root, "packages", "mcp", "package.json"),
+  join(root, "packages", "slides-studio-mcp", "package.json"),
+];
+const packages = await Promise.all(paths.map(async (path) => JSON.parse(await readFile(path, "utf8"))));
+const versions = new Set(packages.map((manifest) => manifest.version));
+
+if (versions.size !== 1) {
+  throw new Error(`Package versions must match: ${packages.map(({ name, version }) => `${name}@${version}`).join(", ")}`);
+}
+
+const [version] = versions;
+if (tag !== `v${version}`) throw new Error(`Release tag ${tag} does not match package version v${version}.`);
+
+process.stdout.write(`Verified ${tag}: ${packages.map(({ name, version: packageVersion }) => `${name}@${packageVersion}`).join(", ")}\n`);


### PR DESCRIPTION
## Summary

- add least-privilege CI, CodeQL, dependency-review, and OpenSSF Scorecard workflows
- pin every GitHub Action to an immutable commit SHA
- configure weekly Dependabot updates for npm and Actions
- add security reporting policy, CODEOWNERS, and a PR security checklist
- add an OIDC-ready npm publishing workflow with provenance and release-version verification

## Verification

- npm test (13 tests passed)
- npm run build
- YAML syntax validation for all workflow/config files
- npm pack dry-runs for both public packages
- release tag verification for v0.2.0

After this PR is green and merged, repository rules will require CI, CodeQL, and dependency review on future changes to main.