### PR TITLE
Calibrate TikTok text box spacing

### DIFF
--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -24,15 +24,17 @@ export const LEGACY_CLIPBOARD_STORAGE_KEY = "slide-studio-layer-clipboard";
 
 export const HISTORY_LIMIT = 200;
 
-export const BOX_TEXT_LINE_HEIGHT = 1.17;
+export const BOX_TEXT_LINE_HEIGHT = 1.24;
 
-export const BOX_LINE_HEIGHT = 1.46;
+export const BOX_LINE_HEIGHT = 1.5;
 
-export const BOX_HORIZONTAL_PADDING = 0.46;
+export const BOX_HORIZONTAL_PADDING = 0.45;
+
+export const BOX_BACKGROUND_VERTICAL_OFFSET = 0.03;
 
 export const TEXT_BOX_EDGE_PADDING = 0.3;
 
-export const BOX_CORNER_RADIUS = 0.18;
+export const BOX_CORNER_RADIUS = 0.225;
 
 export const FONT_SIZE_MIN = 20;
 
@@ -308,6 +310,18 @@ function appendLeftLineBackgroundTransition(path, current, next, middleY, radius
   );
 }
 
+function lineBackgroundTransitionY(widths, index, lineHeight, boxHeight, top) {
+  const upperLineTop = top + index * lineHeight;
+
+  // TikTok lets a wider upper row keep its full background depth before the
+  // contour turns inward. That protects descenders (for example the final
+  // "g" in "long") while preserving the existing placement when the next
+  // row expands outward.
+  return widths[index] > widths[index + 1]
+    ? upperLineTop + boxHeight
+    : upperLineTop + (boxHeight + lineHeight) / 2;
+}
+
 export function perLineBackgroundSvgPath(widths, lineHeight, boxHeight, contentLeft, contentWidth, align, radius, top = 0) {
   if (!widths.length) return "";
   const normalizedWidths = normalizePerLineBackgroundWidths(widths, align, radius);
@@ -330,7 +344,7 @@ export function perLineBackgroundSvgPath(widths, lineHeight, boxHeight, contentL
   ];
 
   for (let index = 0; index < bounds.length - 1; index += 1) {
-    const middleY = top + index * lineHeight + (boxHeight + lineHeight) / 2;
+    const middleY = lineBackgroundTransitionY(normalizedWidths, index, lineHeight, boxHeight, top);
     appendRightLineBackgroundTransition(path, bounds[index].right, bounds[index + 1].right, middleY, cornerRadius);
   }
 
@@ -342,7 +356,7 @@ export function perLineBackgroundSvgPath(widths, lineHeight, boxHeight, contentL
   );
 
   for (let index = bounds.length - 2; index >= 0; index -= 1) {
-    const middleY = top + index * lineHeight + (boxHeight + lineHeight) / 2;
+    const middleY = lineBackgroundTransitionY(normalizedWidths, index, lineHeight, boxHeight, top);
     appendLeftLineBackgroundTransition(path, bounds[index + 1].left, bounds[index].left, middleY, cornerRadius);
   }
 

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -8,6 +8,7 @@ import {
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
   BOX_HORIZONTAL_PADDING,
+  BOX_BACKGROUND_VERTICAL_OFFSET,
   TEXT_BOX_EDGE_PADDING,
   BOX_CORNER_RADIUS,
   FONT_SIZE_MIN,
@@ -570,7 +571,7 @@ export function createPerLineBackground(text, widths, lineHeight, fontSize, cont
   svg.setAttribute("preserveAspectRatio", "none");
   svg.setAttribute("aria-hidden", "true");
   svg.style.height = `${height}px`;
-  svg.style.top = `${(lineHeight - boxHeight) / 2}px`;
+  svg.style.top = `${(lineHeight - boxHeight) / 2 + fontSize * BOX_BACKGROUND_VERTICAL_OFFSET}px`;
 
   const path = document.createElementNS(namespace, "path");
   path.setAttribute("d", perLineBackgroundSvgPath(widths, lineHeight, boxHeight, 0, contentWidth, align, radius));

--- a/src/slide-renderer.mjs
+++ b/src/slide-renderer.mjs
@@ -8,6 +8,7 @@ import {
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
   BOX_HORIZONTAL_PADDING,
+  BOX_BACKGROUND_VERTICAL_OFFSET,
   TEXT_BOX_EDGE_PADDING,
   BOX_CORNER_RADIUS,
   textColor,
@@ -147,7 +148,7 @@ export function drawTextLayer(context, text, imageWidth, imageHeight) {
       innerWidth,
       align,
       radius,
-      startY - backgroundHeight / 2,
+      startY - backgroundHeight / 2 + fontSize * BOX_BACKGROUND_VERTICAL_OFFSET,
     );
     context.fill(new Path2D(backgroundPath));
   }

--- a/styles.css
+++ b/styles.css
@@ -2195,16 +2195,16 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: var(--box-text-line-height, 1.17em);
+  height: var(--box-text-line-height, 1.24em);
   margin: 0;
-  padding: 0 var(--box-horizontal-padding, 0.46em);
+  padding: 0 var(--box-horizontal-padding, 0.45em);
   color: var(--text-color, #fff);
   background: transparent;
-  line-height: var(--box-text-line-height, 1.17em);
+  line-height: var(--box-text-line-height, 1.24em);
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"] .text-editor {
-  line-height: var(--box-text-line-height, 1.17em);
+  line-height: var(--box-text-line-height, 1.24em);
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="left"] .text-line {
@@ -2212,7 +2212,7 @@ button:disabled {
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="left"] .text-editor {
-  transform: translateX(var(--box-horizontal-padding, 0.46em));
+  transform: translateX(var(--box-horizontal-padding, 0.45em));
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="right"] .text-line {
@@ -2220,7 +2220,7 @@ button:disabled {
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-align="right"] .text-editor {
-  transform: translateX(calc(-1 * var(--box-horizontal-padding, 0.46em)));
+  transform: translateX(calc(-1 * var(--box-horizontal-padding, 0.45em)));
 }
 
 .text-box[data-style="boxed"][data-box-shape="lines"][data-background="black"] .text-line {

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -169,6 +169,14 @@ test("produces one deterministic circular-arc path for per-line text backgrounds
   assert.equal(stepped.includes(" Q "), false);
 });
 
+test("keeps a wider upper row behind descenders before narrowing", () => {
+  const narrowing = perLineBackgroundSvgPath([140, 80], 30, 40, 0, 140, "center", 5);
+  const widening = perLineBackgroundSvgPath([80, 140], 30, 40, 0, 140, "center", 5);
+
+  assert.match(narrowing, /V 35 A 5 5 0 0 1 135 40 H 115 A 5 5 0 0 0 110 45/);
+  assert.match(widening, /V 30 A 5 5 0 0 0 115 35 H 135 A 5 5 0 0 1 140 40/);
+});
+
 test("rotates pointer deltas into layer-local axes", () => {
   const result = rotateDelta(10, 0, 90);
   assert.ok(Math.abs(result.x) < 1e-10);


### PR DESCRIPTION
## Summary
- calibrate multiline box height, line spacing, padding, and corner radius against the native TikTok screenshot
- preserve descender clearance when a wider line narrows into the next row
- keep editor and exported PNG geometry in sync

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local