### PR TITLE
Add keyboard slide navigation

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -648,6 +648,97 @@ try {
     throw new Error(`Native slide drag ordering changed: ${JSON.stringify(slideReordering)}`);
   }
 
+  const keyboardSlideNavigation = await evaluate(cdp, `(() => {
+    const activeSlideId = () => window.carouselBotAgent.inspect({ includeAllProjects: false }).activeSlideId;
+    const activeThumbId = () => document.querySelector('.slide-thumb.is-active')?.dataset.slideId || null;
+    const press = (key, target = document) => {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      target.dispatchEvent(event);
+      return { key, activeSlideId: activeSlideId(), activeThumbId: activeThumbId(), prevented: event.defaultPrevented };
+    };
+    document.querySelector('.slide-thumb[data-slide-id=${JSON.stringify(slide.createdSlideId)}]').click();
+    const steps = [
+      press('ArrowLeft'),
+      press('ArrowUp'),
+      press('ArrowRight'),
+      press('ArrowRight'),
+      press('ArrowDown'),
+      press('ArrowLeft'),
+      press('ArrowDown'),
+      press('ArrowUp'),
+    ];
+    const activeButton = document.querySelector('.slide-thumb.is-active');
+    const activeRect = activeButton.getBoundingClientRect();
+    activeButton.dispatchEvent(new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: activeRect.left + activeRect.width / 2,
+      clientY: activeRect.top + activeRect.height / 2,
+    }));
+    const menuOpenBeforeNavigation = Boolean(document.querySelector('.layer-menu'));
+    const menuStep = press('ArrowRight');
+    const menuOpenAfterNavigation = Boolean(document.querySelector('.layer-menu'));
+    press('ArrowLeft');
+    const textBox = document.querySelector('.text-box');
+    textBox.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true, button: 0 }));
+    const inlineEditor = textBox.querySelector('.text-editor');
+    const inlineEditingStep = press('ArrowRight', inlineEditor);
+    inlineEditor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    const title = document.querySelector('.project-title-input');
+    const inputSteps = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].map((key) => press(key, title));
+    const textareaStep = press('ArrowRight', document.querySelector('#text-value'));
+    const rangeStep = press('ArrowRight', document.querySelector('#font-size'));
+    return {
+      steps,
+      menuOpenBeforeNavigation,
+      menuStep,
+      menuOpenAfterNavigation,
+      inlineEditingStep,
+      inputSteps,
+      textareaStep,
+      rangeStep,
+    };
+  })()`);
+  const expectedKeyboardSlideIds = [
+    slide.createdSlideId,
+    slide.createdSlideId,
+    uploadedSlide.id,
+    uploadedSlide.id,
+    uploadedSlide.id,
+    slide.createdSlideId,
+    uploadedSlide.id,
+    slide.createdSlideId,
+  ];
+  if (
+    keyboardSlideNavigation.steps.some((step, index) => (
+      step.activeSlideId !== expectedKeyboardSlideIds[index]
+      || step.activeThumbId !== expectedKeyboardSlideIds[index]
+      || !step.prevented
+    ))
+    || !keyboardSlideNavigation.menuOpenBeforeNavigation
+    || keyboardSlideNavigation.menuOpenAfterNavigation
+    || keyboardSlideNavigation.menuStep.activeSlideId !== uploadedSlide.id
+    || keyboardSlideNavigation.menuStep.activeThumbId !== uploadedSlide.id
+    || !keyboardSlideNavigation.menuStep.prevented
+    || keyboardSlideNavigation.inlineEditingStep.activeSlideId !== slide.createdSlideId
+    || keyboardSlideNavigation.inlineEditingStep.activeThumbId !== slide.createdSlideId
+    || keyboardSlideNavigation.inlineEditingStep.prevented
+    || keyboardSlideNavigation.inputSteps.some((step) => (
+      step.activeSlideId !== slide.createdSlideId
+      || step.activeThumbId !== slide.createdSlideId
+      || step.prevented
+    ))
+    || keyboardSlideNavigation.textareaStep.activeSlideId !== slide.createdSlideId
+    || keyboardSlideNavigation.textareaStep.activeThumbId !== slide.createdSlideId
+    || keyboardSlideNavigation.textareaStep.prevented
+    || keyboardSlideNavigation.rangeStep.activeSlideId !== slide.createdSlideId
+    || keyboardSlideNavigation.rangeStep.activeThumbId !== slide.createdSlideId
+    || keyboardSlideNavigation.rangeStep.prevented
+  ) {
+    throw new Error(`Keyboard slide navigation changed: ${JSON.stringify(keyboardSlideNavigation)}`);
+  }
+
   await evaluate(cdp, `(() => {
     const button = document.querySelector('.slide-thumb[data-slide-id="${slide.createdSlideId}"]');
     const rect = button.getBoundingClientRect();
@@ -889,6 +980,7 @@ try {
     undoRedo: true,
     nativeClipboard: true,
     imageUpload: true,
+    keyboardSlideNavigation: true,
     nativeSlideLifecycle: true,
     nativeOutputActions: true,
     nativeProjectDeletion: true,

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -95,6 +95,15 @@ export function routeFromPathname(pathname = window.location.pathname) {
   }
 }
 
+export function adjacentSlideId(slides, activeSlideId, offset) {
+  if (!Array.isArray(slides) || !slides.length) return null;
+  const activeIndex = slides.findIndex((slide) => slide.id === activeSlideId);
+  if (activeIndex < 0) return null;
+  const direction = Math.sign(Number(offset) || 0);
+  const nextIndex = clamp(activeIndex + direction, 0, slides.length - 1);
+  return slides[nextIndex]?.id || null;
+}
+
 export function escapeHtml(value = "") {
   return String(value)
     .replaceAll("&", "&amp;")

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -7,6 +7,7 @@ import {
   CANVAS_ZOOM_MIN,
   CANVAS_ZOOM_MAX,
   projectPath,
+  adjacentSlideId,
   escapeHtml,
   normalizeHexColor,
   textColor,
@@ -375,6 +376,28 @@ export function createEditorUI({ projects, actions, output }) {
     });
   }
 
+  function activateSlide(slideId, { reveal = false } = {}) {
+    const project = activeProject();
+    if (!project?.slides.some((slide) => slide.id === slideId)) return false;
+    state.activeSlideId = slideId;
+    clearLayerSelection();
+    state.photoAdjustMode = false;
+    closeLayerMenu();
+    renderEditor();
+    if (reveal) {
+      app.querySelector(".slide-thumb.is-active")?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+    return true;
+  }
+
+  function navigateSlides(offset) {
+    const project = activeProject();
+    const slideId = adjacentSlideId(project?.slides, state.activeSlideId, offset);
+    if (!slideId) return false;
+    if (slideId !== state.activeSlideId) activateSlide(slideId, { reveal: true });
+    return true;
+  }
+
 
   function bindEditorEvents() {
     bindGlobalActions();
@@ -397,10 +420,7 @@ export function createEditorUI({ projects, actions, output }) {
 
     app.querySelectorAll("[data-slide-id]").forEach((button) => {
       button.addEventListener("click", () => {
-        state.activeSlideId = button.dataset.slideId;
-        clearLayerSelection();
-        state.photoAdjustMode = false;
-        renderEditor();
+        activateSlide(button.dataset.slideId);
       });
     });
     bindSlideReordering();
@@ -1137,6 +1157,7 @@ export function createEditorUI({ projects, actions, output }) {
     toast,
     renderDashboard,
     renderEditor,
+    navigateSlides,
     refreshSelection,
     ensureTextFits,
     setCanvasZoom,

--- a/src/editor.mjs
+++ b/src/editor.mjs
@@ -121,6 +121,23 @@ export async function init() {
         editingBox.focus({ preventScroll: true });
       }
     }
+    const slideOffset = {
+      ArrowLeft: -1,
+      ArrowUp: -1,
+      ArrowRight: 1,
+      ArrowDown: 1,
+    }[event.key];
+    if (slideOffset
+      && !event.defaultPrevented
+      && !event.metaKey
+      && !event.ctrlKey
+      && !event.altKey
+      && !event.shiftKey
+      && !isEditingTextTarget(event.target)
+      && editorUI.navigateSlides(slideOffset)) {
+      event.preventDefault();
+      return;
+    }
     const meta = event.metaKey || event.ctrlKey;
     if (meta && app.querySelector(".stage")) {
       if (event.key === "+" || event.key === "=") {

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  adjacentSlideId,
   applyCropValues,
   cloneProject,
   ensureBoxedTextContrast,
@@ -35,6 +36,17 @@ import {
   textColor,
   wrapText,
 } from "../src/editor-model.mjs";
+
+test("finds adjacent slides without wrapping past either end", () => {
+  const slides = [{ id: "first" }, { id: "middle" }, { id: "final" }];
+  assert.equal(adjacentSlideId(slides, "middle", -1), "first");
+  assert.equal(adjacentSlideId(slides, "middle", 1), "final");
+  assert.equal(adjacentSlideId(slides, "first", -1), "first");
+  assert.equal(adjacentSlideId(slides, "final", 1), "final");
+  assert.equal(adjacentSlideId(slides, "middle", 0), "middle");
+  assert.equal(adjacentSlideId(slides, "missing", 1), null);
+  assert.equal(adjacentSlideId([], "first", 1), null);
+});
 
 test("routes dashboard and encoded project URLs", () => {
   assert.deepEqual(routeFromPathname("/"), { view: "dashboard" });


### PR DESCRIPTION
Adds bounded slide navigation for the four plain arrow keys: Left and Up select the previous slide, while Right and Down select the next. Navigation stops at both ends, stays disabled in inputs, textareas, inline text editors, and inspector controls, reveals the active thumbnail, and closes stale context menus. Includes pure-model boundary tests and real-browser regression coverage. Verified with the complete local release gate.