### PR TITLE
Match TikTok multiline text backgrounds

### DIFF
--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -24,17 +24,15 @@ export const LEGACY_CLIPBOARD_STORAGE_KEY = "slide-studio-layer-clipboard";
 
 export const HISTORY_LIMIT = 200;
 
-export const BOX_TEXT_LINE_HEIGHT = 1.12;
+export const BOX_TEXT_LINE_HEIGHT = 1.17;
 
-export const BOX_LINE_HEIGHT = 1.42;
+export const BOX_LINE_HEIGHT = 1.46;
 
-export const BOX_HORIZONTAL_PADDING = 0.52;
+export const BOX_HORIZONTAL_PADDING = 0.46;
 
 export const TEXT_BOX_EDGE_PADDING = 0.3;
 
-export const BOX_CORNER_RADIUS = 0.27;
-
-export const BOX_JUNCTION_RADIUS = 0.18;
+export const BOX_CORNER_RADIUS = 0.18;
 
 export const FONT_SIZE_MIN = 20;
 
@@ -265,66 +263,95 @@ export function getImageLayout(slide, canvasWidth, canvasHeight) {
   };
 }
 
-export function lineCornerRadii(widths, index, radius) {
-  const width = widths[index] || 0;
-  const above = widths[index - 1];
-  const below = widths[index + 1];
-  const slop = Math.max(2, radius * 0.2);
-  const top = above == null || width > above + slop;
-  const bottom = below == null || width > below + slop;
-  return [top ? radius : 0, top ? radius : 0, bottom ? radius : 0, bottom ? radius : 0];
-}
+export function normalizePerLineBackgroundWidths(widths, align, radius) {
+  const normalized = [...widths];
+  const boundaryScale = align === "center" ? 0.5 : 1;
+  let changed = true;
 
-export function lineJunctionCorners(widths, lineCenters, centerX, boxHeight, radius) {
-  const corners = [];
-  for (let index = 0; index < widths.length - 1; index += 1) {
-    const upperWidth = widths[index] || 0;
-    const lowerWidth = widths[index + 1] || 0;
-    const sideGap = Math.abs(upperWidth - lowerWidth) / 2;
-    if (sideGap <= Math.max(1, radius * 0.1)) continue;
-    const cornerRadius = Math.min(radius, sideGap);
-
-    if (upperWidth < lowerWidth) {
-      const boundaryY = lineCenters[index + 1] - boxHeight / 2;
-      corners.push(
-        { cx: centerX - upperWidth / 2, cy: boundaryY, radius: cornerRadius, quadrant: "upper-left" },
-        { cx: centerX + upperWidth / 2, cy: boundaryY, radius: cornerRadius, quadrant: "upper-right" },
-      );
-    } else {
-      const boundaryY = lineCenters[index] + boxHeight / 2;
-      corners.push(
-        { cx: centerX - lowerWidth / 2, cy: boundaryY, radius: cornerRadius, quadrant: "lower-left" },
-        { cx: centerX + lowerWidth / 2, cy: boundaryY, radius: cornerRadius, quadrant: "lower-right" },
-      );
+  // TikTok merges near-equal neighboring rows when the step cannot hold two
+  // full-radius corners. This preserves one radius instead of pinching it.
+  while (changed) {
+    changed = false;
+    for (let index = 0; index < normalized.length - 1; index += 1) {
+      const boundaryGap = Math.abs(normalized[index] - normalized[index + 1]) * boundaryScale;
+      if (boundaryGap <= 0.01 || boundaryGap > radius * 2 + 0.01) continue;
+      const mergedWidth = Math.max(normalized[index], normalized[index + 1]);
+      if (normalized[index] !== mergedWidth || normalized[index + 1] !== mergedWidth) changed = true;
+      normalized[index] = mergedWidth;
+      normalized[index + 1] = mergedWidth;
     }
   }
-  return corners;
+  return normalized;
 }
 
-export function roundedRectSvgPath(x, y, width, height, radii) {
-  const [tl, tr, br, bl] = radii.map((value) => Math.max(0, Math.min(value, width / 2, height / 2)));
-  return [
-    `M ${x + tl} ${y}`,
-    `H ${x + width - tr}`,
-    `Q ${x + width} ${y} ${x + width} ${y + tr}`,
-    `V ${y + height - br}`,
-    `Q ${x + width} ${y + height} ${x + width - br} ${y + height}`,
-    `H ${x + bl}`,
-    `Q ${x} ${y + height} ${x} ${y + height - bl}`,
-    `V ${y + tl}`,
-    `Q ${x} ${y} ${x + tl} ${y}`,
+function appendRightLineBackgroundTransition(path, current, next, middleY, radius) {
+  const difference = next - current;
+  if (Math.abs(difference) <= 0.01) return;
+  const horizontalDirection = Math.sign(difference);
+  path.push(
+    `V ${middleY - radius}`,
+    `A ${radius} ${radius} 0 0 ${horizontalDirection < 0 ? 1 : 0} ${current + horizontalDirection * radius} ${middleY}`,
+    `H ${next - horizontalDirection * radius}`,
+    `A ${radius} ${radius} 0 0 ${horizontalDirection > 0 ? 1 : 0} ${next} ${middleY + radius}`,
+  );
+}
+
+function appendLeftLineBackgroundTransition(path, current, next, middleY, radius) {
+  const difference = next - current;
+  if (Math.abs(difference) <= 0.01) return;
+  const horizontalDirection = Math.sign(difference);
+  path.push(
+    `V ${middleY + radius}`,
+    `A ${radius} ${radius} 0 0 ${horizontalDirection > 0 ? 1 : 0} ${current + horizontalDirection * radius} ${middleY}`,
+    `H ${next - horizontalDirection * radius}`,
+    `A ${radius} ${radius} 0 0 ${horizontalDirection < 0 ? 1 : 0} ${next} ${middleY - radius}`,
+  );
+}
+
+export function perLineBackgroundSvgPath(widths, lineHeight, boxHeight, contentLeft, contentWidth, align, radius, top = 0) {
+  if (!widths.length) return "";
+  const normalizedWidths = normalizePerLineBackgroundWidths(widths, align, radius);
+  const bounds = normalizedWidths.map((width) => {
+    const left = align === "left"
+      ? contentLeft
+      : align === "right"
+        ? contentLeft + contentWidth - width
+        : contentLeft + (contentWidth - width) / 2;
+    return { left, right: left + width };
+  });
+  const first = bounds[0];
+  const last = bounds.at(-1);
+  const bottom = top + (widths.length - 1) * lineHeight + boxHeight;
+  const cornerRadius = Math.min(radius, lineHeight / 2, boxHeight / 2, normalizedWidths[0] / 2, normalizedWidths.at(-1) / 2);
+  const path = [
+    `M ${first.left + cornerRadius} ${top}`,
+    `H ${first.right - cornerRadius}`,
+    `A ${cornerRadius} ${cornerRadius} 0 0 1 ${first.right} ${top + cornerRadius}`,
+  ];
+
+  for (let index = 0; index < bounds.length - 1; index += 1) {
+    const middleY = top + index * lineHeight + (boxHeight + lineHeight) / 2;
+    appendRightLineBackgroundTransition(path, bounds[index].right, bounds[index + 1].right, middleY, cornerRadius);
+  }
+
+  path.push(
+    `V ${bottom - cornerRadius}`,
+    `A ${cornerRadius} ${cornerRadius} 0 0 1 ${last.right - cornerRadius} ${bottom}`,
+    `H ${last.left + cornerRadius}`,
+    `A ${cornerRadius} ${cornerRadius} 0 0 1 ${last.left} ${bottom - cornerRadius}`,
+  );
+
+  for (let index = bounds.length - 2; index >= 0; index -= 1) {
+    const middleY = top + index * lineHeight + (boxHeight + lineHeight) / 2;
+    appendLeftLineBackgroundTransition(path, bounds[index + 1].left, bounds[index].left, middleY, cornerRadius);
+  }
+
+  path.push(
+    `V ${top + cornerRadius}`,
+    `A ${cornerRadius} ${cornerRadius} 0 0 1 ${first.left + cornerRadius} ${top}`,
     "Z",
-  ].join(" ");
-}
-
-export function concaveCornerSvgPath({ cx, cy, radius, quadrant }) {
-  const paths = {
-    "upper-left": `M ${cx} ${cy - radius} L ${cx} ${cy} L ${cx - radius} ${cy} A ${radius} ${radius} 0 0 0 ${cx} ${cy - radius} Z`,
-    "upper-right": `M ${cx} ${cy - radius} L ${cx} ${cy} L ${cx + radius} ${cy} A ${radius} ${radius} 0 0 1 ${cx} ${cy - radius} Z`,
-    "lower-right": `M ${cx} ${cy + radius} L ${cx} ${cy} L ${cx + radius} ${cy} A ${radius} ${radius} 0 0 0 ${cx} ${cy + radius} Z`,
-    "lower-left": `M ${cx} ${cy + radius} L ${cx} ${cy} L ${cx - radius} ${cy} A ${radius} ${radius} 0 0 1 ${cx} ${cy + radius} Z`,
-  };
-  return paths[quadrant];
+  );
+  return path.join(" ");
 }
 
 export function rotateDelta(dx, dy, degrees) {

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -10,7 +10,6 @@ import {
   BOX_HORIZONTAL_PADDING,
   TEXT_BOX_EDGE_PADDING,
   BOX_CORNER_RADIUS,
-  BOX_JUNCTION_RADIUS,
   FONT_SIZE_MIN,
   FONT_SIZE_MAX,
   FONT_SIZE_SLIDER_MAX,
@@ -27,10 +26,7 @@ import {
   sliderPositionFromFontSize,
   formatFontSize,
   getImageLayout,
-  lineCornerRadii,
-  lineJunctionCorners,
-  roundedRectSvgPath,
-  concaveCornerSvgPath,
+  perLineBackgroundSvgPath,
   wrapText,
 } from "./editor-model.mjs";
 import {
@@ -339,7 +335,7 @@ export function renderTextBox(text) {
       data-background="${background}"
       data-box-shape="${backgroundShape}"
       data-align="${textAlignment(text)}"
-      style="left:${text.x * 100}%;top:${text.y * 100}%;width:${text.width * 100}%;height:${text.height * 100}%;transform:rotate(${text.rotation || 0}deg);--text-color:${color};--outline-color:${outlineColor};"
+      style="left:${text.x * 100}%;top:${text.y * 100}%;width:${text.width * 100}%;height:${text.height * 100}%;transform:rotate(${text.rotation || 0}deg);--text-color:${color};--outline-color:${outlineColor};--box-text-line-height:${BOX_TEXT_LINE_HEIGHT}em;--box-horizontal-padding:${BOX_HORIZONTAL_PADDING}em;"
       tabindex="0"
       aria-label="Text layer: ${escapeHtml(text.text)}"
     >
@@ -521,6 +517,8 @@ export function updateTextBox(text) {
   const color = textColor(text);
   box.style.setProperty("--text-color", color);
   box.style.setProperty("--outline-color", outlineColorFor(color));
+  box.style.setProperty("--box-text-line-height", `${BOX_TEXT_LINE_HEIGHT}em`);
+  box.style.setProperty("--box-horizontal-padding", `${BOX_HORIZONTAL_PADDING}em`);
   const insideVisual = box.querySelector(".text-visual--inside");
   if (insideVisual) insideVisual.style.clipPath = layerClipCss(text.x, text.y, text.width, text.height);
   box.querySelectorAll(".text-content-wrap").forEach((contentWrap) => {
@@ -563,12 +561,9 @@ export function createPerLineBackground(text, widths, lineHeight, fontSize, cont
   const namespace = "http://www.w3.org/2000/svg";
   const boxHeight = fontSize * BOX_LINE_HEIGHT;
   const radius = Math.min(fontSize * BOX_CORNER_RADIUS, boxHeight / 2);
-  const junctionRadius = Math.min(fontSize * BOX_JUNCTION_RADIUS, boxHeight / 2);
   const height = (widths.length - 1) * lineHeight + boxHeight;
-  const lineCenters = widths.map((_, index) => index * lineHeight + boxHeight / 2);
   const fill = text.background === "black" ? "#111111" : "#ffffff";
   const align = textAlignment(text);
-  const lineStart = (width) => align === "left" ? 0 : align === "right" ? contentWidth - width : (contentWidth - width) / 2;
   const svg = document.createElementNS(namespace, "svg");
   svg.setAttribute("class", "text-background");
   svg.setAttribute("viewBox", `0 0 ${contentWidth} ${height}`);
@@ -577,25 +572,10 @@ export function createPerLineBackground(text, widths, lineHeight, fontSize, cont
   svg.style.height = `${height}px`;
   svg.style.top = `${(lineHeight - boxHeight) / 2}px`;
 
-  widths.forEach((width, index) => {
-    const path = document.createElementNS(namespace, "path");
-    path.setAttribute("d", roundedRectSvgPath(
-      lineStart(width),
-      index * lineHeight,
-      width,
-      boxHeight,
-      lineCornerRadii(widths, index, radius),
-    ));
-    path.setAttribute("fill", fill);
-    svg.appendChild(path);
-  });
-
-  (align === "center" ? lineJunctionCorners(widths, lineCenters, contentWidth / 2, boxHeight, junctionRadius) : []).forEach((corner) => {
-    const path = document.createElementNS(namespace, "path");
-    path.setAttribute("d", concaveCornerSvgPath(corner));
-    path.setAttribute("fill", fill);
-    svg.appendChild(path);
-  });
+  const path = document.createElementNS(namespace, "path");
+  path.setAttribute("d", perLineBackgroundSvgPath(widths, lineHeight, boxHeight, 0, contentWidth, align, radius));
+  path.setAttribute("fill", fill);
+  svg.appendChild(path);
   return svg;
 }
 

--- a/src/slide-renderer.mjs
+++ b/src/slide-renderer.mjs
@@ -10,15 +10,13 @@ import {
   BOX_HORIZONTAL_PADDING,
   TEXT_BOX_EDGE_PADDING,
   BOX_CORNER_RADIUS,
-  BOX_JUNCTION_RADIUS,
   textColor,
   outlineColorFor,
   overlayCrop,
   textAlignment,
   slideItems,
   getImageLayout,
-  lineCornerRadii,
-  lineJunctionCorners,
+  perLineBackgroundSvgPath,
   wrapText,
 } from "./editor-model.mjs";
 import { activeProject, getOverlayMetrics } from "./editor-state.mjs";
@@ -130,7 +128,6 @@ export function drawTextLayer(context, text, imageWidth, imageHeight) {
   const contentLeft = x + edgePadding;
   const contentRight = x + width - edgePadding;
   const textX = align === "left" ? contentLeft + alignedTextInset : align === "right" ? contentRight - alignedTextInset : x + width / 2;
-  const pillStart = (pillWidth) => align === "left" ? contentLeft : align === "right" ? contentRight - pillWidth : x + (width - pillWidth) / 2;
 
   if (text.style === "boxed" && text.backgroundShape === "full") {
     context.fillStyle = text.background === "black" ? "#111111" : "#ffffff";
@@ -141,24 +138,18 @@ export function drawTextLayer(context, text, imageWidth, imageHeight) {
   if (perLineBox) {
     const backgroundHeight = fontSize * BOX_LINE_HEIGHT;
     const radius = Math.min(fontSize * BOX_CORNER_RADIUS, backgroundHeight / 2);
-    const junctionRadius = Math.min(fontSize * BOX_JUNCTION_RADIUS, backgroundHeight / 2);
-    const lineCenters = visibleLines.map((_, index) => startY + index * lineHeight);
     context.fillStyle = text.background === "black" ? "#111111" : "#ffffff";
-    visibleLines.forEach((line, index) => {
-      if (!line) return;
-      const backgroundWidth = pillWidths[index];
-      roundedRect(
-        context,
-        pillStart(backgroundWidth),
-        lineCenters[index] - backgroundHeight / 2,
-        backgroundWidth,
-        backgroundHeight,
-        lineCornerRadii(pillWidths, index, radius),
-      );
-      context.fill();
-    });
-    (align === "center" ? lineJunctionCorners(pillWidths, lineCenters, x + width / 2, backgroundHeight, junctionRadius) : [])
-      .forEach((corner) => fillConcaveCorner(context, corner));
+    const backgroundPath = perLineBackgroundSvgPath(
+      pillWidths,
+      lineHeight,
+      backgroundHeight,
+      contentLeft,
+      innerWidth,
+      align,
+      radius,
+      startY - backgroundHeight / 2,
+    );
+    context.fill(new Path2D(backgroundPath));
   }
 
   visibleLines.forEach((line, index) => {
@@ -180,42 +171,6 @@ export function drawTextLayer(context, text, imageWidth, imageHeight) {
 export function roundedRect(context, x, y, width, height, radius) {
   context.beginPath();
   context.roundRect(x, y, width, height, radius);
-}
-
-export function fillConcaveCorner(context, { cx, cy, radius, quadrant }) {
-  const shapes = {
-    "upper-left": {
-      start: [cx, cy - radius],
-      corner: [cx, cy],
-      arcStart: [cx - radius, cy],
-      arc: [cx - radius, cy - radius, Math.PI * 0.5, 0, true],
-    },
-    "upper-right": {
-      start: [cx, cy - radius],
-      corner: [cx, cy],
-      arcStart: [cx + radius, cy],
-      arc: [cx + radius, cy - radius, Math.PI * 0.5, Math.PI, false],
-    },
-    "lower-right": {
-      start: [cx, cy + radius],
-      corner: [cx, cy],
-      arcStart: [cx + radius, cy],
-      arc: [cx + radius, cy + radius, -Math.PI * 0.5, -Math.PI, true],
-    },
-    "lower-left": {
-      start: [cx, cy + radius],
-      corner: [cx, cy],
-      arcStart: [cx - radius, cy],
-      arc: [cx - radius, cy + radius, -Math.PI * 0.5, 0, false],
-    },
-  }[quadrant];
-  context.beginPath();
-  context.moveTo(...shapes.start);
-  context.lineTo(...shapes.corner);
-  context.lineTo(...shapes.arcStart);
-  context.arc(shapes.arc[0], shapes.arc[1], radius, shapes.arc[2], shapes.arc[3], shapes.arc[4]);
-  context.closePath();
-  context.fill();
 }
 
 export async function fingerprintData(value) {

--- a/styles.css
+++ b/styles.css
@@ -2195,12 +2195,16 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 1.12em;
+  height: var(--box-text-line-height, 1.17em);
   margin: 0;
-  padding: 0 0.52em;
+  padding: 0 var(--box-horizontal-padding, 0.46em);
   color: var(--text-color, #fff);
   background: transparent;
-  line-height: 1.12;
+  line-height: var(--box-text-line-height, 1.17em);
+}
+
+.text-box[data-style="boxed"][data-box-shape="lines"] .text-editor {
+  line-height: var(--box-text-line-height, 1.17em);
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="left"] .text-line {
@@ -2208,7 +2212,7 @@ button:disabled {
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="left"] .text-editor {
-  transform: translateX(0.52em);
+  transform: translateX(var(--box-horizontal-padding, 0.46em));
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="right"] .text-line {
@@ -2216,7 +2220,7 @@ button:disabled {
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="right"] .text-editor {
-  transform: translateX(-0.52em);
+  transform: translateX(calc(-1 * var(--box-horizontal-padding, 0.46em)));
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-background="black"] .text-line {

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -4,7 +4,6 @@ import assert from "node:assert/strict";
 import {
   applyCropValues,
   cloneProject,
-  concaveCornerSvgPath,
   ensureBoxedTextContrast,
   escapeHtml,
   fontSizeFromSliderPosition,
@@ -17,8 +16,7 @@ import {
   layerClipCss,
   layerKey,
   layerStageInset,
-  lineCornerRadii,
-  lineJunctionCorners,
+  normalizePerLineBackgroundWidths,
   nextLayerZ,
   normalizeHexColor,
   outlineColorFor,
@@ -28,7 +26,7 @@ import {
   projectPath,
   rgbToHex,
   rotateDelta,
-  roundedRectSvgPath,
+  perLineBackgroundSvgPath,
   routeFromPathname,
   safeFilename,
   slideItems,
@@ -153,18 +151,22 @@ test("calculates cover-image layout and clamps pan offsets", () => {
   assert.equal(layout.maxOffsetY, 0);
 });
 
-test("identifies exposed and joined corners for per-line text boxes", () => {
-  assert.deepEqual(lineCornerRadii([100, 80], 0, 10), [10, 10, 10, 10]);
-  assert.deepEqual(lineCornerRadii([80, 100], 1, 10), [10, 10, 10, 10]);
-  assert.deepEqual(lineJunctionCorners([80, 120], [20, 60], 100, 40, 8), [
-    { cx: 60, cy: 40, radius: 8, quadrant: "upper-left" },
-    { cx: 140, cy: 40, radius: 8, quadrant: "upper-right" },
-  ]);
+test("merges only text-row steps that cannot hold uniform corners", () => {
+  assert.deepEqual(normalizePerLineBackgroundWidths([100, 130], "center", 10), [130, 130]);
+  assert.deepEqual(normalizePerLineBackgroundWidths([100, 150], "center", 10), [100, 150]);
+  assert.deepEqual(normalizePerLineBackgroundWidths([100, 130, 160], "center", 10), [160, 160, 160]);
+  assert.deepEqual(normalizePerLineBackgroundWidths([100, 115], "left", 10), [115, 115]);
+  assert.deepEqual(normalizePerLineBackgroundWidths([100, 130], "right", 10), [100, 130]);
 });
 
-test("produces deterministic convex and concave SVG paths", () => {
-  assert.equal(roundedRectSvgPath(0, 0, 100, 50, [10, 10, 10, 10]), "M 10 0 H 90 Q 100 0 100 10 V 40 Q 100 50 90 50 H 10 Q 0 50 0 40 V 10 Q 0 0 10 0 Z");
-  assert.equal(concaveCornerSvgPath({ cx: 10, cy: 20, radius: 4, quadrant: "upper-left" }), "M 10 16 L 10 20 L 6 20 A 4 4 0 0 0 10 16 Z");
+test("produces one deterministic circular-arc path for per-line text backgrounds", () => {
+  assert.equal(
+    perLineBackgroundSvgPath([100], 30, 40, 0, 100, "center", 10),
+    "M 10 0 H 90 A 10 10 0 0 1 100 10 V 30 A 10 10 0 0 1 90 40 H 10 A 10 10 0 0 1 0 30 V 10 A 10 10 0 0 1 10 0 Z",
+  );
+  const stepped = perLineBackgroundSvgPath([80, 140], 30, 40, 0, 140, "center", 10);
+  assert.equal((stepped.match(/A 10 10/g) || []).length, 8);
+  assert.equal(stepped.includes(" Q "), false);
 });
 
 test("rotates pointer deltas into layer-local axes", () => {


### PR DESCRIPTION
## Summary
- render per-line boxed text as one continuous circular-arc contour
- normalize near-equal neighboring rows so every transition keeps the same radius
- share identical geometry between the editor and PNG export
- tune line height and padding to the approved TikTok-native proportions

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local