### PR TITLE
Automate protected production deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -43,3 +44,55 @@ jobs:
         run: npm run test:editor:browser
         env:
           CHROME_PATH: /usr/bin/google-chrome
+
+  deploy-production:
+    name: Deploy production
+    needs: test
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: production
+      url: https://carousel.bot
+
+    steps:
+      - name: Check whether deployment credentials are configured
+        id: credentials
+        env:
+          HAS_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+          HAS_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+        run: |
+          if [[ "$HAS_CLOUDFLARE_API_TOKEN" == "true" && "$HAS_CLOUDFLARE_ACCOUNT_ID" == "true" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Production deployment skipped until the Cloudflare environment secrets are configured."
+          fi
+
+      - name: Check out verified main
+        if: steps.credentials.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        if: steps.credentials.outputs.configured == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies without lifecycle scripts
+        if: steps.credentials.outputs.configured == 'true'
+        run: npm ci --ignore-scripts
+
+      - name: Build the production bundle
+        if: steps.credentials.outputs.configured == 'true'
+        run: npm run build
+
+      - name: Deploy the verified bundle to Cloudflare Pages
+        if: steps.credentials.outputs.configured == 'true'
+        run: ./node_modules/.bin/wrangler pages deploy dist --project-name slides-editor --branch main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ npm run deploy
 
 The production deploy command is intentionally main-only. Experimental branches can use the persistent development environment with `npm run deploy:dev`.
 
+Protected `main` updates also run the production deployment job after CI passes. The job uses the `production` GitHub environment, which is restricted to `main`, and skips until these environment secrets are configured:
+
+- `CLOUDFLARE_ACCOUNT_ID` — the account that owns the existing `slides-editor` Pages project.
+- `CLOUDFLARE_API_TOKEN` — a custom token limited to that account with **Account → Cloudflare Pages → Edit** permission.
+
+The Cloudflare credentials are exposed only to the final Wrangler upload step; pull-request jobs never receive them. To deploy an already-merged commit after adding or rotating the secrets, manually run the **CI** workflow on `main` from the Actions tab.
+
 The current Pages project name and legacy `slides-editor.pages.dev` hostname are intentionally retained during the domain migration. See [docs/REBRAND_ROLLOUT.md](docs/REBRAND_ROLLOUT.md) before changing GitHub, npm, Cloudflare, or DNS.
 
 ## Domain migration

--- a/test/production-deploy-workflow.test.mjs
+++ b/test/production-deploy-workflow.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workflow = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+test("production deploys only verified main with narrowly scoped Cloudflare credentials", () => {
+  assert.match(workflow, /push:\n\s+branches: \[main\]/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /pull_request_target:/);
+  assert.match(workflow, /permissions:\n\s+contents: read/);
+  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+  assert.match(workflow, /deploy-production:[\s\S]*needs: test/);
+  assert.match(workflow, /if: github\.event_name != 'pull_request' && github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment:\n\s+name: production/);
+  assert.match(workflow, /npm ci --ignore-scripts/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(
+    workflow,
+    /\.\/node_modules\/\.bin\/wrangler pages deploy dist --project-name slides-editor --branch main/,
+  );
+  assert.match(workflow, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
+  assert.match(workflow, /CLOUDFLARE_ACCOUNT_ID: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ID \}\}/);
+});


### PR DESCRIPTION
## Summary
- deploy the existing Direct Upload Pages project after CI passes on protected main
- restrict credentials to a main-only GitHub production environment and the final Wrangler step
- support manual reruns for already-merged commits and skip cleanly until secrets are configured
- document the minimum Cloudflare token scope and add a workflow security regression test

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local

## Required one-time setup
Add CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN as secrets in the production environment. The token should be restricted to the owning Cloudflare account with Account > Cloudflare Pages > Edit.