### PR TITLE
Harden npm release authorization

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,25 +6,72 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: npm-publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish with provenance
+  verify:
+    name: Verify protected release source
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: npm-release
+    timeout-minutes: 15
+    outputs:
+      release-sha: ${{ steps.release.outputs.sha }}
+      npm-tag: ${{ steps.release.outputs.npm-tag }}
 
     steps:
+      - name: Validate release metadata before checkout
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$RELEASE_TAG" =~ $tag_pattern ]]; then
+            echo "Release tag must be an exact v-prefixed semantic version." >&2
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" == *-* && "$RELEASE_PRERELEASE" != "true" ]]; then
+            echo "A prerelease version must be marked as a GitHub prerelease." >&2
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" != *-* && "$RELEASE_PRERELEASE" == "true" ]]; then
+            echo "A stable version cannot be marked as a GitHub prerelease." >&2
+            exit 1
+          fi
+
       - name: Check out the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify tag commit belongs to protected main
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Checked-out commit does not match the release tag." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$head_commit" origin/main; then
+            echo "Release commit must belong to protected main." >&2
+            exit 1
+          fi
+          echo "sha=$head_commit" >> "$GITHUB_OUTPUT"
+          if [[ "$RELEASE_PRERELEASE" == "true" ]]; then
+            echo "npm-tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Node.js and npm registry
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -37,19 +84,70 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Verify release tag and package versions
-        run: node scripts/verify-release.mjs "${{ github.event.release.tag_name }}"
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: node scripts/verify-release.mjs "$RELEASE_TAG" "$RELEASE_PRERELEASE"
 
       - name: Test release source
         run: npm test
 
-      - name: Publish stable packages
-        if: ${{ !github.event.release.prerelease }}
-        run: |
-          npm publish --workspace carouselbot --access public --provenance --tag latest
-          npm publish --workspace slides-studio-mcp --access public --provenance --tag latest
+  publish-carouselbot:
+    name: Publish carouselbot with provenance
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
 
-      - name: Publish prerelease packages
-        if: ${{ github.event.release.prerelease }}
-        run: |
-          npm publish --workspace carouselbot --access public --provenance --tag beta
-          npm publish --workspace slides-studio-mcp --access public --provenance --tag beta
+    steps:
+      - name: Check out verified release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify.outputs.release-sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Publish canonical package
+        env:
+          NPM_TAG: ${{ needs.verify.outputs.npm-tag }}
+        run: npm publish --workspace carouselbot --access public --provenance --tag "$NPM_TAG"
+
+  publish-compatibility:
+    name: Publish slides-studio-mcp compatibility package
+    needs:
+      - verify
+      - publish-carouselbot
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out verified release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify.outputs.release-sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Publish compatibility package
+        env:
+          NPM_TAG: ${{ needs.verify.outputs.npm-tag }}
+        run: npm publish --workspace slides-studio-mcp --access public --provenance --tag "$NPM_TAG"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Migration rollout flags live in `app-config.js`. They default to a non-forwardin
 
 ## Security
 
-Report suspected vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Pull requests are checked by CI, CodeQL, dependency review, and OpenSSF Scorecard. Dependency and GitHub Action updates are proposed automatically by Dependabot, and release packages are published from tagged GitHub releases through the provenance-enabled workflow in `.github/workflows/publish.yml`.
+Report suspected vulnerabilities privately through the process in [SECURITY.md](SECURITY.md). Pull requests run CI, CodeQL, and dependency review; OpenSSF Scorecard monitors the repository separately. Dependabot proposes dependency and GitHub Action updates.
+
+npm releases use GitHub Actions trusted publishing instead of a stored npm token. The release workflow accepts only version tags whose commits belong to protected `main`, tests that source, and requests npm provenance. Running `carouselbot setup` pins the selected package version in the generated MCP configuration; updating is an explicit rerun of the setup command. The active controls and local trust boundaries are documented in [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,44 @@
 
 ## Supported versions
 
-Security fixes are applied to the latest released version of CarouselBot and its
-MCP packages.
+The hosted editor is updated in place. Security fixes for the npm packages are
+applied to the latest release line.
 
-| Version | Supported |
+| Component | Supported |
 | --- | --- |
-| 0.2.x | Yes |
-| Earlier versions | No |
+| Hosted editor at `carousel.bot` | Current deployment |
+| `carouselbot` and `slides-studio-mcp` 0.2.x | Yes |
+| Earlier npm versions | No |
+
+## Active security controls
+
+- **Repository:** protected `main`, pull-request checks, linear history, immutable
+  GitHub Action SHAs, least-privilege workflow permissions, Dependabot, CodeQL,
+  dependency review, secret scanning, and push protection.
+- **npm releases:** exact `v<semver>` tags, release commits verified against
+  protected `main`, matching package versions, tests before publishing, and an
+  `npm-release` environment restricted to release tags.
+- **Package identity:** npm trusted publishing uses a short-lived GitHub OIDC
+  credential instead of a stored npm token. Publishing requests npm provenance.
+  The canonical and compatibility packages publish in separate jobs so a failed
+  compatibility publish can be retried without republishing the canonical package.
+- **Installed MCP version:** setup writes an exact package version into the local
+  MCP configuration. Users update deliberately by rerunning `npx carouselbot@latest setup`.
+- **Application:** the public site is static and has no application backend. User
+  projects stay in browser storage. The optional MCP companion binds to loopback,
+  checks the browser origin, and uses random local bearer tokens.
+
+The release workflow has no npm-token fallback: if the npm Trusted Publisher
+configuration does not match this repository, `.github/workflows/publish.yml`,
+and the `npm-release` environment, publishing fails closed. Provenance is visible
+on npm for releases produced by that workflow; older releases may predate it.
+
+## Trust boundaries
+
+The MCP companion is designed for a trusted local user account. Processes and MCP
+clients running as the same operating-system user are mutually trusted; it is not
+a sandbox against hostile software already running on that account. The companion
+does not expose a public network service or upload projects to CarouselBot.
 
 ## Reporting a vulnerability
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -6,6 +6,9 @@ Local-first MCP companion for the hosted [CarouselBot editor](https://carousel.b
 npx carouselbot@latest setup
 ```
 
+Setup pins that exact package version in the generated MCP configuration. Rerun
+the command when you intentionally want to update.
+
 For non-interactive agent setup, select the current client explicitly:
 
 ```bash

--- a/packages/mcp/src/setup.mjs
+++ b/packages/mcp/src/setup.mjs
@@ -62,8 +62,7 @@ export async function runSetup(arguments_) {
   const clientArgument = arguments_.find((value) => value.startsWith("--client="))?.slice("--client=".length);
   const requested = clientArgument ? clientArgument.split(",").map((value) => value.trim().toLowerCase()) : supported.filter(commandExists);
   const clients = [...new Set(requested)].filter((client) => supported.includes(client));
-  const releaseTag = PACKAGE_VERSION.includes("-beta.") ? "beta" : "latest";
-  const specifier = `${PACKAGE_NAME}@${releaseTag}`;
+  const specifier = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
   const dryRun = flags.has("--dry-run");
   const assumeYes = flags.has("--yes") || flags.has("-y");
   if (!clients.length) throw new Error("No supported agent CLI was detected. Use --client=claude,codex,hermes,opencode,openclaw or copy the generic stdio config below.");

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -1,0 +1,22 @@
+const RELEASE_TAG_PATTERN = /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+
+export function validateReleaseMetadata(tag, prerelease) {
+  if (!RELEASE_TAG_PATTERN.test(tag || "")) {
+    throw new Error("Release tag must be an exact v-prefixed semantic version.");
+  }
+  if (typeof prerelease !== "boolean") {
+    throw new Error("Release prerelease state must be true or false.");
+  }
+
+  const version = tag.slice(1);
+  const versionIsPrerelease = version.includes("-");
+  if (versionIsPrerelease !== prerelease) {
+    throw new Error(
+      versionIsPrerelease
+        ? "A prerelease version must be marked as a GitHub prerelease."
+        : "A stable version cannot be marked as a GitHub prerelease.",
+    );
+  }
+
+  return { version, npmTag: prerelease ? "beta" : "latest" };
+}

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,10 +1,15 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { validateReleaseMetadata } from "./release-policy.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const tag = process.argv[2];
-if (!tag) throw new Error("Usage: node scripts/verify-release.mjs <vVERSION>");
+const prereleaseArgument = process.argv[3];
+if (!tag || !["true", "false"].includes(prereleaseArgument)) {
+  throw new Error("Usage: node scripts/verify-release.mjs <vVERSION> <true|false>");
+}
+const { version, npmTag } = validateReleaseMetadata(tag, prereleaseArgument === "true");
 
 const paths = [
   join(root, "packages", "mcp", "package.json"),
@@ -17,7 +22,9 @@ if (versions.size !== 1) {
   throw new Error(`Package versions must match: ${packages.map(({ name, version }) => `${name}@${version}`).join(", ")}`);
 }
 
-const [version] = versions;
-if (tag !== `v${version}`) throw new Error(`Release tag ${tag} does not match package version v${version}.`);
+const [packageVersion] = versions;
+if (version !== packageVersion) throw new Error(`Release tag ${tag} does not match package version v${packageVersion}.`);
 
-process.stdout.write(`Verified ${tag}: ${packages.map(({ name, version: packageVersion }) => `${name}@${packageVersion}`).join(", ")}\n`);
+process.stdout.write(
+  `Verified ${tag} for npm tag ${npmTag}: ${packages.map(({ name, version: manifestVersion }) => `${name}@${manifestVersion}`).join(", ")}\n`,
+);

--- a/test/release-policy.test.cjs
+++ b/test/release-policy.test.cjs
@@ -1,0 +1,52 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFile } = require("node:fs/promises");
+const { join } = require("node:path");
+
+const root = join(__dirname, "..");
+
+test("release metadata accepts stable and prerelease semantic versions", async () => {
+  const { validateReleaseMetadata } = await import(join(root, "scripts/release-policy.mjs"));
+
+  assert.deepEqual(validateReleaseMetadata("v1.2.3", false), { version: "1.2.3", npmTag: "latest" });
+  assert.deepEqual(validateReleaseMetadata("v1.2.3-beta.1", true), { version: "1.2.3-beta.1", npmTag: "beta" });
+});
+
+test("release metadata rejects unsafe tags and mismatched release types", async () => {
+  const { validateReleaseMetadata } = await import(join(root, "scripts/release-policy.mjs"));
+
+  for (const tag of ["main", "v1.2", "v$(id)", "v1.2.3;echo", "v01.2.3"]) {
+    assert.throws(() => validateReleaseMetadata(tag, false));
+  }
+  assert.throws(() => validateReleaseMetadata("v1.2.3-beta.1", false));
+  assert.throws(() => validateReleaseMetadata("v1.2.3", true));
+});
+
+test("publish workflow validates source before executing repository code", async () => {
+  const workflow = await readFile(join(root, ".github/workflows/publish.yml"), "utf8");
+  const validation = workflow.indexOf("Validate release metadata before checkout");
+  const checkout = workflow.indexOf("Check out the released tag");
+  const ancestry = workflow.indexOf("git merge-base --is-ancestor");
+  const install = workflow.indexOf("npm ci --ignore-scripts");
+
+  assert.ok(validation >= 0 && validation < checkout);
+  assert.ok(checkout < ancestry && ancestry < install);
+  assert.match(workflow, /ref: \$\{\{ needs\.verify\.outputs\.release-sha \}\}/);
+  assert.match(workflow, /publish-compatibility:[\s\S]*- publish-carouselbot/);
+
+  const lines = workflow.split("\n");
+  let runBlockIndent = null;
+  for (const line of lines) {
+    const indent = line.length - line.trimStart().length;
+    if (runBlockIndent !== null && line.trim() && indent <= runBlockIndent) runBlockIndent = null;
+    if (/^\s*run:\s*\|\s*$/.test(line)) runBlockIndent = indent;
+    if (runBlockIndent !== null) assert.doesNotMatch(line, /\$\{\{\s*github\.event\./);
+    if (/^\s*run:\s*[^|]/.test(line)) assert.doesNotMatch(line, /\$\{\{\s*github\.event\./);
+  }
+});
+
+test("MCP setup pins the installed package version", async () => {
+  const setup = await readFile(join(root, "packages/mcp/src/setup.mjs"), "utf8");
+  assert.match(setup, /const specifier = `\$\{PACKAGE_NAME\}@\$\{PACKAGE_VERSION\}`/);
+  assert.doesNotMatch(setup, /PACKAGE_NAME\}@\$\{releaseTag/);
+});


### PR DESCRIPTION
## Summary

- validate exact semantic release tags before checkout and require the tag commit to belong to protected `main`
- scope OIDC permissions to two ordered, independently retryable npm publish jobs
- pin generated MCP configurations to the installed package version
- document the active repository, npm, application, and local trust controls without adding new policy files
- add focused regression tests for hostile tags, release ordering, and version pinning

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `node scripts/verify-release.mjs v0.2.0 false`
- [x] Actionlint passes for `.github/workflows/publish.yml`
- [x] `npm pack --dry-run` passes for both packages
- [x] GitHub `npm-release` environment restricted to `v*` tags

No package or GitHub Release was published.