### PR TITLE
Add local Mac font support

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,14 +8,15 @@ The editor deliberately uses a small ES-module graph rather than a framework or 
 
 ```text
 main ───────────────> editor + agent-commands
-agent-commands ─────> editor + store + view + renderer + state + model
+agent-commands ─────> editor + store + view + renderer + fonts + state + model
 editor ─────────────> projects + actions + output + UI + store + state + model
-UI ─────────────────> interactions + view + state + model
-projects ───────────> store + view + state + model
-actions ────────────> store + renderer + state + model
+UI ─────────────────> interactions + view + fonts + state + model
+projects ───────────> store + view + fonts + state + model
+actions ────────────> store + renderer + fonts + state + model
 output ─────────────> renderer + view + state + model
 interactions ───────> view + state + model
-store/view/renderer ─> state + model
+view/renderer ──────> fonts + state + model
+fonts/store ────────> model
 state ──────────────> model
 ```
 
@@ -42,6 +43,8 @@ An arrow points from an importing module toward its dependencies. The four featu
 ### Views and rendering
 
 `editor-view.mjs` creates editor markup and updates live layer DOM. `slide-renderer.mjs` draws the export representation onto a canvas. Both use the same model helpers for colors, crops, layer order, text alignment, wrapping, and boxed-text geometry.
+
+`project-fonts.mjs` owns project-font normalization, private local face data, `FontFace` registration, public redaction, and the shared font descriptors used by DOM and canvas rendering. `ensureProjectFontsLoaded` is the exact-font gate before measurement or rendered output. A missing or invalid imported face remains editable with a visible warning, but rendering and export fail with `FONT_UNAVAILABLE` instead of silently accepting fallback pixels.
 
 Dashboard covers and slide thumbnails also use the final slide renderer. `editor-output.mjs` versions and revokes their Blob URLs to prevent stale previews and leaks, and owns the related PNG download and Web Share workflows.
 
@@ -72,6 +75,12 @@ window.slideStudioAgent
 
 The local MCP bridge waits for the readiness promise before processing operations.
 
+### Local-font companion boundary
+
+Installed fonts are an optional capability of the loopback MCP companion. After explicit permission in the editor, the companion indexes supported macOS font directories, parses each face (including every TTC face), and returns only stable opaque `localFontId` metadata. Filesystem paths, index fingerprints, and raw bytes never appear in MCP or inspection responses.
+
+An import resolves one selected face inside the companion and transfers its bytes once to the reserved browser tab over the authenticated loopback bridge. TTC faces are repacked as standalone SFNT data before transfer. The browser stores those bytes only in the local IndexedDB project record, registers a generated CSS family, and returns a project-scoped `fontId`; agents apply that ID to text instead of guessing a family name. The companion retains only its private index, recent-use metadata, and short-lived pending transfers.
+
 ## Data and rendering invariants
 
 - Output is 1080 × 1920.
@@ -80,6 +89,8 @@ The local MCP bridge waits for the readiness promise before processing operation
 - Overlay crop rectangles are normalized within the source image and have a minimum 5% size.
 - Layer `z` values determine one combined ordering across text and overlays.
 - Text wrapping and boxed-line geometry must agree between DOM previews and exported canvas images.
+- Imported font bytes remain local, and font metadata returned to agents never contains a filesystem path or stored bytes.
+- A text layer using a project font is measured and rendered only after that exact face has loaded.
 - TikTok placement chrome is preview-only and is never exported.
 - Project images stay embedded in the local project record; they are not uploaded by the application.
 - Layer geometry is applied with dynamic style attributes. The deployment CSP permits style attributes while keeping stylesheet and script sources restricted to the application origin.
@@ -97,6 +108,7 @@ Avoid committed pixel snapshots. Canvas output can vary across browser and platf
 ## Where a change belongs
 
 - Pure calculation or normalization: `editor-model.mjs`.
+- Project-font records, exact-face loading, or shared font descriptors: `project-fonts.mjs`.
 - Active selection or state-aware geometry: `editor-state.mjs`.
 - IndexedDB transaction or project notification: `project-store.mjs`.
 - Markup or live DOM painting: `editor-view.mjs`.

--- a/local-mcp-bridge.js
+++ b/local-mcp-bridge.js
@@ -12,6 +12,7 @@ const LOCAL_MCP_POLL_INTERVAL_MS = 250;
 const LOCAL_MCP_NOTIFICATION_DURATION_MS = 6_300;
 const LOCAL_MCP_CONNECTION_KEYS = ["carouselbot:mcp-connected", "slide-studio:mcp-connected"];
 const LOCAL_MCP_EDITOR_KEYS = ["carouselbot:mcp-editor-id", "slide-studio:mcp-editor-id"];
+const LOCAL_MCP_FONT_PERMISSION_KEYS = ["carouselbot:local-fonts-enabled", "slide-studio:local-fonts-enabled"];
 const LOCAL_MCP_ACTIVITY_CHANNEL = "carouselbot:mcp-activity";
 const LOCAL_MCP_AGENT_PROMPT = "Read https://raw.githubusercontent.com/alexgusevski/carouselbot/refs/heads/main/packages/mcp/README.md and install and configure the CarouselBot MCP and skill for this agent. Do not stop for a restart: if native MCP tools are not available in this session, use the documented CLI fallback so you can operate CarouselBot immediately. When you’re done, reply concisely with: “I’m done and ready to test the connection.”";
 
@@ -44,6 +45,20 @@ function localMcpForgetConnection() {
   } catch { /* The live connection can still be stopped. */ }
 }
 
+function localMcpLocalFontsWereEnabled() {
+  try {
+    return LOCAL_MCP_FONT_PERMISSION_KEYS.some((key) => localStorage.getItem(key) === "1");
+  } catch {
+    return false;
+  }
+}
+
+function localMcpRememberLocalFontsEnabled() {
+  try {
+    LOCAL_MCP_FONT_PERMISSION_KEYS.forEach((key) => localStorage.setItem(key, "1"));
+  } catch { /* Permission remains active for this browser session. */ }
+}
+
 function localMcpEditorId() {
   try {
     const existing = LOCAL_MCP_EDITOR_KEYS.map((key) => sessionStorage.getItem(key)).find(Boolean);
@@ -69,6 +84,7 @@ const localMcpBridgeState = {
   stopped: false,
   editorId: localMcpEditorId(),
   sessionToken: null,
+  localFontsEnabled: localMcpLocalFontsWereEnabled(),
   agents: [],
   editSessions: [],
   events: [],
@@ -395,12 +411,14 @@ async function localMcpHandshake() {
     pageOrigin: location.origin,
     visibilityState: document.visibilityState,
     hasFocus: document.hasFocus(),
+    localFontsEnabled: localMcpBridgeState.localFontsEnabled,
     state: window.carouselBotAgent.inspect({ includeAllProjects: false }),
   });
   const result = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(result.error || `Bridge returned ${response.status}`);
   if (result.protocolVersion !== window.carouselBotAgent.protocolVersion) throw new Error("The website and local companion versions are incompatible. Update the npm package and reload this page.");
   localMcpBridgeState.sessionToken = result.sessionToken;
+  if (typeof result.localFontsEnabled === "boolean") localMcpBridgeState.localFontsEnabled = result.localFontsEnabled;
   localMcpBridgeState.agents = result.agents || [];
   localMcpBridgeState.editSessions = result.editSessions || [];
   localMcpBridgeState.connected = true;
@@ -535,6 +553,81 @@ async function localMcpFetchMedia(mediaId) {
   return { file: new File([blob], name, { type: blob.type }), name };
 }
 
+async function localMcpRequireConnectedForFonts() {
+  if (!localMcpBridgeState.connected) await localMcpConnectFromClick();
+  if (!localMcpBridgeState.connected || !localMcpBridgeState.sessionToken) {
+    throw new Error("Connect CarouselBot to the local companion before using installed fonts.");
+  }
+  if (!localMcpBridgeState.localFontsEnabled && localMcpLocalFontsWereEnabled()) {
+    const response = await localMcpSendJson("/fonts/enable", { editorId: localMcpBridgeState.editorId });
+    const result = await response.json().catch(() => ({}));
+    if (response.ok && result.enabled === true) localMcpBridgeState.localFontsEnabled = true;
+  }
+}
+
+async function localMcpJsonResult(response, fallbackMessage) {
+  const result = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(result.error || fallbackMessage);
+  return result;
+}
+
+async function localMcpEnableLocalFonts() {
+  await localMcpRequireConnectedForFonts();
+  const response = await localMcpSendJson("/fonts/enable", { editorId: localMcpBridgeState.editorId });
+  const result = await localMcpJsonResult(response, "Could not enable installed fonts.");
+  if (result.enabled !== true) throw new Error("The local companion did not enable installed fonts.");
+  localMcpBridgeState.localFontsEnabled = true;
+  localMcpRememberLocalFontsEnabled();
+  return { enabled: true };
+}
+
+async function localMcpListLocalFonts({ query = "", limit, cursor, sort } = {}) {
+  await localMcpRequireConnectedForFonts();
+  const parameters = new URLSearchParams({ editorId: localMcpBridgeState.editorId });
+  if (query) parameters.set("query", String(query));
+  if (limit != null) parameters.set("limit", String(limit));
+  if (cursor) parameters.set("cursor", String(cursor));
+  if (sort) parameters.set("sort", String(sort));
+  const response = await localMcpRequest(`/fonts?${parameters}`);
+  return localMcpJsonResult(response, "Could not list installed fonts.");
+}
+
+function localMcpDecodedHeader(response, name, fallback = "") {
+  const value = response.headers.get(name);
+  if (!value) return fallback;
+  try { return decodeURIComponent(value); } catch { return fallback; }
+}
+
+async function localMcpReadFontResponse(response, fallbackName = "local-font") {
+  if (!response.ok) {
+    const result = await response.json().catch(() => ({}));
+    throw new Error(result.error || "Could not read the local font.");
+  }
+  const blob = await response.blob();
+  const name = localMcpDecodedHeader(response, "X-CarouselBot-Filename", fallbackName);
+  const localFontId = localMcpDecodedHeader(response, "X-CarouselBot-Local-Font-Id", "");
+  return { file: new File([blob], name, { type: blob.type }), name, localFontId };
+}
+
+async function localMcpFetchLocalFont(localFontId) {
+  await localMcpRequireConnectedForFonts();
+  const response = await localMcpRequest(`/fonts/${encodeURIComponent(localFontId)}?editorId=${encodeURIComponent(localMcpBridgeState.editorId)}`);
+  return localMcpReadFontResponse(response);
+}
+
+async function localMcpFetchFontMedia(fontMediaId) {
+  await localMcpRequireConnectedForFonts();
+  const response = await localMcpRequest(`/font-media/${encodeURIComponent(fontMediaId)}?editorId=${encodeURIComponent(localMcpBridgeState.editorId)}`);
+  return localMcpReadFontResponse(response);
+}
+
+async function localMcpMarkFontUsed(localFontId) {
+  await localMcpRequireConnectedForFonts();
+  const response = await localMcpSendJson("/fonts/use", { editorId: localMcpBridgeState.editorId, localFontId });
+  const result = await localMcpJsonResult(response, "Could not update local font usage.");
+  return result.font || null;
+}
+
 document.addEventListener("click", (event) => {
   const trigger = event.target.closest?.('[data-action="connect-agent"]');
   if (trigger) localMcpOpenModal(trigger);
@@ -561,7 +654,16 @@ window.carouselBotLocalMcpBridge = {
   connect: localMcpConnectFromClick,
   disconnect: localMcpDisconnectFromClick,
   fetchMedia: localMcpFetchMedia,
+  enableLocalFonts: localMcpEnableLocalFonts,
+  listLocalFonts: localMcpListLocalFonts,
+  fetchLocalFont: localMcpFetchLocalFont,
+  fetchFontMedia: localMcpFetchFontMedia,
+  markFontUsed: localMcpMarkFontUsed,
   notify: localMcpNotify,
-  getState: () => ({ ...localMcpBridgeState, lastFocusedElement: undefined }),
+  getState: () => ({
+    ...localMcpBridgeState,
+    localFontsEnabled: localMcpBridgeState.localFontsEnabled || localMcpLocalFontsWereEnabled(),
+    lastFocusedElement: undefined,
+  }),
 };
 window.slideStudioLocalMcpBridge = window.carouselBotLocalMcpBridge;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,6 +1241,35 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -1248,9 +1277,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/carouselbot": {
       "resolved": "packages/mcp",
       "link": true
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -1290,6 +1337,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -1366,6 +1419,29 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1426,6 +1502,12 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1459,6 +1541,12 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -1558,13 +1646,17 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/undici": {
       "version": "7.29.0",
@@ -1584,6 +1676,26 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/which": {
@@ -1717,10 +1829,11 @@
     },
     "packages/mcp": {
       "name": "carouselbot",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0",
+        "fontkit": "^2.0.4",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -1731,10 +1844,10 @@
       }
     },
     "packages/slides-studio-mcp": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "carouselbot": "0.2.0"
+        "carouselbot": "0.3.0"
       },
       "bin": {
         "slides-studio-mcp": "bin/cli.mjs"

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -36,6 +36,20 @@ Browser reconnection is automatic. Retry transient disconnects; use `restart` on
 
 The companion binds only to `127.0.0.1`. There is no hosted relay: projects remain in browser IndexedDB and local images remain on the user's computer.
 
+## Installed fonts
+
+CarouselBot can use fonts installed on the same Mac as the companion. Open a text layer's font control once and choose **Allow local fonts**. The permission is stored in that browser; until it is granted, agent calls return `FONT_PERMISSION_REQUIRED`.
+
+Agents use project-scoped IDs rather than CSS family guesses:
+
+```text
+list_local_fonts({ query: "Didot" })
+import_font({ editSessionId, projectId, localFontId })
+add_text({ editSessionId, projectId, slideId, text, fontId })
+```
+
+`list_project_fonts` reports faces already embedded in a project. `add_text` and `update_text` accept the returned `fontId`, plus optional `fontWeight`, `fontStyle`, and variable-axis settings. The companion returns opaque local font IDs and never exposes font paths. A selected face is transferred over the authenticated loopback connection, persisted only in the browser's local IndexedDB project, and loaded before fitting or rendering. If the exact bytes are missing or invalid, rendering reports `FONT_UNAVAILABLE` instead of silently using a fallback.
+
 Any MCP client can launch it with:
 
 ```bash

--- a/packages/mcp/guidance/design.md
+++ b/packages/mcp/guidance/design.md
@@ -20,6 +20,7 @@ Read this before creating or editing slides. Use it as a compact quality bar, th
 - Align related text layers consistently. Center is a safe default; use left alignment for editorial layouts.
 - Use rotation sparingly. Small intentional angles can add energy; arbitrary angles make carousels feel inconsistent.
 - Reuse a small palette and consistent type scale across the project.
+- For an installed Mac font, select an exact face with `list_local_fonts`, import its opaque ID with `import_font`, and apply only the returned project `fontId`. Reuse project faces through `list_project_fonts`; never guess family strings.
 
 ## Working method
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carouselbot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local-first MCP companion for the hosted CarouselBot editor",
   "type": "module",
   "license": "MIT",
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",
+    "fontkit": "^2.0.4",
     "zod": "^4.4.3"
   },
   "publishConfig": {

--- a/packages/mcp/skill/carouselbot/SKILL.md
+++ b/packages/mcp/skill/carouselbot/SKILL.md
@@ -46,6 +46,15 @@ With only one agent and one editor, the server can create an implicit session fo
 
 Inspect the assigned editor before editing and keep the returned IDs and revision. Work on the assigned project and slide. Pass `expectedRevision` for sensitive mutations. If `STALE_PROJECT` is returned, the browser has reloaded the canonical IndexedDB copy; inspect again and retry with current IDs. Prefer `apply_operations` for compact related changes while preserving logical order.
 
+When the user asks for a font installed on their Mac, use the deterministic two-ID flow:
+
+1. Call `list_local_fonts` with a family/style query and choose an exact face from its metadata. Never guess a CSS family or construct a `localFontId`.
+2. Call `import_font` with that opaque `localFontId`. Keep the returned project-scoped `fontId`.
+3. Pass the returned `fontId` to `add_text` or `update_text`. Import and application are separate calls for a newly selected face; do not invent a batch placeholder.
+4. Render and inspect the result. Use `list_project_fonts` to reuse faces already embedded in the project.
+
+If listing returns `FONT_PERMISSION_REQUIRED`, ask the user to open the real CarouselBot tab and choose **Allow local fonts** from the text font control, then retry. Do not bypass this with browser automation. Font paths and bytes are intentionally unavailable to agents. If rendering reports `FONT_UNAVAILABLE`, preserve the editable text, report the missing face, and ask the user to replace or re-import it rather than accepting fallback pixels.
+
 Use readable role-based type ranges: title `92–124`, subtitle `68–84`, body `54–68`, caption `44–52`. Do not solve dense copy by dropping below the body range; shorten it or split it across slides. `add_text` and `update_text` automatically preserve width and fit height around every wrapped line with safe padding. For highlighted text, prefer `style: "boxed"` with `backgroundShape: "lines"`. Use `backgroundShape: "full"` only for a deliberate card. Call `fit_text_boxes` with `mode: "both"` only when you intentionally want the width to shrink too.
 
 After each meaningful composition or after a short batch, call `render_slide` and inspect the returned image. Fix clipping, spacing, contrast, unsafe overlay placement, and weak hierarchy before claiming the slide is finished. Use `export_slide` or `export_project` only when local files are requested; do not overwrite existing files unless authorized.

--- a/packages/mcp/src/daemon.mjs
+++ b/packages/mcp/src/daemon.mjs
@@ -2,17 +2,21 @@
 import { createServer } from "node:http";
 import { randomBytes, randomUUID } from "node:crypto";
 import { appendFile, mkdir, open, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { basename, extname } from "node:path";
+import { basename, delimiter, extname } from "node:path";
 import {
   ALLOWED_ORIGINS, AUDIT_LOG_PATH, BRIDGE_HOST, BRIDGE_PORT, BRIDGE_URL, DAEMON_LOCK_PATH,
   DAEMON_STATE_PATH, PACKAGE_NAME, PACKAGE_VERSION, PROTOCOL_VERSION, STATE_DIRECTORY,
 } from "./config.mjs";
+import { createLocalFontService } from "./local-fonts.mjs";
 
 const MAX_JSON_BYTES = 40 * 1024 * 1024;
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
 const EDITOR_TTL_MS = Number(process.env.CAROUSELBOT_EDITOR_TTL_MS || process.env.SLIDE_STUDIO_EDITOR_TTL_MS) || 60_000;
 const CLIENT_TTL_MS = 45_000;
 const MEDIA_TTL_MS = 5 * 60_000;
+const FONT_MEDIA_TTL_MS = 5 * 60_000;
+const MAX_FONT_MEDIA_ITEMS = 32;
+const MAX_FONT_MEDIA_BYTES = 256 * 1024 * 1024;
 const COMMAND_TIMEOUT_MS = 90_000;
 const EDIT_SESSION_TTL_MS = Number(process.env.CAROUSELBOT_EDIT_SESSION_TTL_MS || process.env.SLIDE_STUDIO_EDIT_SESSION_TTL_MS) || 5 * 60_000;
 const MAX_AUDIT_EVENTS = 500;
@@ -24,8 +28,17 @@ const editors = new Map();
 const clients = new Map();
 const inflight = new Map();
 const media = new Map();
+const fontMedia = new Map();
 const editSessions = new Map();
 const auditEvents = [];
+const configuredFontDirectories = String(process.env.CAROUSELBOT_FONT_DIRS || process.env.SLIDE_STUDIO_FONT_DIRS || "")
+  .split(delimiter)
+  .map((value) => value.trim())
+  .filter(Boolean);
+const localFonts = createLocalFontService({
+  cacheDirectory: STATE_DIRECTORY,
+  ...(configuredFontDirectories.length ? { directories: configuredFontDirectories } : {}),
+});
 let focusedEditorId = null;
 let lockHandle = null;
 let idleSince = null;
@@ -189,7 +202,7 @@ function browserCors(origin) {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Authorization, Content-Type",
-    "Access-Control-Expose-Headers": "X-CarouselBot-Filename, X-Slide-Studio-Filename",
+    "Access-Control-Expose-Headers": "X-CarouselBot-Filename, X-Slide-Studio-Filename, X-CarouselBot-Local-Font-Id",
     "Access-Control-Allow-Private-Network": "true",
     "Access-Control-Max-Age": "600",
     "Cache-Control": "no-store",
@@ -201,6 +214,18 @@ function sendJson(response, statusCode, value, headers = {}) {
   const body = JSON.stringify(value);
   response.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8", "Content-Length": Buffer.byteLength(body), "Cache-Control": "no-store", ...headers });
   response.end(body);
+}
+
+function sendLocalFont(response, item, headers = {}) {
+  response.writeHead(200, {
+    ...headers,
+    "Content-Type": item.mimeType,
+    "Content-Length": item.buffer.length,
+    "X-CarouselBot-Filename": encodeURIComponent(item.filename),
+    "X-Slide-Studio-Filename": encodeURIComponent(item.filename),
+    "X-CarouselBot-Local-Font-Id": encodeURIComponent(item.font.localFontId),
+  });
+  response.end(item.buffer);
 }
 
 function readJson(request) {
@@ -269,6 +294,7 @@ function disconnectEditor(editorId, message = "Browser editor disconnected.") {
   endEditorPoll(editor);
   for (const session of editSessions.values()) if (session.editorId === editorId) releaseEditSession(session.id, "editor disconnected");
   editors.delete(editorId);
+  for (const [id, item] of fontMedia) if (item.editorId === editorId) fontMedia.delete(id);
   if (focusedEditorId === editorId) focusedEditorId = null;
   for (const [requestId, pending] of inflight) {
     if (pending.editorId !== editorId) continue;
@@ -303,6 +329,22 @@ function selectEditor(clientId) {
   if (connected.length === 1) return connected[0];
   if (!connected.length) throw new Error("No CarouselBot editor is connected. Open the editor and click Connect AI.");
   throw new Error("Multiple editors are connected and none is selected. Call list_editors, then select_editor.");
+}
+
+function requireLocalFontPermission(editor) {
+  if (editor?.localFontsEnabled) return editor;
+  throw codedError("FONT_PERMISSION_REQUIRED", "Open CarouselBot and enable local fonts.");
+}
+
+function selectLocalFontEditor(clientId) {
+  return requireLocalFontPermission(selectEditor(clientId));
+}
+
+function localFontEditorForCall(clientId, editSessionId) {
+  if (!editSessionId) return selectLocalFontEditor(clientId);
+  const session = requireEditSession(editSessionId);
+  session.lastClientId = clientId;
+  return requireLocalFontPermission(editors.get(session.editorId));
 }
 
 function resolveBrowserTarget(clientId, { editSessionId, mutating, projectId }) {
@@ -348,10 +390,21 @@ function callBrowser(clientId, toolName, operation, label, { editSessionId = nul
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       inflight.delete(requestId);
+      if (operation?.fontMediaId) fontMedia.delete(operation.fontMediaId);
       recordAudit({ action: "tool.result", client, session, editorId: editor.id, projectId, toolName, status: "error", message: "Browser timeout" });
       reject(codedError("BROWSER_TIMEOUT", "The browser did not answer within 90 seconds."));
     }, COMMAND_TIMEOUT_MS);
-    inflight.set(requestId, { resolve, reject, timer, editorId: editor.id, client, session, projectId, toolName });
+    inflight.set(requestId, {
+      resolve,
+      reject,
+      timer,
+      editorId: editor.id,
+      client,
+      session,
+      projectId,
+      toolName,
+      fontMediaId: operation?.fontMediaId || null,
+    });
     queueEditorEvent(editor, { kind: "command", requestId, toolName, operation, label, editSessionId: session?.id || null, agent: publicClient(client) });
   });
 }
@@ -380,6 +433,51 @@ async function prepareMedia(filePath) {
   const id = randomUUID();
   media.set(id, { id, buffer, mimeType, filename: basename(filePath), expiresAt: Date.now() + MEDIA_TTL_MS });
   return { mediaId: id, filename: basename(filePath), mimeType, size: buffer.length };
+}
+
+function localFontFilename(font, mimeType) {
+  const extension = ({
+    "font/ttf": "ttf",
+    "font/otf": "otf",
+    "font/woff": "woff",
+    "font/woff2": "woff2",
+  })[mimeType] || "font";
+  const stem = String(font?.postscriptName || font?.localFontId || "local-font")
+    .replace(/[^a-z0-9._-]+/gi, "-")
+    .replace(/^-+|-+$/g, "") || "local-font";
+  return `${stem}.${extension}`;
+}
+
+async function readLocalFontFace(localFontId) {
+  if (!localFontId || typeof localFontId !== "string") throw codedError("FONT_NOT_FOUND", "A valid localFontId is required.");
+  const prepared = await localFonts.readFace(localFontId);
+  if (!prepared?.font || !prepared?.buffer) throw codedError("FONT_NOT_FOUND", `Local font is unavailable: ${localFontId}`);
+  const buffer = Buffer.isBuffer(prepared.buffer) ? prepared.buffer : Buffer.from(prepared.buffer);
+  const mimeType = prepared.mimeType || "application/octet-stream";
+  return { font: prepared.font, buffer, mimeType, filename: localFontFilename(prepared.font, mimeType) };
+}
+
+async function prepareFont(clientId, localFontId, editSessionId) {
+  const editor = localFontEditorForCall(clientId, editSessionId);
+  const prepared = await readLocalFontFace(localFontId);
+  const now = Date.now();
+  let retainedBytes = 0;
+  for (const [id, item] of fontMedia) {
+    if (item.expiresAt < now) fontMedia.delete(id);
+    else retainedBytes += item.buffer.length;
+  }
+  if (fontMedia.size >= MAX_FONT_MEDIA_ITEMS || retainedBytes + prepared.buffer.length > MAX_FONT_MEDIA_BYTES) {
+    throw codedError("FONT_TRANSFER_LIMIT", "Too many local fonts are waiting to be transferred. Finish the pending imports and retry.");
+  }
+  const fontMediaId = randomUUID();
+  fontMedia.set(fontMediaId, {
+    ...prepared,
+    id: fontMediaId,
+    editorId: editor.id,
+    localFontId: prepared.font.localFontId,
+    expiresAt: now + FONT_MEDIA_TTL_MS,
+  });
+  return { font: prepared.font, fontMediaId };
 }
 
 async function writeExport(filePath, data, overwrite) {
@@ -430,6 +528,11 @@ async function handleInternalCall(body) {
     const events = auditEvents.filter((event) => (!body.projectId || event.projectId === body.projectId) && (!body.status || event.status === body.status));
     return { events: events.slice(-limit).reverse(), localLogPath: AUDIT_LOG_PATH };
   }
+  if (body.action === "list_local_fonts") {
+    localFontEditorForCall(body.clientId, body.editSessionId);
+    return localFonts.list({ query: body.query, limit: body.limit, cursor: body.cursor, sort: body.sort });
+  }
+  if (body.action === "prepare_font") return prepareFont(body.clientId, body.localFontId, body.editSessionId);
   if (body.action === "prepare_media") return prepareMedia(body.path);
   if (body.action === "write_export") return writeExport(body.path, body.data, Boolean(body.overwrite));
   if (body.action === "notify") {
@@ -518,12 +621,14 @@ const server = createServer(async (request, response) => {
       }
       const editor = {
         id: body.editorId, queue: [], poll: null, pageUrl: body.pageUrl,
-        pollTimer: null, state: body.state, lastSeen: Date.now(), cors, sessionToken: randomBytes(32).toString("base64url"),
+        pollTimer: null, state: body.state, lastSeen: Date.now(), cors,
+        localFontsEnabled: body.localFontsEnabled === true,
+        sessionToken: randomBytes(32).toString("base64url"),
       };
       editors.set(editor.id, editor);
       if (body.hasFocus && body.visibilityState === "visible") focusedEditorId = editor.id;
       log(`Editor connected (${editor.id.slice(0, 8)})`);
-      return sendJson(response, 200, { ok: true, editorId: editor.id, sessionToken: editor.sessionToken, protocolVersion: PROTOCOL_VERSION, version: PACKAGE_VERSION, agents: activeClients().map(publicClient), editSessions: activeEditSessions().map(publicSession) }, cors);
+      return sendJson(response, 200, { ok: true, editorId: editor.id, sessionToken: editor.sessionToken, protocolVersion: PROTOCOL_VERSION, version: PACKAGE_VERSION, localFontsEnabled: editor.localFontsEnabled, agents: activeClients().map(publicClient), editSessions: activeEditSessions().map(publicSession) }, cors);
     }
     if (url.pathname === "/activate" && request.method === "POST") {
       const body = await readJson(request);
@@ -544,6 +649,55 @@ const server = createServer(async (request, response) => {
       if (!editor) return;
       disconnectEditor(editor.id);
       return sendJson(response, 200, { ok: true, editorId: editor.id }, cors);
+    }
+    if (url.pathname === "/fonts/enable" && request.method === "POST") {
+      const body = await readJson(request);
+      const editor = requireEditor(request, response, body.editorId, cors);
+      if (!editor) return;
+      editor.localFontsEnabled = true;
+      return sendJson(response, 200, { enabled: true }, cors);
+    }
+    if (url.pathname === "/fonts" && request.method === "GET") {
+      const editor = requireEditor(request, response, url.searchParams.get("editorId"), cors);
+      if (!editor) return;
+      requireLocalFontPermission(editor);
+      const result = await localFonts.list({
+        query: url.searchParams.get("query") || "",
+        limit: url.searchParams.has("limit") ? Number(url.searchParams.get("limit")) : undefined,
+        cursor: url.searchParams.get("cursor") || null,
+        sort: url.searchParams.get("sort") || undefined,
+      });
+      return sendJson(response, 200, result, cors);
+    }
+    if (url.pathname === "/fonts/use" && request.method === "POST") {
+      const body = await readJson(request);
+      const editor = requireEditor(request, response, body.editorId, cors);
+      if (!editor) return;
+      requireLocalFontPermission(editor);
+      const font = await localFonts.markUsed(body.localFontId);
+      if (!font) throw codedError("FONT_NOT_FOUND", `Local font is unavailable: ${body.localFontId}`);
+      return sendJson(response, 200, { font }, cors);
+    }
+    if (url.pathname.startsWith("/fonts/") && request.method === "GET") {
+      const editor = requireEditor(request, response, url.searchParams.get("editorId"), cors);
+      if (!editor) return;
+      requireLocalFontPermission(editor);
+      const localFontId = decodeURIComponent(url.pathname.slice("/fonts/".length));
+      return sendLocalFont(response, await readLocalFontFace(localFontId), cors);
+    }
+    if (url.pathname.startsWith("/font-media/") && request.method === "GET") {
+      const editor = requireEditor(request, response, url.searchParams.get("editorId"), cors);
+      if (!editor) return;
+      requireLocalFontPermission(editor);
+      const id = decodeURIComponent(url.pathname.slice("/font-media/".length));
+      const item = fontMedia.get(id);
+      if (!item || item.expiresAt < Date.now()) {
+        fontMedia.delete(id);
+        throw codedError("FONT_MEDIA_UNAVAILABLE", "Local font transfer is missing or expired.");
+      }
+      if (item.editorId !== editor.id) throw codedError("FONT_MEDIA_UNAVAILABLE", "Local font transfer is missing or expired.");
+      fontMedia.delete(id);
+      return sendLocalFont(response, item, cors);
     }
     if (url.pathname === "/events" && request.method === "GET") {
       const editor = requireEditor(request, response, url.searchParams.get("editorId"), cors);
@@ -580,6 +734,7 @@ const server = createServer(async (request, response) => {
       if (!pending || pending.editorId !== editor.id) return sendJson(response, 404, { error: "Unknown request." }, cors);
       inflight.delete(body.requestId);
       clearTimeout(pending.timer);
+      if (pending.fontMediaId) fontMedia.delete(pending.fontMediaId);
       if (body.state) editor.state = body.state;
       if (body.ok) {
         try {
@@ -612,7 +767,11 @@ const server = createServer(async (request, response) => {
     return sendJson(response, 404, { error: "Not found." }, cors);
   } catch (error) {
     const headers = cors || {};
-    const statusCode = error.code === "ENOENT" ? 404 : error.code === "EACCES" ? 403 : 400;
+    const statusCode = ["ENOENT", "FONT_NOT_FOUND", "FONT_MEDIA_UNAVAILABLE"].includes(error.code)
+      ? 404
+      : ["EACCES", "FONT_PERMISSION_REQUIRED"].includes(error.code)
+        ? 403
+        : error.code === "FONT_TRANSFER_LIMIT" ? 429 : 400;
     return sendJson(response, statusCode, { error: error.message }, headers);
   }
 });
@@ -661,6 +820,7 @@ async function cleanup() {
 setInterval(() => {
   const now = Date.now();
   for (const [id, item] of media) if (item.expiresAt < now) media.delete(id);
+  for (const [id, item] of fontMedia) if (item.expiresAt < now) fontMedia.delete(id);
   for (const session of editSessions.values()) if (session.lastSeen < now - EDIT_SESSION_TTL_MS) releaseEditSession(session.id, "lease expired");
   let clientsChanged = false;
   for (const [id, client] of clients) if (client.lastSeen < now - CLIENT_TTL_MS) {

--- a/packages/mcp/src/local-fonts.mjs
+++ b/packages/mcp/src/local-fonts.mjs
@@ -1,0 +1,574 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, extname, join } from "node:path";
+import * as fontkit from "fontkit";
+
+const INDEX_VERSION = 1;
+const CURSOR_VERSION = 1;
+const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
+const MAX_FONT_FILE_BYTES = 256 * 1024 * 1024;
+const MAX_EXTRACTED_FONT_BYTES = 128 * 1024 * 1024;
+const MAX_DISCOVERED_FILES = 20_000;
+const MAX_COLLECTION_FACES = 512;
+const MAX_SFNT_TABLES = 4_096;
+const PUBLIC_FONT_KEYS = [
+  "localFontId",
+  "family",
+  "fullName",
+  "postscriptName",
+  "subfamily",
+  "weight",
+  "italic",
+  "lastUsedAt",
+  "variableAxes",
+];
+const FONT_EXTENSIONS = new Set([".ttf", ".otf", ".ttc", ".woff", ".woff2"]);
+const STYLE_WEIGHTS = [
+  [/\b(?:thin|hairline)\b/i, 100],
+  [/\b(?:extra[ -]?light|ultra[ -]?light)\b/i, 200],
+  [/\blight\b/i, 300],
+  [/\b(?:medium)\b/i, 500],
+  [/\b(?:semi[ -]?bold|demi[ -]?bold)\b/i, 600],
+  [/\b(?:extra[ -]?bold|ultra[ -]?bold)\b/i, 800],
+  [/\b(?:black|heavy)\b/i, 900],
+  [/\bbold\b/i, 700],
+];
+const STYLE_ORDER = [
+  /\bregular\b/i,
+  /\bbook\b/i,
+  /\bmedium\b/i,
+  /\b(?:semi[ -]?bold|demi[ -]?bold)\b/i,
+  /\bbold\b/i,
+];
+
+export function defaultMacFontDirectories() {
+  if (platform() !== "darwin") return [];
+  return [
+    join(homedir(), "Library", "Fonts"),
+    "/Library/Fonts",
+    "/System/Library/Fonts",
+    "/System/Library/Fonts/Supplemental",
+  ];
+}
+
+function codedError(code, message) {
+  const error = new Error(`[${code}] ${message}`);
+  error.code = code;
+  return error;
+}
+
+function sha256(value, encoding = "hex") {
+  return createHash("sha256").update(value).digest(encoding);
+}
+
+function usageGenerationFor(usage) {
+  return sha256(JSON.stringify([...usage.entries()].sort(([left], [right]) => left.localeCompare(right))), "base64url").slice(0, 24);
+}
+
+function stableFontId(pathInternal, faceIndex, size, mtimeMs) {
+  const identity = `${pathInternal}\0${faceIndex}\0${size}\0${mtimeMs}`;
+  return `font_${sha256(identity, "base64url").slice(0, 24)}`;
+}
+
+function cleanString(value, fallback = "") {
+  const normalized = String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240);
+  return normalized || fallback;
+}
+
+function inferredWeight(font, subfamily) {
+  const os2Weight = Number(font?.["OS/2"]?.usWeightClass);
+  if (Number.isFinite(os2Weight) && os2Weight >= 1 && os2Weight <= 1_000) return Math.round(os2Weight);
+  const variationWeight = Number(font?.variationAxes?.wght?.default);
+  if (Number.isFinite(variationWeight) && variationWeight >= 1 && variationWeight <= 1_000) return Math.round(variationWeight);
+  const match = STYLE_WEIGHTS.find(([pattern]) => pattern.test(subfamily));
+  return match?.[1] || 400;
+}
+
+function variableAxes(font) {
+  return Object.entries(font?.variationAxes || {}).flatMap(([rawTag, value]) => {
+    const tag = cleanString(rawTag).slice(0, 4);
+    const min = Number(value?.min);
+    const max = Number(value?.max);
+    const defaultValue = Number(value?.default);
+    if (!/^[\x20-\x7e]{4}$/.test(tag) || ![min, max, defaultValue].every(Number.isFinite) || min > max) return [];
+    return [{
+      tag,
+      name: cleanString(value?.name, tag),
+      min,
+      max,
+      default: Math.min(max, Math.max(min, defaultValue)),
+    }];
+  }).sort((left, right) => left.tag.localeCompare(right.tag, "en"));
+}
+
+function metadataForFont(font, source, faceIndex) {
+  const postscriptName = cleanString(font?.postscriptName);
+  const fullName = cleanString(font?.fullName, postscriptName);
+  const family = cleanString(font?.familyName, fullName || postscriptName || "Unknown font");
+  const subfamily = cleanString(font?.subfamilyName, "Regular");
+  const fsSelection = font?.["OS/2"]?.fsSelection || {};
+  const italic = Boolean(fsSelection.italic || fsSelection.oblique || Number(font?.italicAngle));
+  const localFontId = stableFontId(source.pathInternal, faceIndex, source.size, source.mtimeMs);
+  return {
+    localFontId,
+    family,
+    fullName: fullName || family,
+    postscriptName: postscriptName || fullName || family,
+    sourcePostscriptName: postscriptName || null,
+    subfamily,
+    weight: inferredWeight(font, subfamily),
+    italic,
+    variableAxes: variableAxes(font),
+    pathInternal: source.pathInternal,
+    faceIndex,
+    size: source.size,
+    mtimeMs: source.mtimeMs,
+    fileFingerprint: source.fileFingerprint,
+    fingerprint: sha256(`${source.fileFingerprint}\0${faceIndex}\0${postscriptName}`),
+    extension: source.extension,
+  };
+}
+
+function publicFont(font, usage) {
+  const value = {
+    localFontId: font.localFontId,
+    family: font.family,
+    fullName: font.fullName,
+    postscriptName: font.postscriptName,
+    subfamily: font.subfamily,
+    weight: font.weight,
+    italic: Boolean(font.italic),
+    lastUsedAt: usage.get(font.localFontId) || null,
+    variableAxes: Array.isArray(font.variableAxes) ? font.variableAxes.map((axis) => ({ ...axis })) : [],
+  };
+  return Object.fromEntries(PUBLIC_FONT_KEYS.map((key) => [key, value[key]]));
+}
+
+function styleRank(font) {
+  const style = `${font.subfamily} ${font.italic ? "Italic" : ""}`;
+  const base = STYLE_ORDER.findIndex((pattern) => pattern.test(style));
+  return (font.italic ? 100 : 0) + (base < 0 ? 5 : base);
+}
+
+const collator = new Intl.Collator("en", { sensitivity: "base", numeric: true });
+
+function alphabetical(left, right) {
+  return collator.compare(left.family, right.family)
+    || styleRank(left) - styleRank(right)
+    || collator.compare(left.subfamily, right.subfamily)
+    || collator.compare(left.fullName, right.fullName)
+    || left.localFontId.localeCompare(right.localFontId);
+}
+
+function normalizedQuery(value) {
+  return cleanString(value).normalize("NFKC").toLocaleLowerCase("en-US").slice(0, 240);
+}
+
+function cursorValue(value) {
+  try {
+    if (typeof value !== "string" || !value || value.length > 2_048) throw new Error("invalid");
+    const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (decoded?.v !== CURSOR_VERSION || !Number.isInteger(decoded.offset) || decoded.offset < 0) throw new Error("invalid");
+    return decoded;
+  } catch {
+    throw codedError("INVALID_FONT_CURSOR", "The local-font cursor is invalid or expired. Start listing again without a cursor.");
+  }
+}
+
+function encodeCursor(value) {
+  return Buffer.from(JSON.stringify({ v: CURSOR_VERSION, ...value })).toString("base64url");
+}
+
+async function readJson(path) {
+  if (!path) return null;
+  try { return JSON.parse(await readFile(path, "utf8")); }
+  catch { return null; }
+}
+
+async function writePrivateJson(path, value) {
+  if (!path) return;
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+    await chmod(path, 0o600).catch(() => {});
+  } finally {
+    await unlink(temporary).catch(() => {});
+  }
+}
+
+async function fontPaths(directories) {
+  const roots = [];
+  for (const candidate of directories) {
+    try { roots.push(await realpath(candidate)); }
+    catch { /* Missing font roots are normal. */ }
+  }
+  roots.sort();
+  const discovered = new Map();
+  const pending = [...new Set(roots)];
+  while (pending.length) {
+    const directory = pending.shift();
+    let entries;
+    try { entries = await readdir(directory, { withFileTypes: true }); }
+    catch { continue; }
+    entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(path);
+        continue;
+      }
+      if (!entry.isFile() || !FONT_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+      let canonical;
+      let metadata;
+      try {
+        canonical = await realpath(path);
+        metadata = await stat(canonical);
+      } catch { continue; }
+      if (!metadata.isFile() || metadata.size <= 0 || metadata.size > MAX_FONT_FILE_BYTES) continue;
+      discovered.set(canonical, {
+        pathInternal: canonical,
+        size: metadata.size,
+        mtimeMs: Number(metadata.mtimeMs),
+        extension: extname(canonical).toLowerCase(),
+      });
+      if (discovered.size > MAX_DISCOVERED_FILES) {
+        throw codedError("FONT_INDEX_TOO_LARGE", "Too many local font files were found to index safely.");
+      }
+    }
+  }
+  return [...discovered.values()].sort((left, right) => left.pathInternal.localeCompare(right.pathInternal));
+}
+
+async function readFileSafely(pathInternal) {
+  const flags = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW || 0);
+  const handle = await open(pathInternal, flags);
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size <= 0 || metadata.size > MAX_FONT_FILE_BYTES) {
+      throw codedError("FONT_UNAVAILABLE", "The selected local font is unavailable or too large.");
+    }
+    return { buffer: await handle.readFile(), metadata };
+  } finally {
+    await handle.close();
+  }
+}
+
+function mimeTypeFor(buffer, extension = "") {
+  const signature = buffer.subarray(0, 4).toString("latin1");
+  if (signature === "wOF2") return "font/woff2";
+  if (signature === "wOFF") return "font/woff";
+  if (signature === "OTTO") return "font/otf";
+  if (["\u0000\u0001\u0000\u0000", "true", "typ1"].includes(signature)) return "font/ttf";
+  if (extension === ".woff2") return "font/woff2";
+  if (extension === ".woff") return "font/woff";
+  if (extension === ".otf") return "font/otf";
+  return "font/ttf";
+}
+
+function checksum(buffer) {
+  let sum = 0;
+  for (let offset = 0; offset < buffer.length; offset += 4) {
+    let word = 0;
+    for (let index = 0; index < 4; index += 1) word = ((word << 8) | (buffer[offset + index] || 0)) >>> 0;
+    sum = (sum + word) >>> 0;
+  }
+  return sum;
+}
+
+function checkedRange(buffer, offset, length, label) {
+  if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0 || offset + length > buffer.length) {
+    throw codedError("INVALID_FONT_COLLECTION", `The selected collection has an invalid ${label}.`);
+  }
+}
+
+function align4(value) {
+  return Math.ceil(value / 4) * 4;
+}
+
+/** Repack one TTC/OTC face as a standalone, browser-loadable SFNT font. */
+export function extractTtcFace(value, faceIndex) {
+  const source = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  checkedRange(source, 0, 12, "header");
+  if (source.subarray(0, 4).toString("ascii") !== "ttcf") {
+    throw codedError("INVALID_FONT_COLLECTION", "The selected font is not a TrueType/OpenType collection.");
+  }
+  const faceCount = source.readUInt32BE(8);
+  if (!faceCount || faceCount > MAX_COLLECTION_FACES) throw codedError("INVALID_FONT_COLLECTION", "The collection has an invalid face count.");
+  if (!Number.isInteger(faceIndex) || faceIndex < 0 || faceIndex >= faceCount) {
+    throw codedError("FONT_FACE_NOT_FOUND", `Font face ${faceIndex} does not exist in this collection.`);
+  }
+  checkedRange(source, 12, faceCount * 4, "face directory");
+  const faceOffset = source.readUInt32BE(12 + faceIndex * 4);
+  checkedRange(source, faceOffset, 12, "face header");
+  const sfntVersion = source.subarray(faceOffset, faceOffset + 4);
+  const signature = sfntVersion.toString("latin1");
+  if (!["\u0000\u0001\u0000\u0000", "true", "typ1", "OTTO"].includes(signature)) {
+    throw codedError("INVALID_FONT_COLLECTION", "The selected collection face is not an SFNT font.");
+  }
+  const tableCount = source.readUInt16BE(faceOffset + 4);
+  if (!tableCount || tableCount > MAX_SFNT_TABLES) throw codedError("INVALID_FONT_COLLECTION", "The collection face has an invalid table count.");
+  checkedRange(source, faceOffset + 12, tableCount * 16, "table directory");
+  const records = [];
+  const tags = new Set();
+  for (let index = 0; index < tableCount; index += 1) {
+    const recordOffset = faceOffset + 12 + index * 16;
+    const tagBytes = source.subarray(recordOffset, recordOffset + 4);
+    const tag = tagBytes.toString("latin1");
+    const offset = source.readUInt32BE(recordOffset + 8);
+    const length = source.readUInt32BE(recordOffset + 12);
+    checkedRange(source, offset, length, `table ${JSON.stringify(tag)}`);
+    if (tags.has(tag)) throw codedError("INVALID_FONT_COLLECTION", "The collection face contains duplicate table tags.");
+    tags.add(tag);
+    if (tag !== "DSIG") records.push({ tag, tagBytes: Buffer.from(tagBytes), offset, length });
+  }
+  const head = records.find((record) => record.tag === "head");
+  if (!head || head.length < 12) throw codedError("INVALID_FONT_COLLECTION", "The collection face has no valid head table.");
+
+  let outputLength = 12 + records.length * 16;
+  for (const record of records) {
+    outputLength = align4(outputLength);
+    record.outputOffset = outputLength;
+    outputLength += align4(record.length);
+    if (outputLength > MAX_EXTRACTED_FONT_BYTES) throw codedError("FONT_TOO_LARGE", "The selected font face is too large to transfer safely.");
+  }
+  const output = Buffer.alloc(outputLength);
+  sfntVersion.copy(output, 0);
+  output.writeUInt16BE(records.length, 4);
+  const highestPowerOfTwo = 2 ** Math.floor(Math.log2(records.length));
+  output.writeUInt16BE(highestPowerOfTwo * 16, 6);
+  output.writeUInt16BE(Math.log2(highestPowerOfTwo), 8);
+  output.writeUInt16BE(records.length * 16 - highestPowerOfTwo * 16, 10);
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    source.copy(output, record.outputOffset, record.offset, record.offset + record.length);
+    if (record.tag === "head") output.writeUInt32BE(0, record.outputOffset + 8);
+    const directoryOffset = 12 + index * 16;
+    record.tagBytes.copy(output, directoryOffset);
+    output.writeUInt32BE(checksum(output.subarray(record.outputOffset, record.outputOffset + record.length)), directoryOffset + 4);
+    output.writeUInt32BE(record.outputOffset, directoryOffset + 8);
+    output.writeUInt32BE(record.length, directoryOffset + 12);
+  }
+  const adjustment = (0xb1b0afba - checksum(output)) >>> 0;
+  output.writeUInt32BE(adjustment, head.outputOffset + 8);
+  if (checksum(output) !== 0xb1b0afba) throw codedError("INVALID_FONT_COLLECTION", "The extracted font checksum could not be repaired.");
+  return output;
+}
+
+function safeFilename(font, mimeType) {
+  const extension = mimeType === "font/woff2" ? ".woff2" : mimeType === "font/woff" ? ".woff" : mimeType === "font/otf" ? ".otf" : ".ttf";
+  const stem = cleanString(font.postscriptName || font.fullName || "local-font", "local-font")
+    .replace(/[^a-z0-9._-]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120) || "local-font";
+  return `${stem}${extension}`;
+}
+
+export function createLocalFontService({
+  directories = defaultMacFontDirectories(),
+  cacheDirectory = null,
+  cachePath = cacheDirectory ? join(cacheDirectory, "local-font-index-v1.json") : null,
+  usagePath = cacheDirectory ? join(cacheDirectory, "local-font-usage-v1.json") : null,
+  refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS,
+  now = () => Date.now(),
+} = {}) {
+  let records = new Map();
+  let files = [];
+  let generation = "empty";
+  let initialized = false;
+  let lastRefreshAt = -Infinity;
+  let refreshPromise = null;
+  let usagePromise = null;
+  let usage = new Map();
+  let usageGeneration = usageGenerationFor(usage);
+  let usageWrite = Promise.resolve();
+
+  async function loadUsage() {
+    if (usagePromise) return usagePromise;
+    usagePromise = (async () => {
+      const cached = await readJson(usagePath);
+      usage = new Map(Object.entries(cached?.usage || {}).flatMap(([id, timestamp]) => (
+        /^font_[A-Za-z0-9_-]{8,}$/.test(id) && Number.isFinite(Number(timestamp)) && Number(timestamp) > 0
+          ? [[id, Number(timestamp)]]
+          : []
+      )));
+      usageGeneration = usageGenerationFor(usage);
+      return usage;
+    })();
+    return usagePromise;
+  }
+
+  async function buildIndex() {
+    const candidates = await fontPaths(directories);
+    const cached = await readJson(cachePath);
+    const cachedFiles = new Map((cached?.version === INDEX_VERSION && Array.isArray(cached.files) ? cached.files : [])
+      .map((file) => [file.pathInternal, file]));
+    const nextFiles = [];
+    const seenFingerprints = new Set();
+    const nextRecords = new Map();
+    for (const candidate of candidates) {
+      const previous = cachedFiles.get(candidate.pathInternal);
+      let indexed;
+      if (previous && previous.size === candidate.size && previous.mtimeMs === candidate.mtimeMs && previous.extension === candidate.extension) {
+        indexed = previous;
+      } else {
+        try {
+          const { buffer } = await readFileSafely(candidate.pathInternal);
+          const fileFingerprint = sha256(buffer);
+          const parsed = fontkit.create(buffer);
+          const parsedFaces = Array.isArray(parsed?.fonts) ? parsed.fonts : [parsed];
+          if (!parsedFaces.length || parsedFaces.length > MAX_COLLECTION_FACES) throw new Error("Invalid face count");
+          const source = { ...candidate, fileFingerprint };
+          indexed = {
+            ...candidate,
+            fileFingerprint,
+            faces: parsedFaces.map((font, faceIndex) => metadataForFont(font, source, faceIndex)),
+          };
+        } catch {
+          indexed = { ...candidate, fileFingerprint: null, faces: [], invalid: true };
+        }
+      }
+      nextFiles.push(indexed);
+      if (!indexed.fileFingerprint || seenFingerprints.has(indexed.fileFingerprint)) continue;
+      seenFingerprints.add(indexed.fileFingerprint);
+      for (const face of indexed.faces || []) nextRecords.set(face.localFontId, face);
+    }
+    files = nextFiles;
+    records = nextRecords;
+    generation = sha256([...records.keys()].sort().join("\0"), "base64url").slice(0, 24);
+    lastRefreshAt = now();
+    initialized = true;
+    await writePrivateJson(cachePath, { version: INDEX_VERSION, generatedAt: lastRefreshAt, files });
+    return records;
+  }
+
+  async function refresh({ force = false } = {}) {
+    if (!force && initialized && now() - lastRefreshAt < refreshIntervalMs) return records;
+    if (!refreshPromise) refreshPromise = buildIndex().finally(() => { refreshPromise = null; });
+    return refreshPromise;
+  }
+
+  async function list({ query = "", limit = 50, cursor = null, sort = "recent_then_alphabetical" } = {}) {
+    await Promise.all([refresh(), loadUsage()]);
+    const safeQuery = normalizedQuery(query);
+    const safeSort = sort === "alphabetical" ? "alphabetical" : "recent_then_alphabetical";
+    const safeLimit = Math.max(1, Math.min(200, Number.isFinite(Number(limit)) ? Math.trunc(Number(limit)) : 50));
+    let offset = 0;
+    if (cursor) {
+      const decoded = cursorValue(cursor);
+      if (
+        decoded.generation !== generation
+        || decoded.query !== safeQuery
+        || decoded.sort !== safeSort
+        || (safeSort === "recent_then_alphabetical" && decoded.usageGeneration !== usageGeneration)
+      ) {
+        throw codedError("INVALID_FONT_CURSOR", "The local-font cursor is invalid or expired. Start listing again without a cursor.");
+      }
+      offset = decoded.offset;
+    }
+    let matches = [...records.values()].filter((font) => {
+      if (!safeQuery) return true;
+      return [font.family, font.fullName, font.postscriptName, font.subfamily]
+        .some((value) => normalizedQuery(value).includes(safeQuery));
+    });
+    if (safeSort === "alphabetical") matches.sort(alphabetical);
+    else {
+      const recent = matches
+        .filter((font) => usage.has(font.localFontId))
+        .sort((left, right) => usage.get(right.localFontId) - usage.get(left.localFontId) || alphabetical(left, right))
+        .slice(0, 8);
+      const recentIds = new Set(recent.map((font) => font.localFontId));
+      matches = [...recent, ...matches.filter((font) => !recentIds.has(font.localFontId)).sort(alphabetical)];
+    }
+    const page = matches.slice(offset, offset + safeLimit);
+    const nextOffset = offset + page.length;
+    return {
+      fonts: page.map((font) => publicFont(font, usage)),
+      nextCursor: nextOffset < matches.length
+        ? encodeCursor({
+          generation,
+          query: safeQuery,
+          sort: safeSort,
+          offset: nextOffset,
+          ...(safeSort === "recent_then_alphabetical" ? { usageGeneration } : {}),
+        })
+        : null,
+    };
+  }
+
+  async function resolve(localFontId) {
+    await Promise.all([refresh(), loadUsage()]);
+    const font = records.get(String(localFontId || ""));
+    return font ? { ...font, lastUsedAt: usage.get(font.localFontId) || null } : null;
+  }
+
+  async function readFace(localFontId) {
+    let font = await resolve(localFontId);
+    if (!font) return null;
+    let read;
+    try { read = await readFileSafely(font.pathInternal); }
+    catch {
+      await refresh({ force: true });
+      throw codedError("FONT_UNAVAILABLE", `${font.fullName} is not available on this device.`);
+    }
+    const currentMtime = Number(read.metadata.mtimeMs);
+    const currentFingerprint = sha256(read.buffer);
+    if (read.metadata.size !== font.size || currentMtime !== font.mtimeMs || currentFingerprint !== font.fileFingerprint) {
+      await refresh({ force: true });
+      throw codedError("FONT_UNAVAILABLE", `${font.fullName} changed on this device. List local fonts again and use its new ID.`);
+    }
+    let buffer = read.buffer;
+    if (buffer.subarray(0, 4).toString("ascii") === "ttcf") buffer = extractTtcFace(buffer, font.faceIndex);
+    const mimeType = mimeTypeFor(buffer, font.extension);
+    try {
+      const parsed = fontkit.create(buffer);
+      if (Array.isArray(parsed?.fonts) || (font.sourcePostscriptName && cleanString(parsed?.postscriptName) !== font.sourcePostscriptName)) {
+        throw new Error("Extracted face mismatch");
+      }
+    } catch {
+      throw codedError("FONT_UNAVAILABLE", `${font.fullName} could not be prepared for the browser.`);
+    }
+    return {
+      font: publicFont(font, usage),
+      buffer,
+      mimeType,
+      filename: safeFilename(font, mimeType),
+    };
+  }
+
+  async function markUsed(localFontId, at = now()) {
+    await Promise.all([refresh(), loadUsage()]);
+    const font = records.get(String(localFontId || ""));
+    if (!font) return null;
+    const timestamp = Number.isFinite(Number(at)) && Number(at) > 0 ? Number(at) : now();
+    usage.set(font.localFontId, timestamp);
+    usageGeneration = usageGenerationFor(usage);
+    usageWrite = usageWrite.then(() => writePrivateJson(usagePath, {
+      version: INDEX_VERSION,
+      usage: Object.fromEntries([...usage.entries()].sort(([left], [right]) => left.localeCompare(right))),
+    }));
+    await usageWrite;
+    return publicFont(font, usage);
+  }
+
+  return { list, resolve, readFace, markUsed, refresh };
+}

--- a/packages/mcp/src/mcp-server.mjs
+++ b/packages/mcp/src/mcp-server.mjs
@@ -13,12 +13,17 @@ const expectedRevision = z.number().int().min(0).optional().describe("Optional o
 const editSessionId = optionalId.describe("Edit session from begin_edit_session. Required for coordinated parallel editing.");
 const targetProject = { editSessionId, projectId: optionalId, expectedRevision };
 const targetSlide = { editSessionId, projectId: optionalId, slideId: optionalId, expectedRevision };
+const fontId = z.union([id, z.null()]).optional().describe("Project font ID returned by import_font. Use null to restore the built-in font.");
 const textFields = {
   text: z.string().max(4000).optional(), x: unit.optional(), y: unit.optional(), width: positiveUnit.optional(), height: positiveUnit.optional(),
   role: z.enum(["title", "subtitle", "body", "caption"]).optional().describe("Semantic size role. Recommended ranges: title 92-124, subtitle 68-84, body 54-68, caption 44-52."),
   size: z.number().min(20).max(180).optional(), style: z.enum(["plain", "outline", "boxed"]).optional(),
   outlineWidth: z.number().min(0).max(40).optional(), color: color.optional(), background: z.enum(["white", "black"]).optional(),
   backgroundShape: z.enum(["lines", "full"]).optional(), align: z.enum(["left", "center", "right"]).optional(),
+  fontId,
+  fontWeight: z.number().int().min(1).max(1000).optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
+  fontVariationSettings: z.record(z.string().regex(/^[A-Za-z0-9]{4}$/), z.number()).optional(),
   rotation: z.number().min(-720).max(720).optional(), z: z.number().optional(),
 };
 const imageFields = {
@@ -35,7 +40,7 @@ function textResult(value, summary = value) {
 }
 
 function compactMutation(value) {
-  const keys = ["id", "editSessionId", "editorId", "projectId", "slideId", "revision", "leaseExpiresAt", "purpose", "released", "opened", "createdSlideId", "createdTextId", "fittedTextBox", "createdImageId", "createdLayers", "assetId", "deletedAssetId", "deletedProjectId", "deletedSlideId", "deletedLayerIds", "updatedTextIds", "fittedTextBoxes", "updatedImageIds", "applied", "path", "bytes"];
+  const keys = ["id", "editSessionId", "editorId", "projectId", "slideId", "revision", "leaseExpiresAt", "purpose", "released", "opened", "createdSlideId", "createdTextId", "fittedTextBox", "createdImageId", "createdLayers", "assetId", "fontId", "localFontId", "existing", "repaired", "deletedAssetId", "deletedProjectId", "deletedSlideId", "deletedLayerIds", "updatedTextIds", "fittedTextBoxes", "updatedImageIds", "applied", "path", "bytes"];
   return Object.fromEntries(keys.flatMap((key) => value?.[key] == null ? [] : [[key, value[key]]]));
 }
 
@@ -56,7 +61,7 @@ function operationLabel(toolName) {
     create_project: "Creating a project…", update_project: "Updating the project…", delete_project: "Deleting a project…",
     open_project: "Opening a project…", add_slide: "Adding a slide…", update_slide: "Updating a slide…",
     duplicate_slide: "Duplicating a slide…", reorder_slides: "Reordering slides…", delete_slide: "Deleting a slide…",
-    add_text: "Adding text…", update_text: "Updating text…", fit_text_boxes: "Fitting text boxes…", import_asset: "Importing a local image…",
+    add_text: "Adding text…", update_text: "Updating text…", fit_text_boxes: "Fitting text boxes…", import_font: "Adding a local font…", import_asset: "Importing a local image…",
     update_asset: "Updating an image asset…", delete_asset: "Deleting an image asset…", add_image: "Placing an image…",
     update_image: "Updating an image…", delete_layers: "Deleting layers…", duplicate_layers: "Duplicating layers…",
     reorder_layers: "Reordering layers…", undo: "Undoing the last edit…", redo: "Redoing the last edit…",
@@ -67,11 +72,11 @@ function operationLabel(toolName) {
 async function browserOperation(companion, toolName, args) {
   const { editSessionId: sessionId, ...toolArgs } = args;
   const definition = definitions.get(toolName);
-  const operation = await prepareOperation(companion, toolName, toolArgs);
+  const operation = await prepareOperation(companion, toolName, toolArgs, sessionId);
   return companion.call("browser", { toolName, operation, label: operationLabel(toolName), editSessionId: sessionId, mutating: Boolean(definition?.mutating) });
 }
 
-async function prepareOperation(companion, toolName, args) {
+async function prepareOperation(companion, toolName, args, editSessionId = null) {
   const operation = { ...args };
   if (operation.backgroundPath) {
     const prepared = await companion.call("prepare_media", { path: absolutePath(operation.backgroundPath) });
@@ -83,10 +88,15 @@ async function prepareOperation(companion, toolName, args) {
     operation.mediaId = prepared.mediaId;
     delete operation.path;
   }
+  if (toolName === "import_font") {
+    const prepared = await companion.call("prepare_font", { localFontId: operation.localFontId, editSessionId });
+    operation.font = prepared.font;
+    operation.fontMediaId = prepared.fontMediaId;
+  }
   const type = ({
     create_project: "project.create", open_project: "project.open", update_project: "project.update", delete_project: "project.delete",
     add_slide: "slide.add", update_slide: "slide.update", duplicate_slide: "slide.duplicate", reorder_slides: "slide.reorder", delete_slide: "slide.delete",
-    add_text: "text.add", update_text: "text.update", fit_text_boxes: "text.fit", import_asset: "asset.import", update_asset: "asset.update", delete_asset: "asset.delete",
+    add_text: "text.add", update_text: "text.update", fit_text_boxes: "text.fit", import_font: "font.import", list_project_fonts: "font.list", import_asset: "asset.import", update_asset: "asset.update", delete_asset: "asset.delete",
     add_image: "image.add", update_image: "image.update", delete_layers: "layer.delete", duplicate_layers: "layer.duplicate", reorder_layers: "layer.reorder",
     undo: "history.undo", redo: "history.redo", set_view: "view.update", render_slide: "slide.render", inspect_editor: "editor.inspect",
   })[toolName];
@@ -151,6 +161,8 @@ export async function createCarouselBotMcpServer(companion) {
   register("list_edit_sessions", "List active edit reservations, their owners, projects, and lease expirations.", z.object({}).strict(), () => companion.call("list_edit_sessions"), { readOnlyHint: true });
   register("list_recent_operations", "Read the local sanitized operation audit. Text, prompts, paths, and image bytes are never logged.", z.object({ limit: z.number().int().min(1).max(200).default(50), projectId: optionalId, status: z.enum(["started", "ok", "error", "blocked"]).optional() }).strict(), (args) => companion.call("list_recent_operations", args), { readOnlyHint: true });
   register("inspect_editor", "Inspect projects, slides, assets, and every text/image layer without returning image bytes.", z.object({ ...targetSlide, includeAllProjects: z.boolean().default(true) }).strict(), (args) => browserOperation(companion, "inspect_editor", args), { readOnlyHint: true });
+  register("list_local_fonts", "Search fonts installed on this computer. Returns opaque local font IDs and never filesystem paths. The user must enable local fonts in CarouselBot first.", z.object({ editSessionId, query: z.string().max(200).optional(), limit: z.number().int().min(1).max(200).default(80), cursor: z.string().max(2048).optional(), sort: z.enum(["recent_then_alphabetical", "alphabetical"]).default("recent_then_alphabetical") }).strict(), (args) => companion.call("list_local_fonts", args), { readOnlyHint: true });
+  register("list_project_fonts", "List fonts already imported into one project, including whether each face is currently available.", z.object({ ...targetProject, projectId: id }).strict(), (args) => browserOperation(companion, "list_project_fonts", args), { readOnlyHint: true });
   register("show_notification", "Show a short visual notification in a connected editor for status or marketing demos.", z.object({ editSessionId, message: z.string().min(1).max(240), tone: z.enum(["agent", "success", "info", "error"]).default("agent") }).strict(), ({ editSessionId, ...args }) => companion.call("notify", { ...args, editSessionId }), { destructiveHint: false, idempotentHint: false });
 
   register("create_project", "Create an empty project without changing the user's current browser view. Its dashboard card appears live when the dashboard is open.", z.object({ editSessionId, name: z.string().min(1).max(160) }).strict(), (args) => browserOperation(companion, "create_project", args), { destructiveHint: false });
@@ -167,6 +179,7 @@ export async function createCarouselBotMcpServer(companion) {
   register("add_text", "Add a text layer. Choose a semantic role and a size within its readable range. Width is preserved while height is fitted automatically with safe padding; boxed text defaults to the preferred per-line background.", z.object({ ...targetSlide, ...textFields, text: z.string().min(1).max(4000) }).strict(), (args) => browserOperation(companion, "add_text", args), { destructiveHint: false });
   register("update_text", "Update one or more text layers. Every updated layer automatically keeps its width and refits its height with safe padding, so a render-fit-render loop is unnecessary.", z.object({ ...targetSlide, updates: z.array(z.object({ id, ...textFields }).strict()).min(1).max(100) }).strict(), (args) => browserOperation(companion, "update_text", args), { destructiveHint: true });
   register("fit_text_boxes", "Explicitly resize text boxes to their rendered content. add_text and update_text already fit height automatically; use mode=both only when you also want to shrink width.", z.object({ ...targetSlide, textIds: z.array(id).min(1).max(100), mode: z.enum(["height", "both"]).default("both") }).strict(), (args) => browserOperation(companion, "fit_text_boxes", args), { destructiveHint: true });
+  register("import_font", "Add one installed font face to a project using a localFontId returned by list_local_fonts. Exact face bytes remain on this computer and duplicate imports are reused.", z.object({ ...targetProject, projectId: id, localFontId: id }).strict(), (args) => browserOperation(companion, "import_font", args), { destructiveHint: false });
 
   register("import_asset", "Import a local image file into the active project's reusable asset library. Image bytes stay local.", z.object({ ...targetSlide, path: z.string().min(1), name: z.string().max(160).optional() }).strict(), (args) => browserOperation(companion, "import_asset", args), { destructiveHint: false });
   register("update_asset", "Rename a reusable image asset.", z.object({ ...targetProject, assetId: id, name: z.string().min(1).max(160) }).strict(), (args) => browserOperation(companion, "update_asset", args), { destructiveHint: true });
@@ -220,7 +233,7 @@ export async function createCarouselBotMcpServer(companion) {
       if (!definition?.mutating) throw new Error(`Tool cannot be batched: ${item.tool}`);
       const args = definition.inputSchema.parse(item.arguments);
       const { editSessionId: _ignored, ...toolArgs } = args;
-      items.push({ toolName: item.tool, operation: await prepareOperation(companion, item.tool, toolArgs), label: operationLabel(item.tool) });
+      items.push({ toolName: item.tool, operation: await prepareOperation(companion, item.tool, toolArgs, sessionId), label: operationLabel(item.tool) });
     }
     return companion.call("batch", { items, editSessionId: sessionId });
   }, { destructiveHint: true });

--- a/packages/mcp/test/font-tools.test.mjs
+++ b/packages/mcp/test/font-tools.test.mjs
@@ -1,0 +1,375 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { InMemoryTransport } from "@modelcontextprotocol/server";
+import { createCarouselBotMcpServer } from "../src/mcp-server.mjs";
+
+const PUBLIC_LOCAL_FONT = {
+  localFontId: "local-didot-regular",
+  family: "Didot",
+  fullName: "Didot",
+  postscriptName: "Didot",
+  subfamily: "Regular",
+  weight: 400,
+  italic: false,
+  lastUsedAt: 0,
+  variableAxes: [],
+};
+
+function createCompanion(handler = async () => ({})) {
+  const calls = [];
+  return {
+    calls,
+    async identify(name, version) {
+      calls.push({ method: "identify", name, version });
+    },
+    async call(action, args = {}) {
+      calls.push({ method: "call", action, args });
+      return handler(action, args, calls);
+    },
+  };
+}
+
+async function createHarness(companion) {
+  const server = await createCarouselBotMcpServer(companion);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const pending = new Map();
+  let id = 0;
+  clientTransport.onmessage = (message) => {
+    const resolve = pending.get(message.id);
+    if (!resolve) return;
+    pending.delete(message.id);
+    resolve(message);
+  };
+  await server.connect(serverTransport);
+  await clientTransport.start();
+
+  const request = async (method, params = {}) => {
+    const requestId = ++id;
+    const response = new Promise((resolve) => pending.set(requestId, resolve));
+    await clientTransport.send({ jsonrpc: "2.0", id: requestId, method, params });
+    return response;
+  };
+  const notify = (method, params = {}) => clientTransport.send({ jsonrpc: "2.0", method, params });
+
+  const initialized = await request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "font-tools-test", version: "1" },
+  });
+  assert.equal(initialized.result.serverInfo.name, "carouselbot");
+  await notify("notifications/initialized");
+
+  return {
+    request,
+    async callTool(name, args = {}) {
+      const response = await request("tools/call", { name, arguments: args });
+      assert.equal(response.error, undefined, response.error?.message);
+      return response.result;
+    },
+    async close() {
+      await clientTransport.close().catch(() => {});
+      await server.close().catch(() => {});
+    },
+  };
+}
+
+async function withHarness(companion, callback) {
+  const harness = await createHarness(companion);
+  try {
+    return await callback(harness);
+  } finally {
+    await harness.close();
+  }
+}
+
+function toolByName(tools, name) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  assert.ok(tool, `missing ${name}`);
+  return tool;
+}
+
+test("publishes local and project font tools with strict agent-facing schemas", async () => {
+  const companion = createCompanion();
+  await withHarness(companion, async ({ request }) => {
+    const listed = await request("tools/list");
+    const { tools } = listed.result;
+    const localFonts = toolByName(tools, "list_local_fonts");
+    const projectFonts = toolByName(tools, "list_project_fonts");
+    const importFont = toolByName(tools, "import_font");
+    const addText = toolByName(tools, "add_text");
+    const updateText = toolByName(tools, "update_text");
+    const applyOperations = toolByName(tools, "apply_operations");
+
+    assert.deepEqual(localFonts.annotations, { openWorldHint: false, readOnlyHint: true });
+    assert.deepEqual(projectFonts.annotations, { openWorldHint: false, readOnlyHint: true });
+    assert.deepEqual(importFont.annotations, { openWorldHint: false, destructiveHint: false });
+    assert.match(localFonts.description, /never filesystem paths/i);
+
+    assert.deepEqual(localFonts.inputSchema.properties.sort.enum, ["recent_then_alphabetical", "alphabetical"]);
+    assert.equal(localFonts.inputSchema.properties.limit.minimum, 1);
+    assert.equal(localFonts.inputSchema.properties.limit.maximum, 200);
+    assert.equal(localFonts.inputSchema.properties.cursor.maxLength, 2048);
+    assert.deepEqual(importFont.inputSchema.required.sort(), ["localFontId", "projectId"]);
+    assert.equal(Object.hasOwn(importFont.inputSchema.properties, "path"), false);
+
+    const addTextProperties = addText.inputSchema.properties;
+    assert.ok(addTextProperties.fontId.anyOf.some((schema) => schema.type === "null"));
+    assert.equal(addTextProperties.fontWeight.minimum, 1);
+    assert.equal(addTextProperties.fontWeight.maximum, 1000);
+    assert.deepEqual(addTextProperties.fontStyle.enum, ["normal", "italic"]);
+    assert.equal(addTextProperties.fontVariationSettings.additionalProperties.type, "number");
+
+    const updateItem = updateText.inputSchema.properties.updates.items;
+    assert.ok(updateItem.properties.fontId);
+    assert.ok(updateItem.properties.fontVariationSettings);
+    const batchToolEnum = applyOperations.inputSchema.properties.operations.items.properties.tool.enum;
+    assert.ok(batchToolEnum.includes("import_font"));
+  });
+});
+
+test("list_local_fonts applies bounded defaults, rejects private inputs, and returns a public DTO", async () => {
+  const companion = createCompanion(async (action) => {
+    assert.equal(action, "list_local_fonts");
+    return { fonts: [PUBLIC_LOCAL_FONT], nextCursor: null };
+  });
+
+  await withHarness(companion, async ({ callTool }) => {
+    const result = await callTool("list_local_fonts");
+    assert.deepEqual(result.structuredContent, { fonts: [PUBLIC_LOCAL_FONT], nextCursor: null });
+    assert.doesNotMatch(JSON.stringify(result), /pathInternal|fileFingerprint|faceIndex|fontData|\/System\/Library\/Fonts/);
+    assert.deepEqual(
+      companion.calls.find((call) => call.action === "list_local_fonts")?.args,
+      { limit: 80, sort: "recent_then_alphabetical" },
+    );
+
+    const maximumCursor = "A".repeat(2048);
+    const withMaximumCursor = await callTool("list_local_fonts", { cursor: maximumCursor });
+    assert.equal(withMaximumCursor.isError, undefined);
+    assert.equal(companion.calls.findLast((call) => call.action === "list_local_fonts")?.args.cursor, maximumCursor);
+
+    const beforeOversized = companion.calls.length;
+    const oversized = await callTool("list_local_fonts", { cursor: `${maximumCursor}A` });
+    assert.equal(oversized.isError, true);
+    assert.equal(companion.calls.length, beforeOversized, "oversized cursors must not reach the companion");
+
+    const beforeInvalid = companion.calls.length;
+    const invalid = await callTool("list_local_fonts", { path: "/System/Library/Fonts/Didot.ttc" });
+    assert.equal(invalid.isError, true);
+    assert.match(invalid.content[0].text, /unrecognized key|invalid/i);
+    assert.equal(companion.calls.length, beforeInvalid, "invalid public input must not reach the companion");
+  });
+});
+
+test("list_project_fonts uses the read-only browser operation and keeps stored font bytes private", async () => {
+  const publicProjectFont = {
+    id: "project-font-1",
+    source: "local",
+    localFontId: PUBLIC_LOCAL_FONT.localFontId,
+    family: "Didot",
+    fullName: "Didot",
+    postscriptName: "Didot",
+    subfamily: "Regular",
+    weight: 400,
+    italic: false,
+    cssFamily: "carousel-font-project-font-1",
+    variableAxes: [],
+    addedAt: 1_788_126_972_333,
+    available: true,
+  };
+  const companion = createCompanion(async (action, args) => {
+    assert.equal(action, "browser");
+    assert.deepEqual(args, {
+      toolName: "list_project_fonts",
+      operation: { type: "font.list", projectId: "project-1" },
+      label: "Editing in CarouselBot…",
+      editSessionId: "session-1",
+      mutating: false,
+    });
+    return { projectId: "project-1", revision: 4, fonts: [publicProjectFont] };
+  });
+
+  await withHarness(companion, async ({ callTool }) => {
+    const result = await callTool("list_project_fonts", {
+      editSessionId: "session-1",
+      projectId: "project-1",
+    });
+    assert.deepEqual(result.structuredContent, {
+      projectId: "project-1",
+      revision: 4,
+      fonts: [publicProjectFont],
+    });
+    assert.doesNotMatch(JSON.stringify(result), /fontData|data:font|pathInternal|fontMediaId|\/System\/Library\/Fonts/);
+  });
+});
+
+test("import_font prepares the exact local face with the edit session and exposes only the public mutation result", async () => {
+  const prepared = {
+    font: PUBLIC_LOCAL_FONT,
+    fontMediaId: "font-media-secret",
+  };
+  const companion = createCompanion(async (action, args) => {
+    if (action === "prepare_font") return prepared;
+    if (action === "browser") {
+      assert.deepEqual(args, {
+        toolName: "import_font",
+        operation: {
+          type: "font.import",
+          projectId: "project-1",
+          localFontId: PUBLIC_LOCAL_FONT.localFontId,
+          font: PUBLIC_LOCAL_FONT,
+          fontMediaId: "font-media-secret",
+        },
+        label: "Adding a local font…",
+        editSessionId: "session-1",
+        mutating: true,
+      });
+      return {
+        projectId: "project-1",
+        fontId: "project-font-1",
+        localFontId: PUBLIC_LOCAL_FONT.localFontId,
+        family: "Didot",
+        subfamily: "Regular",
+        weight: 400,
+        italic: false,
+        existing: false,
+        revision: 42,
+      };
+    }
+    return {};
+  });
+
+  await withHarness(companion, async ({ callTool }) => {
+    await callTool("get_design_guidance");
+    const result = await callTool("import_font", {
+      editSessionId: "session-1",
+      projectId: "project-1",
+      localFontId: PUBLIC_LOCAL_FONT.localFontId,
+    });
+
+    assert.deepEqual(
+      companion.calls.find((call) => call.action === "prepare_font")?.args,
+      { localFontId: PUBLIC_LOCAL_FONT.localFontId, editSessionId: "session-1" },
+    );
+    assert.equal(result.structuredContent.fontId, "project-font-1");
+    assert.equal(result.structuredContent.revision, 42);
+    assert.doesNotMatch(JSON.stringify(result), /font-media-secret|fontData|pathInternal|\/System\/Library\/Fonts/);
+    assert.deepEqual(JSON.parse(result.content[0].text), {
+      projectId: "project-1",
+      revision: 42,
+      fontId: "project-font-1",
+      localFontId: PUBLIC_LOCAL_FONT.localFontId,
+      existing: false,
+    });
+  });
+});
+
+test("font text fields validate before dispatch and preserve deterministic IDs and variable axes", async () => {
+  const companion = createCompanion(async (action, args) => action === "browser"
+    ? { projectId: args.operation.projectId, createdTextId: "text-1", revision: 1 }
+    : {});
+
+  await withHarness(companion, async ({ callTool }) => {
+    await callTool("get_design_guidance");
+    const valid = await callTool("add_text", {
+      editSessionId: "session-1",
+      projectId: "project-1",
+      slideId: "slide-1",
+      text: "speed limit",
+      fontId: "project-font-1",
+      fontWeight: 725,
+      fontStyle: "italic",
+      fontVariationSettings: { wght: 725, wdth: 90 },
+    });
+    assert.equal(valid.isError, undefined);
+    const browserCall = companion.calls.find((call) => call.action === "browser");
+    assert.deepEqual(browserCall.args.operation, {
+      type: "text.add",
+      projectId: "project-1",
+      slideId: "slide-1",
+      text: "speed limit",
+      fontId: "project-font-1",
+      fontWeight: 725,
+      fontStyle: "italic",
+      fontVariationSettings: { wght: 725, wdth: 90 },
+    });
+    assert.equal(browserCall.args.editSessionId, "session-1");
+
+    for (const invalidFields of [
+      { fontId: "" },
+      { fontWeight: 0 },
+      { fontWeight: 1001 },
+      { fontStyle: "oblique" },
+      { fontVariationSettings: { weight: 700 } },
+    ]) {
+      const browserCallsBefore = companion.calls.filter((call) => call.action === "browser").length;
+      const invalid = await callTool("add_text", {
+        projectId: "project-1",
+        slideId: "slide-1",
+        text: "invalid font",
+        ...invalidFields,
+      });
+      assert.equal(invalid.isError, true, JSON.stringify(invalidFields));
+      assert.equal(
+        companion.calls.filter((call) => call.action === "browser").length,
+        browserCallsBefore,
+        `invalid fields reached browser: ${JSON.stringify(invalidFields)}`,
+      );
+    }
+  });
+});
+
+test("apply_operations prepares imported fonts against the outer edit session", async () => {
+  const companion = createCompanion(async (action) => {
+    if (action === "prepare_font") return { font: PUBLIC_LOCAL_FONT, fontMediaId: "batch-font-media" };
+    if (action === "batch") return { applied: 2, projectId: "project-1", revision: 7 };
+    return {};
+  });
+
+  await withHarness(companion, async ({ callTool }) => {
+    await callTool("get_design_guidance");
+    const result = await callTool("apply_operations", {
+      editSessionId: "outer-session",
+      operations: [
+        {
+          tool: "import_font",
+          arguments: {
+            editSessionId: "inner-session-must-not-win",
+            projectId: "project-1",
+            localFontId: PUBLIC_LOCAL_FONT.localFontId,
+          },
+        },
+        {
+          tool: "add_text",
+          arguments: {
+            projectId: "project-1",
+            slideId: "slide-1",
+            text: "speed limit",
+            fontId: "already-imported-project-font",
+          },
+        },
+      ],
+    });
+
+    assert.deepEqual(
+      companion.calls.find((call) => call.action === "prepare_font")?.args,
+      { localFontId: PUBLIC_LOCAL_FONT.localFontId, editSessionId: "outer-session" },
+    );
+    const batch = companion.calls.find((call) => call.action === "batch");
+    assert.equal(batch.args.editSessionId, "outer-session");
+    assert.deepEqual(batch.args.items[0].operation, {
+      type: "font.import",
+      projectId: "project-1",
+      localFontId: PUBLIC_LOCAL_FONT.localFontId,
+      font: PUBLIC_LOCAL_FONT,
+      fontMediaId: "batch-font-media",
+    });
+    assert.deepEqual(batch.args.items[1].operation, {
+      type: "text.add",
+      projectId: "project-1",
+      slideId: "slide-1",
+      text: "speed limit",
+      fontId: "already-imported-project-font",
+    });
+    assert.equal(result.structuredContent.applied, 2);
+  });
+});

--- a/packages/mcp/test/local-fonts.test.mjs
+++ b/packages/mcp/test/local-fonts.test.mjs
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fontkit from "fontkit";
+import { createLocalFontService, extractTtcFace } from "../src/local-fonts.mjs";
+
+const root = new URL("../../..", import.meta.url);
+const tikTokSansPath = new URL("assets/TikTokSans.ttf", root).pathname;
+const didotPath = "/System/Library/Fonts/Supplemental/Didot.ttc";
+
+function align4(value) {
+  return (value + 3) & ~3;
+}
+
+function standaloneFontsToTtc(fonts) {
+  const headerLength = align4(12 + fonts.length * 4);
+  const offsets = [];
+  let length = headerLength;
+  for (const font of fonts) {
+    offsets.push(length);
+    length = align4(length + font.length);
+  }
+  const collection = Buffer.alloc(length);
+  collection.write("ttcf", 0, "ascii");
+  collection.writeUInt32BE(0x00020000, 4);
+  collection.writeUInt32BE(fonts.length, 8);
+  fonts.forEach((font, faceIndex) => {
+    const faceOffset = offsets[faceIndex];
+    collection.writeUInt32BE(faceOffset, 12 + faceIndex * 4);
+    font.copy(collection, faceOffset);
+    const tableCount = font.readUInt16BE(4);
+    for (let index = 0; index < tableCount; index += 1) {
+      const tableRecord = faceOffset + 12 + index * 16;
+      collection.writeUInt32BE(font.readUInt32BE(12 + index * 16 + 8) + faceOffset, tableRecord + 8);
+    }
+  });
+  return collection;
+}
+
+function sfntChecksum(buffer) {
+  let sum = 0;
+  for (let offset = 0; offset < buffer.length; offset += 4) {
+    let word = 0;
+    for (let index = 0; index < 4; index += 1) word = ((word << 8) | (buffer[offset + index] || 0)) >>> 0;
+    sum = (sum + word) >>> 0;
+  }
+  return sum;
+}
+
+test("extracts a bounds-checked standalone SFNT face from a TTC", async () => {
+  const standalone = await readFile(tikTokSansPath);
+  const collection = standaloneFontsToTtc([standalone, standalone]);
+  const extracted = extractTtcFace(collection, 1);
+  assert.notEqual(extracted.subarray(0, 4).toString("ascii"), "ttcf");
+  assert.equal(sfntChecksum(extracted), 0xb1b0afba);
+  const parsed = fontkit.create(extracted);
+  assert.equal(parsed.postscriptName, fontkit.create(standalone).postscriptName);
+  assert.throws(() => extractTtcFace(collection, 2), /FONT_FACE_NOT_FOUND/);
+  const invalid = Buffer.from(collection);
+  invalid.writeUInt32BE(invalid.length + 4, 16);
+  assert.throws(() => extractTtcFace(invalid, 1), /INVALID_FONT_COLLECTION/);
+  assert.throws(() => extractTtcFace(standalone, 0), /INVALID_FONT_COLLECTION/);
+});
+
+test("indexes, caches, searches, paginates, resolves, transfers, and sorts local fonts", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "carouselbot-local-fonts-"));
+  const cacheDirectory = join(directory, "cache");
+  const fontDirectory = join(directory, "fonts");
+  await mkdir(fontDirectory);
+  const firstPath = join(fontDirectory, "a-tiktok-sans.ttf");
+  const duplicatePath = join(fontDirectory, "b-duplicate.ttf");
+  const collectionPath = join(fontDirectory, "collection.ttc");
+  try {
+    const standalone = await readFile(tikTokSansPath);
+    await Promise.all([
+      copyFile(tikTokSansPath, firstPath),
+      copyFile(tikTokSansPath, duplicatePath),
+      writeFile(collectionPath, standaloneFontsToTtc([standalone, standalone])),
+      writeFile(join(fontDirectory, "not-a-font.otf"), "not a font"),
+    ]);
+    const service = createLocalFontService({ directories: [fontDirectory], cacheDirectory, refreshIntervalMs: Infinity });
+    const alphabetical = await service.list({ query: "tiktok sans", limit: 20, sort: "alphabetical" });
+    assert.equal(alphabetical.fonts.length, 3, "identical standalone files should be de-duplicated while TTC faces remain distinct");
+    assert.equal(alphabetical.nextCursor, null);
+    assert.ok(alphabetical.fonts.every((font) => font.localFontId.startsWith("font_")));
+    assert.ok(alphabetical.fonts.every((font) => font.lastUsedAt === null));
+    assert.ok(alphabetical.fonts.some((font) => font.variableAxes.some((axis) => axis.tag === "wght")));
+    const serialized = JSON.stringify(alphabetical);
+    assert.doesNotMatch(serialized, /carouselbot-local-fonts|a-tiktok-sans|\/fonts\//);
+    assert.deepEqual(Object.keys(alphabetical.fonts[0]), [
+      "localFontId", "family", "fullName", "postscriptName", "subfamily", "weight", "italic", "lastUsedAt", "variableAxes",
+    ]);
+
+    const firstPage = await service.list({ limit: 1, sort: "alphabetical" });
+    assert.equal(firstPage.fonts.length, 1);
+    assert.ok(firstPage.nextCursor);
+    const secondPage = await service.list({ limit: 1, cursor: firstPage.nextCursor, sort: "alphabetical" });
+    assert.equal(secondPage.fonts.length, 1);
+    assert.notEqual(secondPage.fonts[0].localFontId, firstPage.fonts[0].localFontId);
+    await assert.rejects(service.list({ cursor: "not-a-cursor" }), /INVALID_FONT_CURSOR/);
+    const recentBeforeUsage = await service.list({ limit: 1, sort: "recent_then_alphabetical" });
+    assert.ok(recentBeforeUsage.nextCursor);
+
+    const collectionFont = await Promise.all(alphabetical.fonts.map((font) => service.resolve(font.localFontId)))
+      .then((fonts) => fonts.find((font) => font.extension === ".ttc" && font.faceIndex === 1));
+    assert.ok(collectionFont?.pathInternal.endsWith("collection.ttc"));
+    const prepared = await service.readFace(collectionFont.localFontId);
+    assert.equal(prepared.font.localFontId, collectionFont.localFontId);
+    assert.equal(prepared.mimeType, "font/ttf");
+    assert.match(prepared.filename, /\.ttf$/);
+    assert.notEqual(prepared.buffer.subarray(0, 4).toString("ascii"), "ttcf");
+    assert.equal(fontkit.create(prepared.buffer).postscriptName, collectionFont.postscriptName);
+
+    const usedAt = 1_788_126_972_333;
+    await service.markUsed(alphabetical.fonts.at(-1).localFontId, usedAt);
+    await assert.rejects(
+      service.list({ limit: 1, cursor: recentBeforeUsage.nextCursor, sort: "recent_then_alphabetical" }),
+      /INVALID_FONT_CURSOR/,
+      "recent cursors must expire when usage changes their ordering snapshot",
+    );
+    const alphabeticalAfterUsage = await service.list({ limit: 1, cursor: firstPage.nextCursor, sort: "alphabetical" });
+    assert.equal(alphabeticalAfterUsage.fonts[0].localFontId, secondPage.fonts[0].localFontId, "usage changes must not expire alphabetical cursors");
+    const recent = await service.list({ limit: 20, sort: "recent_then_alphabetical" });
+    assert.equal(recent.fonts[0].localFontId, alphabetical.fonts.at(-1).localFontId);
+    assert.equal(recent.fonts[0].lastUsedAt, usedAt);
+    const persistedRecentPage = await service.list({ limit: 1, sort: "recent_then_alphabetical" });
+    assert.ok(persistedRecentPage.nextCursor);
+
+    const cachedService = createLocalFontService({ directories: [fontDirectory], cacheDirectory, refreshIntervalMs: Infinity });
+    const cached = await cachedService.list({ query: "TikTok", limit: 20, sort: "alphabetical" });
+    assert.deepEqual(cached.fonts.map((font) => font.localFontId), alphabetical.fonts.map((font) => font.localFontId));
+    assert.equal((await cachedService.list({ limit: 20 })).fonts[0].lastUsedAt, usedAt);
+    const resumedRecentPage = await cachedService.list({ limit: 1, cursor: persistedRecentPage.nextCursor, sort: "recent_then_alphabetical" });
+    assert.equal(resumedRecentPage.fonts.length, 1, "persisted usage snapshots should keep valid cursors resumable after restart");
+    assert.ok(existsSync(join(cacheDirectory, "local-font-index-v1.json")));
+    assert.ok(existsSync(join(cacheDirectory, "local-font-usage-v1.json")));
+
+    const beforeIds = new Set(alphabetical.fonts.map((font) => font.localFontId));
+    const changedTime = new Date(Date.now() + 10_000);
+    await utimes(firstPath, changedTime, changedTime);
+    await service.refresh({ force: true });
+    const changed = await service.list({ query: "TikTok", limit: 20, sort: "alphabetical" });
+    assert.ok(changed.fonts.some((font) => !beforeIds.has(font.localFontId)), "changing font metadata should rotate its opaque ID");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("indexes and extracts every Didot TTC face on macOS", { skip: !existsSync(didotPath) }, async () => {
+  const directory = await mkdtemp(join(tmpdir(), "carouselbot-didot-"));
+  const fontDirectory = join(directory, "fonts");
+  await mkdir(fontDirectory);
+  await copyFile(didotPath, join(fontDirectory, "Didot.ttc"));
+  try {
+    const service = createLocalFontService({ directories: [fontDirectory], cacheDirectory: join(directory, "cache"), refreshIntervalMs: Infinity });
+    const { fonts } = await service.list({ query: "Didot", limit: 20, sort: "alphabetical" });
+    assert.equal(fonts.length, 3);
+    assert.deepEqual(fonts.map((font) => font.subfamily), ["Regular", "Bold", "Italic"]);
+    assert.deepEqual(new Set(fonts.map((font) => font.subfamily)), new Set(["Regular", "Italic", "Bold"]));
+    assert.deepEqual(new Set(fonts.map((font) => font.weight)), new Set([400, 700]));
+    for (const font of fonts) {
+      const prepared = await service.readFace(font.localFontId);
+      assert.equal(prepared.mimeType, "font/ttf");
+      assert.equal(fontkit.create(prepared.buffer).postscriptName, font.postscriptName);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/mcp/test/protocol.test.mjs
+++ b/packages/mcp/test/protocol.test.mjs
@@ -67,12 +67,15 @@ test("serves a complete legacy-compatible stdio MCP surface", async () => {
 
     const listed = await rpc.request("tools/list");
     const names = listed.result.tools.map((tool) => tool.name);
-    for (const name of ["get_design_guidance", "list_editors", "begin_edit_session", "end_edit_session", "list_edit_sessions", "list_recent_operations", "inspect_editor", "create_project", "add_slide", "add_text", "fit_text_boxes", "import_asset", "add_image", "render_slide", "export_project", "apply_operations"]) assert.ok(names.includes(name), `missing ${name}`);
+    for (const name of ["get_design_guidance", "list_editors", "begin_edit_session", "end_edit_session", "list_edit_sessions", "list_recent_operations", "inspect_editor", "list_local_fonts", "list_project_fonts", "create_project", "add_slide", "add_text", "fit_text_boxes", "import_font", "import_asset", "add_image", "render_slide", "export_project", "apply_operations"]) assert.ok(names.includes(name), `missing ${name}`);
     assert.ok(names.length >= 30, `expected complete surface, received ${names.length}`);
     assert.ok(listed.result.tools.every((tool) => tool.annotations.openWorldHint === false), "every tool should declare its closed local domain");
     const annotations = Object.fromEntries(listed.result.tools.map((tool) => [tool.name, tool.annotations]));
     assert.equal(annotations.inspect_editor.readOnlyHint, true);
+    assert.equal(annotations.list_local_fonts.readOnlyHint, true);
+    assert.equal(annotations.list_project_fonts.readOnlyHint, true);
     assert.equal(annotations.add_text.destructiveHint, false);
+    assert.equal(annotations.import_font.destructiveHint, false);
     assert.equal(annotations.update_text.destructiveHint, true);
     assert.equal(annotations.delete_project.destructiveHint, true);
 

--- a/packages/mcp/test/shared-daemon.test.mjs
+++ b/packages/mcp/test/shared-daemon.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 test("shares one daemon while preserving per-agent editor selection", async () => {
   const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-shared-"));
@@ -11,6 +12,7 @@ test("shares one daemon while preserving per-agent editor selection", async () =
   process.env.CAROUSELBOT_BRIDGE_PORT = String(port);
   process.env.CAROUSELBOT_EDITOR_TTL_MS = "1000";
   process.env.CAROUSELBOT_EVENT_POLL_TIMEOUT_MS = "2000";
+  process.env.CAROUSELBOT_FONT_DIRS = fileURLToPath(new URL("../../../assets", import.meta.url));
   const { companionRestart, createCompanion } = await import(`../src/companion.mjs?shared=${port}`);
   const first = await createCompanion("Claude Code", "test");
   const second = await createCompanion("Codex", "test");
@@ -34,6 +36,38 @@ test("shares one daemon while preserving per-agent editor selection", async () =
     assert.equal((await first.call("list_editors")).editors.length, 2);
     await first.call("select_editor", { editorId: "editor-a" });
     await second.call("select_editor", { editorId: "editor-b" });
+    await assert.rejects(first.call("list_local_fonts", { query: "TikTok" }), /FONT_PERMISSION_REQUIRED/);
+    const blockedFonts = await fetch(`${base}/fonts?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(blockedFonts.status, 403);
+    const enabledA = await fetch(`${base}/fonts/enable`, {
+      method: "POST",
+      headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ editorId: "editor-a" }),
+    });
+    assert.deepEqual(await enabledA.json(), { enabled: true });
+    const enabledB = await fetch(`${base}/fonts/enable`, {
+      method: "POST",
+      headers: { Origin: origin, Authorization: `Bearer ${editorB.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ editorId: "editor-b" }),
+    });
+    assert.equal(enabledB.status, 200);
+    const localFontList = await first.call("list_local_fonts", { query: "TikTok", sort: "alphabetical", limit: 10 });
+    assert.ok(localFontList.fonts.length >= 1);
+    assert.doesNotMatch(JSON.stringify(localFontList), /pathInternal|fileFingerprint|faceIndex|\/Users\//);
+    const indexedFont = localFontList.fonts[0];
+    const directFont = await fetch(`${base}/fonts/${encodeURIComponent(indexedFont.localFontId)}?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(directFont.status, 200);
+    assert.equal(directFont.headers.get("content-type"), "font/ttf");
+    assert.ok((await directFont.arrayBuffer()).byteLength > 100);
+    const preparedFont = await first.call("prepare_font", { localFontId: indexedFont.localFontId });
+    assert.equal(preparedFont.font.localFontId, indexedFont.localFontId);
+    const wrongEditorTransfer = await fetch(`${base}/font-media/${preparedFont.fontMediaId}?editorId=editor-b`, { headers: { Origin: origin, Authorization: `Bearer ${editorB.sessionToken}` } });
+    assert.equal(wrongEditorTransfer.status, 404);
+    const fontTransfer = await fetch(`${base}/font-media/${preparedFont.fontMediaId}?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(fontTransfer.status, 200);
+    assert.ok((await fontTransfer.arrayBuffer()).byteLength > 100);
+    const repeatedTransfer = await fetch(`${base}/font-media/${preparedFont.fontMediaId}?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(repeatedTransfer.status, 404);
     const firstEditors = await first.call("list_editors");
     const secondEditors = await second.call("list_editors");
     assert.equal(firstEditors.selectedEditorId, "editor-a");
@@ -69,6 +103,53 @@ test("shares one daemon while preserving per-agent editor selection", async () =
         if (event.kind === "command") return event;
       }
     }
+
+    const preparedImport = await first.call("prepare_font", { editSessionId: sessionA.id, localFontId: indexedFont.localFontId });
+    const importCall = first.call("browser", {
+      toolName: "import_font", mutating: true, editSessionId: sessionA.id,
+      operation: { type: "font.import", projectId: "project-a", localFontId: indexedFont.localFontId, font: preparedImport.font, fontMediaId: preparedImport.fontMediaId },
+      label: "Adding a local font…",
+    });
+    const importCommand = await nextCommand("editor-a", editorA.sessionToken);
+    assert.equal(importCommand.operation.font.localFontId, indexedFont.localFontId);
+    const importedBytes = await fetch(`${base}/font-media/${importCommand.operation.fontMediaId}?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(importedBytes.status, 200);
+    await importedBytes.arrayBuffer();
+    await fetch(`${base}/result`, {
+      method: "POST",
+      headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ editorId: "editor-a", requestId: importCommand.requestId, ok: true, result: { projectId: "project-a", fontId: "project-font-1", revision: 1 } }),
+    });
+    assert.equal((await importCall).fontId, "project-font-1");
+
+    const preparedDuplicate = await first.call("prepare_font", { editSessionId: sessionA.id, localFontId: indexedFont.localFontId });
+    const duplicateImportCall = first.call("browser", {
+      toolName: "import_font", mutating: true, editSessionId: sessionA.id,
+      operation: { type: "font.import", projectId: "project-a", localFontId: indexedFont.localFontId, font: preparedDuplicate.font, fontMediaId: preparedDuplicate.fontMediaId },
+      label: "Adding a local font…",
+    });
+    const duplicateImportCommand = await nextCommand("editor-a", editorA.sessionToken);
+    assert.equal(duplicateImportCommand.operation.fontMediaId, preparedDuplicate.fontMediaId);
+    const duplicateResult = await fetch(`${base}/result`, {
+      method: "POST",
+      headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ editorId: "editor-a", requestId: duplicateImportCommand.requestId, ok: true, result: { projectId: "project-a", fontId: "project-font-1", existing: true, revision: 1 } }),
+    });
+    assert.equal(duplicateResult.status, 200);
+    assert.equal((await duplicateImportCall).existing, true);
+    const unusedDuplicateTransfer = await fetch(`${base}/font-media/${preparedDuplicate.fontMediaId}?editorId=editor-a`, { headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}` } });
+    assert.equal(unusedDuplicateTransfer.status, 404, "a successful duplicate import must discard its unused one-time font transfer");
+
+    const unusedFonts = await first.call("list_local_fonts", { editSessionId: sessionA.id, query: "TikTok", limit: 10 });
+    assert.equal(unusedFonts.fonts.find((font) => font.localFontId === indexedFont.localFontId)?.lastUsedAt, null);
+    const usedResponse = await fetch(`${base}/fonts/use`, {
+      method: "POST",
+      headers: { Origin: origin, Authorization: `Bearer ${editorA.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ editorId: "editor-a", localFontId: indexedFont.localFontId }),
+    });
+    assert.equal(usedResponse.status, 200);
+    const usedFonts = await first.call("list_local_fonts", { editSessionId: sessionA.id, query: "TikTok", limit: 10 });
+    assert.ok(usedFonts.fonts.find((font) => font.localFontId === indexedFont.localFontId)?.lastUsedAt > 0);
 
     const browserCall = first.call("browser", {
       toolName: "add_slide", mutating: true, editSessionId: sessionA.id,
@@ -140,5 +221,6 @@ test("shares one daemon while preserving per-agent editor selection", async () =
     delete process.env.CAROUSELBOT_BRIDGE_PORT;
     delete process.env.CAROUSELBOT_EDITOR_TTL_MS;
     delete process.env.CAROUSELBOT_EVENT_POLL_TIMEOUT_MS;
+    delete process.env.CAROUSELBOT_FONT_DIRS;
   }
 });

--- a/packages/slides-studio-mcp/package.json
+++ b/packages/slides-studio-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slides-studio-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Compatibility package for the renamed CarouselBot MCP",
   "type": "module",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "carouselbot": "0.2.0"
+    "carouselbot": "0.3.0"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -575,7 +575,10 @@ try {
     };
   }
   await tool("delete_layers", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, layerIds: [fontProbe.createdTextId] });
-  await waitFor(() => evaluate(cdp, `${JSON.stringify(fontProbe.createdTextId)} !== "" && ![...document.querySelectorAll(".text-box")].some((item) => item.dataset.textId === ${JSON.stringify(fontProbe.createdTextId)})`), "The temporary local-font probe was not removed.");
+  await waitFor(async () => {
+    const visibleTextIds = await evaluate(cdp, `[...document.querySelectorAll(".text-box")].map((item) => item.dataset.textId)`);
+    return Boolean(fontProbe.createdTextId) && !visibleTextIds.includes(fontProbe.createdTextId);
+  }, "The temporary local-font probe was not removed.");
 
   const addedText = (await tool("add_text", {
     projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, text: "Built live by an AI agent",

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -17,7 +17,15 @@ const debuggingPort = 19229;
 const profile = await mkdtemp(join(tmpdir(), "carouselbot-browser-"));
 const stateDirectory = await mkdtemp(join(tmpdir(), "carouselbot-daemon-"));
 const exportPath = join(profile, "agent-export.png");
+const fontExportPath = join(profile, "didot-export.png");
 const projectExportDirectory = join(profile, "project-export");
+const didotPath = "/System/Library/Fonts/Supplemental/Didot.ttc";
+const didotMetadata = await stat(didotPath).catch((error) => {
+  if (error.code === "ENOENT") return null;
+  throw error;
+});
+if (didotMetadata && !didotMetadata.isFile()) throw new Error(`${didotPath} exists but is not a regular file.`);
+const didotAvailable = Boolean(didotMetadata);
 const sharedDaemon = process.argv.includes("--shared-daemon");
 const bridgePort = sharedDaemon ? 43117 : 48000 + Math.floor(Math.random() * 1000);
 const env = sharedDaemon ? process.env : {
@@ -222,6 +230,84 @@ async function boxedLineGeometry(cdp, textId) {
   })()`);
 }
 
+async function textGlyphGeometry(cdp, textId) {
+  return evaluate(cdp, `(() => {
+    const textId = ${JSON.stringify(textId)};
+    const box = [...document.querySelectorAll(".text-box")].find((item) => item.dataset.textId === textId);
+    const content = box?.querySelector(".text-visual--inside .text-content");
+    if (!box || !content || !content.firstChild) return null;
+    const range = document.createRange();
+    range.selectNodeContents(content);
+    const rect = range.getBoundingClientRect();
+    const style = getComputedStyle(content);
+    const measurement = document.createElement("canvas").getContext("2d");
+    measurement.font = style.fontStyle + " " + style.fontWeight + " 104px " + style.fontFamily;
+    measurement.fontVariationSettings = style.fontVariationSettings;
+    const glyphMetrics = measurement.measureText(content.textContent);
+    return {
+      text: content.textContent,
+      renderedWidth: rect.width,
+      renderedHeight: rect.height,
+      glyphWidth: glyphMetrics.width,
+      glyphLeft: glyphMetrics.actualBoundingBoxLeft,
+      glyphRight: glyphMetrics.actualBoundingBoxRight,
+      family: style.fontFamily,
+      weight: style.fontWeight,
+      fontStyle: style.fontStyle,
+      fontReady: document.fonts.check(style.fontStyle + " " + style.fontWeight + " 104px " + style.fontFamily),
+      missing: box.classList.contains("is-font-missing"),
+    };
+  })()`);
+}
+
+async function renderedPixelDifference(cdp, leftBase64, rightBase64) {
+  return evaluate(cdp, `(async () => {
+    const load = (data) => new Promise((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error("Could not decode rendered PNG."));
+      image.src = "data:image/png;base64," + data;
+    });
+    const [left, right] = await Promise.all([load(${JSON.stringify(leftBase64)}), load(${JSON.stringify(rightBase64)})]);
+    if (left.width !== right.width || left.height !== right.height) return {
+      sameDimensions: false,
+      left: [left.width, left.height],
+      right: [right.width, right.height],
+    };
+    const canvas = document.createElement("canvas");
+    canvas.width = left.width;
+    canvas.height = left.height;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    context.drawImage(left, 0, 0);
+    const leftPixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(right, 0, 0);
+    const rightPixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    let changedPixels = 0;
+    let totalChannelDelta = 0;
+    let maxChannelDelta = 0;
+    for (let offset = 0; offset < leftPixels.length; offset += 4) {
+      let changed = false;
+      for (let channel = 0; channel < 4; channel += 1) {
+        const delta = Math.abs(leftPixels[offset + channel] - rightPixels[offset + channel]);
+        changed ||= delta > 0;
+        totalChannelDelta += delta;
+        maxChannelDelta = Math.max(maxChannelDelta, delta);
+      }
+      if (changed) changedPixels += 1;
+    }
+    return {
+      sameDimensions: true,
+      width: left.width,
+      height: left.height,
+      pixels: left.width * left.height,
+      changedPixels,
+      totalChannelDelta,
+      maxChannelDelta,
+    };
+  })()`);
+}
+
 let cdp;
 let secondCdp;
 const additionalCdps = [];
@@ -306,6 +392,191 @@ try {
   if (dashboardAfterSlide.pathname !== "/" || !dashboardAfterSlide.dashboardVisible || !dashboardAfterSlide.slideCount?.startsWith("1 slide")) throw new Error(`Adding a slide changed the dashboard view: ${JSON.stringify(dashboardAfterSlide)}`);
   await tool("open_project", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId });
   await waitFor(() => evaluate(cdp, "document.querySelector('.project-title-input')?.value === 'Full MCP browser test'"), "Explicitly opening the project did not show the editor.");
+
+  const fontProbe = (await tool("add_text", {
+    projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, text: "speed limit",
+    x: 0.1, y: 0.3, width: 0.8, height: 0.16, size: 104, style: "plain", align: "center", color: "#FFFFFF",
+  })).structuredContent;
+  let fontPermissionError = null;
+  try {
+    await tool("list_local_fonts", { query: "Didot", limit: 20, sort: "alphabetical" });
+  } catch (error) {
+    fontPermissionError = error;
+  }
+  if (!fontPermissionError || !/FONT_PERMISSION_REQUIRED|enable local fonts/i.test(fontPermissionError.message)) {
+    throw new Error(`Local font discovery was not refused before consent: ${fontPermissionError?.message || "request succeeded"}`);
+  }
+  const permissionPromptOpened = await evaluate(cdp, `(() => {
+    const select = document.querySelector("#text-font");
+    if (!select) return false;
+    select.value = "__add_local_font__";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    return true;
+  })()`);
+  if (!permissionPromptOpened) throw new Error("The selected text layer did not expose the local-font picker.");
+  await waitFor(() => evaluate(cdp, `Boolean(document.querySelector(".font-picker-backdrop [data-enable-fonts]"))`), "The local-font permission prompt did not open.");
+  await evaluate(cdp, `document.querySelector(".font-picker-backdrop [data-enable-fonts]").click()`);
+  await waitFor(() => evaluate(cdp, `window.carouselBotLocalMcpBridge.getState().localFontsEnabled === true && Boolean(document.querySelector("#font-search"))`), "Explicit local-font permission was not enabled.", 60_000);
+  const rememberedFontPermission = await evaluate(cdp, `localStorage.getItem("carouselbot:local-fonts-enabled")`);
+  if (rememberedFontPermission !== "1") throw new Error("Explicit local-font permission was not remembered.");
+  await evaluate(cdp, `document.querySelector(".font-picker-close")?.click()`);
+
+  const didotList = (await tool("list_local_fonts", { query: "Didot", limit: 20, sort: "alphabetical" })).structuredContent;
+  let localFontAcceptance = {
+    permissionRefused: true,
+    permissionEnabled: true,
+    didotAvailable,
+    didotFaces: 0,
+    changedPixels: 0,
+  };
+  if (didotAvailable) {
+    const didotFaces = didotList.fonts || [];
+    const expectedPublicKeys = ["localFontId", "family", "fullName", "postscriptName", "subfamily", "weight", "italic", "lastUsedAt", "variableAxes"];
+    if (didotFaces.length !== 3
+      || new Set(didotFaces.map((font) => font.localFontId)).size !== 3
+      || JSON.stringify([...new Set(didotFaces.map((font) => font.subfamily))].sort()) !== JSON.stringify(["Bold", "Italic", "Regular"])
+      || didotFaces.some((font) => JSON.stringify(Object.keys(font)) !== JSON.stringify(expectedPublicKeys))) {
+      throw new Error(`Didot.ttc did not expose its three distinct public faces: ${JSON.stringify(didotFaces)}`);
+    }
+    const listedFontJson = JSON.stringify(didotList);
+    if (/pathInternal|sourcePostscriptName|fileFingerprint|fingerprint|Didot\.ttc|\/System\/Library/.test(listedFontJson)) {
+      throw new Error(`Local font discovery exposed private source details: ${listedFontJson}`);
+    }
+    const regularDidot = didotFaces.find((font) => font.subfamily === "Regular" && font.weight === 400 && font.italic === false);
+    if (!regularDidot) throw new Error(`Didot Regular metadata was not exact: ${JSON.stringify(didotFaces)}`);
+
+    await evaluate(cdp, `document.fonts.ready.then(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))))`);
+    const defaultGeometry = await textGlyphGeometry(cdp, fontProbe.createdTextId);
+    if (defaultGeometry?.text !== "speed limit" || !defaultGeometry.family.includes("TikTok Sans") || !defaultGeometry.fontReady || defaultGeometry.glyphWidth <= 0) {
+      throw new Error(`The default speed-limit probe did not render in TikTok Sans: ${JSON.stringify(defaultGeometry)}`);
+    }
+    const defaultRendered = await tool("render_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, width: 360 });
+    const defaultImage = defaultRendered.content.find((item) => item.type === "image");
+    if (!defaultImage?.data) throw new Error("Default-font probe did not render an image.");
+
+    const importedDidot = (await tool("import_font", { projectId: createdProject.projectId, localFontId: regularDidot.localFontId })).structuredContent;
+    if (!importedDidot.fontId || importedDidot.localFontId !== regularDidot.localFontId || importedDidot.existing !== false) {
+      throw new Error(`Didot Regular did not import as one project font: ${JSON.stringify(importedDidot)}`);
+    }
+    await tool("update_text", {
+      projectId: createdProject.projectId,
+      slideId: addedSlide.createdSlideId,
+      updates: [{ id: fontProbe.createdTextId, fontId: importedDidot.fontId }],
+    });
+    const recentDidot = (await tool("list_local_fonts", {
+      query: "Didot",
+      limit: 20,
+      sort: "recent_then_alphabetical",
+    })).structuredContent.fonts;
+    if (recentDidot[0]?.localFontId !== regularDidot.localFontId || !(recentDidot[0].lastUsedAt > 0)) {
+      throw new Error(`Applying Didot through MCP did not update recent font usage: ${JSON.stringify(recentDidot)}`);
+    }
+    const didotGeometry = await waitFor(async () => {
+      const geometry = await textGlyphGeometry(cdp, fontProbe.createdTextId);
+      return geometry?.family.includes("carousel-font-") && geometry.fontReady && !geometry.missing && geometry.glyphWidth > 0 ? geometry : null;
+    }, "The editable speed-limit text did not repaint with the imported Didot face.");
+    if (didotGeometry.text !== "speed limit" || didotGeometry.weight !== "400" || Math.abs(didotGeometry.glyphWidth - defaultGeometry.glyphWidth) < 0.5) {
+      throw new Error(`Didot did not produce distinct glyph metrics: ${JSON.stringify({ defaultGeometry, didotGeometry })}`);
+    }
+    const didotRendered = await tool("render_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, width: 360 });
+    const didotImage = didotRendered.content.find((item) => item.type === "image");
+    if (!didotImage?.data) throw new Error("Didot probe did not render an image.");
+    const fontPixelDifference = await renderedPixelDifference(cdp, defaultImage.data, didotImage.data);
+    if (!fontPixelDifference.sameDimensions || fontPixelDifference.changedPixels < 500 || fontPixelDifference.maxChannelDelta < 32) {
+      throw new Error(`Default and Didot speed-limit renders were not measurably different: ${JSON.stringify(fontPixelDifference)}`);
+    }
+
+    let syntheticItalicError = null;
+    try {
+      await tool("update_text", {
+        projectId: createdProject.projectId,
+        slideId: addedSlide.createdSlideId,
+        updates: [{ id: fontProbe.createdTextId, fontStyle: "italic" }],
+      });
+    } catch (error) {
+      syntheticItalicError = error;
+    }
+    if (!syntheticItalicError || !/FONT_FACE_MISMATCH/.test(syntheticItalicError.message)) {
+      throw new Error(`Didot Regular accepted a synthetic italic request: ${syntheticItalicError?.message || "request succeeded"}`);
+    }
+
+    await tool("undo", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId });
+    const undoneFontInspection = (await tool("inspect_editor", {
+      projectId: createdProject.projectId,
+      slideId: addedSlide.createdSlideId,
+      includeAllProjects: false,
+    })).structuredContent;
+    const undoneProbe = undoneFontInspection.slide.texts.find((text) => text.id === fontProbe.createdTextId);
+    if (undoneProbe?.fontId || undoneProbe?.fontFamily !== "TikTok Sans") {
+      throw new Error(`Undo did not restore the built-in font: ${JSON.stringify(undoneProbe)}`);
+    }
+    await tool("redo", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId });
+    const redoneGeometry = await waitFor(async () => {
+      const geometry = await textGlyphGeometry(cdp, fontProbe.createdTextId);
+      return geometry?.family.includes("carousel-font-") && geometry.fontReady && !geometry.missing ? geometry : null;
+    }, "Redo did not restore the imported Didot face.");
+    if (Math.abs(redoneGeometry.glyphWidth - didotGeometry.glyphWidth) > 0.1) {
+      throw new Error(`Didot metrics changed across undo/redo: ${JSON.stringify({ didotGeometry, redoneGeometry })}`);
+    }
+
+    const projectFonts = (await tool("list_project_fonts", { projectId: createdProject.projectId })).structuredContent;
+    const fontInspection = (await tool("inspect_editor", {
+      projectId: createdProject.projectId,
+      slideId: addedSlide.createdSlideId,
+      includeAllProjects: false,
+    })).structuredContent;
+    const inspectedProbe = fontInspection.slide.texts.find((text) => text.id === fontProbe.createdTextId);
+    if (projectFonts.fonts?.length !== 1
+      || projectFonts.fonts[0].id !== importedDidot.fontId
+      || projectFonts.fonts[0].available !== true
+      || inspectedProbe?.fontId !== importedDidot.fontId) {
+      throw new Error(`Imported Didot metadata was not attached to the editable text: ${JSON.stringify({ projectFonts, inspectedProbe })}`);
+    }
+    const publicFontJson = JSON.stringify({ projectFonts, fontInspection });
+    if (/fontData|data:font|pathInternal|fileFingerprint|fingerprint|Didot\.ttc|\/System\/Library/.test(publicFontJson)) {
+      throw new Error(`Project inspection exposed local font bytes or paths: ${publicFontJson}`);
+    }
+
+    await cdp.send("Page.reload", { ignoreCache: true });
+    await waitFor(() => evaluate(cdp, `document.readyState === "complete" && document.querySelector('.project-title-input')?.value === "Full MCP browser test" && document.querySelector('[data-action="connect-agent"]')?.dataset.mcpStatus === "connected"`), "The font project did not restore after reload.");
+    await evaluate(cdp, `document.fonts.ready.then(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))))`);
+    const restoredGeometry = await waitFor(async () => {
+      const geometry = await textGlyphGeometry(cdp, fontProbe.createdTextId);
+      return geometry?.family.includes("carousel-font-")
+        && geometry.fontReady
+        && !geometry.missing
+        ? geometry
+        : null;
+    }, "The imported Didot face was not restored from the local project after reload.");
+    if (restoredGeometry.text !== "speed limit" || Math.abs(restoredGeometry.glyphWidth - didotGeometry.glyphWidth) > 0.1) {
+      throw new Error(`Didot editor geometry changed after project reload: ${JSON.stringify({ didotGeometry, restoredGeometry })}`);
+    }
+    const restoredRendered = await tool("render_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, width: 360 });
+    const restoredImage = restoredRendered.content.find((item) => item.type === "image");
+    const reloadPixelDifference = await renderedPixelDifference(cdp, didotImage.data, restoredImage?.data || "");
+    if (!reloadPixelDifference.sameDimensions || reloadPixelDifference.changedPixels !== 0) {
+      throw new Error(`Didot slide pixels changed after project reload: ${JSON.stringify(reloadPixelDifference)}`);
+    }
+
+    const fullDidotRender = await tool("render_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, width: 1080 });
+    const fullDidotImage = fullDidotRender.content.find((item) => item.type === "image");
+    await tool("export_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, outputPath: fontExportPath });
+    const exportedDidot = await readFile(fontExportPath);
+    if (!fullDidotImage?.data || !exportedDidot.equals(Buffer.from(fullDidotImage.data, "base64"))) {
+      throw new Error("The exported Didot slide did not match the full-resolution editor renderer.");
+    }
+    localFontAcceptance = {
+      ...localFontAcceptance,
+      didotFaces: didotFaces.length,
+      changedPixels: fontPixelDifference.changedPixels,
+      glyphWidthDelta: Math.abs(didotGeometry.glyphWidth - defaultGeometry.glyphWidth),
+      reloadPixelsChanged: reloadPixelDifference.changedPixels,
+      exportBytes: exportedDidot.length,
+    };
+  }
+  await tool("delete_layers", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, layerIds: [fontProbe.createdTextId] });
+  await waitFor(() => evaluate(cdp, `${JSON.stringify(fontProbe.createdTextId)} !== "" && ![...document.querySelectorAll(".text-box")].some((item) => item.dataset.textId === ${JSON.stringify(fontProbe.createdTextId)})`), "The temporary local-font probe was not removed.");
+
   const addedText = (await tool("add_text", {
     projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, text: "Built live by an AI agent",
     x: 0.1, y: 0.2, width: 0.8, height: 0.16, size: 82, style: "boxed", background: "black", backgroundShape: "lines", color: "#FFFFFF",
@@ -489,7 +760,7 @@ try {
     .catch((error) => { if (!/revision changed/.test(error.message)) throw error; });
   await tool("end_edit_session", { editSessionId });
   editSessionId = null;
-  process.stdout.write(`${JSON.stringify({ connected: true, optInRequired: true, reconnectAfterReload: true, sevenTabConnectionStress: true, crossTabSync: true, crossTabActionNotifications: true, composedDashboardCover: true, dashboardProjectNotification: true, connectionStatusLeftAligned: true, backgroundEditsPreserveView: true, roleBasedTextDefaults: true, automaticTextHeightFitting: true, agentIdentityNotificationIcon: true, compactToolbar: true, fittedFullBox: true, symmetricPerLinePaddingAfterReload: true, projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, textLayers: 2, imageLayers: 1, operationsCovered: 34, previewBytes: imageContent.data.length, exportBytes: (await stat(exportPath)).size, projectExports: exportedProject.fileCount }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ connected: true, optInRequired: true, reconnectAfterReload: true, localFonts: localFontAcceptance, sevenTabConnectionStress: true, crossTabSync: true, crossTabActionNotifications: true, composedDashboardCover: true, dashboardProjectNotification: true, connectionStatusLeftAligned: true, backgroundEditsPreserveView: true, roleBasedTextDefaults: true, automaticTextHeightFitting: true, agentIdentityNotificationIcon: true, compactToolbar: true, fittedFullBox: true, symmetricPerLinePaddingAfterReload: true, projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, textLayers: 2, imageLayers: 1, operationsCovered: 41, previewBytes: imageContent.data.length, exportBytes: (await stat(exportPath)).size, projectExports: exportedProject.fileCount }, null, 2)}\n`);
 } finally {
   await closeChromeGracefully();
   for (const extraCdp of additionalCdps) extraCdp.close();

--- a/src/agent-commands.mjs
+++ b/src/agent-commands.mjs
@@ -3,7 +3,6 @@ import {
   OUTPUT_WIDTH,
   OUTPUT_HEIGHT,
   DEFAULT_OUTLINE_WIDTH,
-  TEXT_WEIGHT,
   TEXT_LINE_HEIGHT,
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
@@ -48,6 +47,18 @@ import {
 } from "./project-store.mjs";
 import { measureCanvas } from "./editor-view.mjs";
 import { getImageDimensions, renderSlideCanvas, fingerprintData } from "./slide-renderer.mjs";
+import {
+  DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_WEIGHT,
+  applyProjectFontToText,
+  createProjectFont,
+  ensureProjectFontsLoaded,
+  projectFontForText,
+  publicProjectFont,
+  textCanvasFont,
+  textFontVariationCss,
+} from "./project-fonts.mjs";
+import { reconcileAgentFontWeightPatch } from "./agent-font-patch.mjs";
 import {
   recordHistory,
   undo,
@@ -103,6 +114,7 @@ function agentProjectSummary(project) {
     revision: Number(project.revision) || 0,
     slideCount: project.slides.length,
     assetCount: (project.assets || []).length,
+    fontCount: (project.fonts || []).length,
     updatedAt: project.updatedAt,
   };
 }
@@ -135,6 +147,7 @@ function agentInspect({ projectId, slideId, includeAllProjects = true } = {}) {
       ...agentProjectSummary(project),
       slides: project.slides.map(agentSlideSummary),
       assets: (project.assets || []).map(({ id, name, width, height }) => ({ id, name, width, height })),
+      fonts: (project.fonts || []).map((font) => publicProjectFont(project, font)),
     } : null,
     slide: slide ? {
       ...agentSlideSummary(slide, project.slides.indexOf(slide)),
@@ -171,6 +184,18 @@ async function agentMedia(mediaId) {
   const imageData = await fileToDataUrl(media.file);
   const dimensions = await getImageDimensions(imageData);
   return { imageData, ...dimensions, name: media.name };
+}
+
+async function agentMarkFontsUsed(project, textLayers) {
+  const bridge = window.carouselBotLocalMcpBridge;
+  if (!bridge?.markFontUsed) return;
+  const localFontIds = [...new Set(textLayers.flatMap((text) => {
+    const font = projectFontForText(project, text);
+    return font?.localFontId ? [font.localFontId] : [];
+  }))];
+  await Promise.all(localFontIds.map((localFontId) => bridge.markFontUsed(localFontId).catch((error) => {
+    console.warn(`Could not update recent font usage for ${localFontId}:`, error);
+  })));
 }
 
 async function agentCommit(project, slide, mutate, message) {
@@ -225,7 +250,13 @@ async function agentCommit(project, slide, mutate, message) {
   };
 }
 
-function agentApplyTextPatch(text, patch = {}) {
+function agentFontError(code, message) {
+  const error = new Error(`[${code}] ${message}`);
+  error.code = code;
+  return error;
+}
+
+function agentApplyTextPatch(text, patch = {}, project = null) {
   if (patch.text != null) text.text = String(patch.text).slice(0, 4000);
   if (patch.role != null && Object.hasOwn(AGENT_TEXT_ROLE_SIZES, patch.role)) text.role = patch.role;
   if (patch.width != null) text.width = clamp(Number(patch.width), 0.1, 1.5);
@@ -239,16 +270,53 @@ function agentApplyTextPatch(text, patch = {}) {
   if (patch.background != null) text.background = patch.background === "black" ? "black" : "white";
   if (patch.backgroundShape != null) text.backgroundShape = patch.backgroundShape === "full" ? "full" : "lines";
   if (patch.align != null) text.align = ["left", "center", "right"].includes(patch.align) ? patch.align : text.align;
+  if (Object.hasOwn(patch, "fontId")) {
+    if (!project) throw new Error("A project is required when changing a text font.");
+    applyProjectFontToText(project, text, patch.fontId);
+  }
+  const projectFont = projectFontForText(project, text);
+  if (patch.fontWeight != null) {
+    const requestedWeight = clamp(Math.round(Number(patch.fontWeight) || DEFAULT_FONT_WEIGHT), 1, 1000);
+    const weightAxis = projectFont?.variableAxes?.find((axis) => axis.tag === "wght");
+    if (projectFont && !weightAxis && requestedWeight !== projectFont.weight) {
+      throw agentFontError("FONT_FACE_MISMATCH", `${projectFont.fullName} is weight ${projectFont.weight}. Import and use the exact installed face for weight ${requestedWeight}.`);
+    }
+    text.fontWeight = weightAxis ? clamp(requestedWeight, weightAxis.min, weightAxis.max) : requestedWeight;
+  }
+  if (patch.fontStyle != null) {
+    const requestedStyle = patch.fontStyle === "italic" ? "italic" : "normal";
+    const exactStyle = projectFont?.italic ? "italic" : "normal";
+    if (projectFont && requestedStyle !== exactStyle) {
+      throw agentFontError("FONT_FACE_MISMATCH", `${projectFont.fullName} is ${exactStyle}. Import and use the exact installed ${requestedStyle} face.`);
+    }
+    text.fontStyle = requestedStyle;
+  }
+  if (patch.fontVariationSettings != null) {
+    const axes = new Map((projectFont?.variableAxes || []).map((axis) => [axis.tag, axis]));
+    if (projectFont) {
+      const unsupported = Object.keys(patch.fontVariationSettings).find((tag) => !axes.has(tag));
+      if (unsupported) throw agentFontError("FONT_AXIS_UNSUPPORTED", `${projectFont.fullName} does not expose the ${unsupported} axis.`);
+    }
+    text.fontVariationSettings = Object.fromEntries(Object.entries(patch.fontVariationSettings)
+      .filter(([tag, value]) => /^[A-Za-z0-9]{4}$/.test(tag) && Number.isFinite(Number(value)))
+      .map(([tag, value]) => {
+        const axis = axes.get(tag);
+        const numeric = tag === "wght" ? Math.round(Number(value)) : Number(value);
+        return [tag, axis ? clamp(numeric, axis.min, axis.max) : tag === "wght" ? clamp(numeric, 1, 1000) : numeric];
+      }));
+  }
+  reconcileAgentFontWeightPatch(text, patch);
   if (patch.rotation != null) text.rotation = ((Number(patch.rotation) || 0) % 360 + 360) % 360;
   if (patch.z != null) text.z = Number(patch.z) || text.z;
   ensureBoxedTextContrast(text);
   return text;
 }
 
-function agentFitTextBox(text, mode = "both") {
+function agentFitTextBox(text, mode = "both", project = agentProject()) {
   const context = measureCanvas.getContext("2d");
   const fontSize = text.size;
-  context.font = `${TEXT_WEIGHT} ${fontSize}px "TikTok Sans"`;
+  context.font = textCanvasFont(project, text, fontSize);
+  if ("fontVariationSettings" in context) context.fontVariationSettings = textFontVariationCss(project, text);
   const perLineBox = text.style === "boxed" && (text.backgroundShape || "lines") !== "full";
   const fullBox = text.style === "boxed" && text.backgroundShape === "full";
   const horizontalInset = perLineBox
@@ -285,11 +353,11 @@ function agentFitTextBox(text, mode = "both") {
   };
 }
 
-function agentAutoFitTextBox(text) {
+function agentAutoFitTextBox(text, project = agentProject()) {
   text.width = clamp(text.width, 0.1, 1);
   text.x = clamp(text.x, 0, 1 - text.width);
   const requestedTop = text.y;
-  const result = agentFitTextBox(text, "height");
+  const result = agentFitTextBox(text, "height", project);
   if (text.height > 1) {
     throw new Error(`Text requires ${result.lineCount} lines and cannot fit on one slide at this width and font size. Shorten it, widen it, reduce it within the role range, or split it across slides.`);
   }
@@ -337,6 +405,8 @@ async function executeCarouselBotAgentOperation(operation) {
 
   if (operation.type === "editor.inspect") {
     if (operation.projectId) await reloadProjectFromDb(operation.projectId, { render: false });
+    const project = state.projects.find((item) => item.id === (operation.projectId || state.activeProjectId));
+    if (project) await ensureProjectFontsLoaded(project).catch(() => {});
     return agentInspect(operation);
   }
   if (operation.type === "ui.notify") {
@@ -357,7 +427,7 @@ async function executeCarouselBotAgentOperation(operation) {
     const now = Date.now();
     const project = {
       id: uid(), name: String(operation.name || "New Project").slice(0, 160), createdAt: now,
-      updatedAt: now, revision: 1, slides: [], assets: [],
+      updatedAt: now, revision: 1, slides: [], assets: [], fonts: [],
     };
     state.projects.push(project);
     await putProject(project);
@@ -479,35 +549,111 @@ async function executeCarouselBotAgentOperation(operation) {
     }, "AI agent deleted a slide");
   }
 
+  if (operation.type === "font.list") {
+    const project = agentProject(operation.projectId);
+    await ensureProjectFontsLoaded(project).catch(() => {});
+    return {
+      projectId: project.id,
+      revision: Number(project.revision) || 0,
+      fonts: (project.fonts || []).map((font) => publicProjectFont(project, font)),
+    };
+  }
+
+  if (operation.type === "font.import") {
+    const project = agentProject(operation.projectId);
+    const current = project.slides.find((item) => item.id === state.activeSlideId) || project.slides[0] || null;
+    const existing = (project.fonts || []).find((font) => font.localFontId === operation.localFontId);
+    if (existing) {
+      try {
+        await ensureProjectFontsLoaded(project, [{ fontId: existing.id }]);
+        return {
+          projectId: project.id,
+          fontId: existing.id,
+          localFontId: existing.localFontId,
+          family: existing.family,
+          subfamily: existing.subfamily,
+          weight: existing.weight,
+          italic: existing.italic,
+          revision: Number(project.revision) || 0,
+          existing: true,
+          repaired: false,
+        };
+      } catch (error) {
+        if (error?.code !== "FONT_UNAVAILABLE") throw error;
+      }
+    }
+    if (!operation.fontMediaId || !operation.font?.localFontId) throw new Error("The local font transfer is incomplete. List the font again and retry import_font.");
+    if (operation.font.localFontId !== operation.localFontId) throw new Error("The selected local font no longer matches the prepared transfer. List fonts and retry.");
+    const transfer = await window.carouselBotLocalMcpBridge.fetchFontMedia(operation.fontMediaId);
+    const source = transfer?.file instanceof Blob
+      ? transfer.file
+      : transfer instanceof Blob
+        ? transfer
+        : new Blob([transfer?.arrayBuffer || transfer?.buffer || transfer], { type: transfer?.mimeType || "font/otf" });
+    const fontData = await fileToDataUrl(source);
+    const font = createProjectFont(operation.font, fontData, existing
+      ? { id: existing.id, addedAt: existing.addedAt }
+      : undefined);
+    const candidateFonts = existing
+      ? (project.fonts || []).map((item) => item.id === existing.id ? font : item)
+      : [...(project.fonts || []), font];
+    const candidate = { ...project, fonts: candidateFonts };
+    await ensureProjectFontsLoaded(candidate, [{ fontId: font.id }]);
+    return agentCommit(project, current, () => {
+      project.fonts ||= [];
+      if (existing) project.fonts.splice(project.fonts.findIndex((item) => item.id === existing.id), 1, font);
+      else project.fonts.push(font);
+      return {
+        fontId: font.id,
+        localFontId: font.localFontId,
+        family: font.family,
+        subfamily: font.subfamily,
+        weight: font.weight,
+        italic: font.italic,
+        existing: Boolean(existing),
+        repaired: Boolean(existing),
+      };
+    }, existing ? "AI agent repaired a local font" : "AI agent added a local font");
+  }
+
   if (operation.type === "text.add") {
     const project = agentProject(operation.projectId);
     const slide = agentSlide(project, operation.slideId);
-    await document.fonts.load(`${TEXT_WEIGHT} 64px "TikTok Sans"`);
     const role = agentTextRole(operation.text, operation.role);
     const text = agentApplyTextPatch({
       id: uid(), text: "Your text", x: 0.12, y: 0.4, width: 0.76, height: 0.12,
       role, size: AGENT_TEXT_ROLE_SIZES[role], style: "plain", outlineWidth: DEFAULT_OUTLINE_WIDTH, color: "#FFFFFF",
+      fontFamily: DEFAULT_FONT_FAMILY, fontWeight: DEFAULT_FONT_WEIGHT, fontStyle: "normal",
       background: "black", backgroundShape: "lines", align: "center", rotation: 0,
       z: nextLayerZ(slide),
-    }, operation);
-    const fittedTextBox = agentAutoFitTextBox(text);
-    return agentCommit(project, slide, () => {
+    }, operation, project);
+    await ensureProjectFontsLoaded(project, [text]);
+    const fittedTextBox = agentAutoFitTextBox(text, project);
+    const result = await agentCommit(project, slide, () => {
       slide.texts.push(text);
       selectOnlyLayer("text", text.id);
       return { createdTextId: text.id, fittedTextBox };
     }, "AI agent added text");
+    if (operation.fontId) await agentMarkFontsUsed(project, [text]);
+    return result;
   }
 
   if (operation.type === "text.update") {
     const project = agentProject(operation.projectId);
     const slide = agentSlide(project, operation.slideId);
-    await document.fonts.load(`${TEXT_WEIGHT} 64px "TikTok Sans"`);
-    return agentCommit(project, slide, () => {
-      const fittedTextBoxes = operation.updates.map(({ id, ...patch }) => {
-        const text = slide.texts.find((item) => item.id === id);
-        if (!text) throw new Error(`Text layer not found: ${id}`);
-        const next = agentApplyTextPatch({ ...text }, patch);
-        const fitted = agentAutoFitTextBox(next);
+    const candidates = operation.updates.map(({ id, ...patch }) => {
+      const text = slide.texts.find((item) => item.id === id);
+      if (!text) throw new Error(`Text layer not found: ${id}`);
+      return {
+        text,
+        next: agentApplyTextPatch({ ...text }, patch, project),
+        appliesFont: Object.hasOwn(patch, "fontId") && Boolean(patch.fontId),
+      };
+    });
+    await ensureProjectFontsLoaded(project, candidates.map(({ next }) => next));
+    const result = await agentCommit(project, slide, () => {
+      const fittedTextBoxes = candidates.map(({ text, next }) => {
+        const fitted = agentAutoFitTextBox(next, project);
         Object.assign(text, next);
         return fitted;
       });
@@ -515,17 +661,24 @@ async function executeCarouselBotAgentOperation(operation) {
       if (updated.length === 1) selectOnlyLayer("text", updated[0]);
       return { updatedTextIds: updated, fittedTextBoxes };
     }, "AI agent updated text");
+    await agentMarkFontsUsed(project, candidates.filter(({ appliesFont }) => appliesFont).map(({ next }) => next));
+    return result;
   }
 
   if (operation.type === "text.fit") {
     const project = agentProject(operation.projectId);
     const slide = agentSlide(project, operation.slideId);
-    await document.fonts.load(`${TEXT_WEIGHT} 64px "TikTok Sans"`);
+    const textLayers = operation.textIds.map((id) => {
+      const text = slide.texts.find((item) => item.id === id);
+      if (!text) throw new Error(`Text layer not found: ${id}`);
+      return text;
+    });
+    await ensureProjectFontsLoaded(project, textLayers);
     return agentCommit(project, slide, () => ({
       fittedTextBoxes: operation.textIds.map((id) => {
         const text = slide.texts.find((item) => item.id === id);
         if (!text) throw new Error(`Text layer not found: ${id}`);
-        return agentFitTextBox(text, operation.mode);
+        return agentFitTextBox(text, operation.mode, project);
       }),
     }), "AI agent fitted text boxes to their content");
   }

--- a/src/agent-font-patch.mjs
+++ b/src/agent-font-patch.mjs
@@ -1,0 +1,28 @@
+function fontWeightConflict(message) {
+  const error = new Error(`[FONT_WEIGHT_CONFLICT] ${message}`);
+  error.code = "FONT_WEIGHT_CONFLICT";
+  return error;
+}
+
+/** Keep the high-level font weight and the low-level wght axis as one source of truth. */
+export function reconcileAgentFontWeightPatch(text, patch = {}) {
+  const settings = text?.fontVariationSettings && typeof text.fontVariationSettings === "object"
+    ? { ...text.fontVariationSettings }
+    : {};
+  const hasVariationWeight = Object.hasOwn(settings, "wght") && Number.isFinite(Number(settings.wght));
+  const patchedVariationWeight = patch.fontVariationSettings != null
+    && Object.hasOwn(patch.fontVariationSettings, "wght")
+    && hasVariationWeight;
+  const patchedFontWeight = patch.fontWeight != null;
+
+  if (patchedVariationWeight && patchedFontWeight && Number(settings.wght) !== Number(text.fontWeight)) {
+    throw fontWeightConflict("fontWeight and fontVariationSettings.wght must resolve to the same value.");
+  }
+  if (patchedVariationWeight) {
+    text.fontWeight = Number(settings.wght);
+  } else if (patchedFontWeight && hasVariationWeight) {
+    settings.wght = Number(text.fontWeight);
+  }
+  if (hasVariationWeight && (patchedVariationWeight || patchedFontWeight)) text.fontVariationSettings = settings;
+  return text;
+}

--- a/src/editor-actions.mjs
+++ b/src/editor-actions.mjs
@@ -31,6 +31,7 @@ import {
 } from "./editor-state.mjs";
 import { putProject } from "./project-store.mjs";
 import { getImageDimensions, fingerprintData } from "./slide-renderer.mjs";
+import { DEFAULT_FONT_FAMILY, DEFAULT_FONT_WEIGHT } from "./project-fonts.mjs";
 
 export function createEditorActions({
   recordHistory,
@@ -148,6 +149,9 @@ export function createEditorActions({
       width,
       height,
       size: 64,
+      fontFamily: DEFAULT_FONT_FAMILY,
+      fontWeight: DEFAULT_FONT_WEIGHT,
+      fontStyle: "normal",
       style: "plain",
       outlineWidth: DEFAULT_OUTLINE_WIDTH,
       color: "#FFFFFF",

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -70,9 +70,16 @@ export function cloneProject(project) {
   return {
     ...project,
     assets: (project.assets || []).map((asset) => ({ ...asset })),
+    fonts: (project.fonts || []).map((font) => ({
+      ...font,
+      variableAxes: (font.variableAxes || []).map((axis) => ({ ...axis })),
+    })),
     slides: (project.slides || []).map((slide) => ({
       ...slide,
-      texts: (slide.texts || []).map((text) => ({ ...text })),
+      texts: (slide.texts || []).map((text) => ({
+        ...text,
+        ...(text.fontVariationSettings ? { fontVariationSettings: { ...text.fontVariationSettings } } : {}),
+      })),
       overlays: (slide.overlays || []).map((overlay) => ({ ...overlay })),
     })),
   };

--- a/src/editor-output.mjs
+++ b/src/editor-output.mjs
@@ -11,7 +11,7 @@ import { canvasToBlob, renderSlideCanvas } from "./slide-renderer.mjs";
 export function createEditorOutput({ toast }) {
   function projectCoverSignature(project) {
     const slide = project.slides[0];
-    return slide ? `${Number(project.revision) || 0}:${slide.id}:${thumbnailSignature(slide)}` : "";
+    return slide ? `${Number(project.revision) || 0}:${slide.id}:${thumbnailSignature(slide, project)}` : "";
   }
 
   async function refreshProjectCover(project) {
@@ -51,11 +51,23 @@ export function createEditorOutput({ toast }) {
         image.alt = "";
         image.dataset.compositeCover = "true";
         currentTarget.replaceChildren(image);
+        currentTarget.removeAttribute("title");
         currentTarget.classList.remove("is-rendering");
       }
     } catch (error) {
       console.error("Could not render project cover", error);
-      target.classList.remove("is-rendering");
+      clearProjectCover(project.id);
+      const currentTarget = app.querySelector(`[data-project-cover-id="${project.id}"]`);
+      if (currentTarget) {
+        currentTarget.classList.remove("is-rendering");
+        currentTarget.title = error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Preview unavailable";
+        if (slide.imageData) {
+          const image = document.createElement("img");
+          image.src = slide.imageData;
+          image.alt = "";
+          currentTarget.replaceChildren(image);
+        } else currentTarget.innerHTML = `<span class="project-preview-empty">Preview unavailable</span>`;
+      }
     }
   }
 
@@ -80,7 +92,11 @@ export function createEditorOutput({ toast }) {
     }, 80);
   }
 
-  function thumbnailSignature(slide) {
+  function thumbnailSignature(slide, project = activeProject()) {
+    const fontIds = new Set((slide.texts || []).map((text) => text.fontId).filter(Boolean));
+    const fonts = (project?.fonts || [])
+      .filter((font) => fontIds.has(font.id))
+      .map((font) => [font.id, font.fingerprint || font.localFontId || "", font.dataRevision || "", font.fontData?.length || 0]);
     return JSON.stringify([
       slide.backgroundRevision || "",
       slide.imageScale || 1,
@@ -88,6 +104,7 @@ export function createEditorOutput({ toast }) {
       slide.imageY || 0,
       slide.texts || [],
       slide.overlays || [],
+      fonts,
     ]);
   }
 
@@ -117,11 +134,18 @@ export function createEditorOutput({ toast }) {
       const currentTarget = app.querySelector(`[data-thumbnail-slide-id="${slide.id}"]`);
       if (currentTarget) {
         currentTarget.innerHTML = renderSlideThumbnail(slide);
+        currentTarget.removeAttribute("title");
         currentTarget.classList.remove("is-rendering");
       }
     } catch (error) {
       console.error(error);
-      target.classList.remove("is-rendering");
+      clearSlideThumbnail(slide.id);
+      const currentTarget = app.querySelector(`[data-thumbnail-slide-id="${slide.id}"]`);
+      if (currentTarget) {
+        currentTarget.classList.remove("is-rendering");
+        currentTarget.title = error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Preview unavailable";
+        currentTarget.innerHTML = renderSlideThumbnail(slide);
+      }
     }
   }
 
@@ -169,7 +193,7 @@ export function createEditorOutput({ toast }) {
       toast("PNG downloaded at full resolution");
     } catch (error) {
       console.error(error);
-      toast("The image couldn’t be downloaded.");
+      toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "The image couldn’t be downloaded.");
     } finally {
       if (exportButton) {
         exportButton.disabled = false;
@@ -206,7 +230,7 @@ export function createEditorOutput({ toast }) {
     } catch (error) {
       if (error?.name === "AbortError") return;
       console.error(error);
-      toast("Couldn’t open the share menu.");
+      toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Couldn’t open the share menu.");
     } finally {
       if (shareButton) {
         shareButton.disabled = false;
@@ -260,7 +284,7 @@ export function createEditorOutput({ toast }) {
       }
       state.shareAllCache = null;
       console.error(error);
-      toast("Couldn’t open the share menu for all slides.");
+      toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Couldn’t open the share menu for all slides.");
     } finally {
       shareButtons.forEach((button) => { button.disabled = false; });
       if (shareButton) shareButton.innerHTML = oldLabel;

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -34,9 +34,11 @@ import {
   putProject,
   deleteProjectFromDb,
 } from "./project-store.mjs";
+import { normalizeProjectFonts, ensureProjectFontsLoaded } from "./project-fonts.mjs";
 
 export function normalizeLoadedProjects(projects) {
   projects.forEach((project) => {
+    normalizeProjectFonts(project);
     if (!Number.isFinite(Number(project.revision))) project.revision = 0;
     if (!Array.isArray(project.assets)) project.assets = [];
     project.slides.forEach((slide) => {
@@ -98,12 +100,14 @@ export function createEditorProjects({
     const expectedRevision = Number(state.projects[index].revision) || 0;
     history.applying = true;
     state.projects[index] = { ...cloneProject(snapshot), revision: expectedRevision + 1, updatedAt: Date.now() };
+    normalizeLoadedProjects([state.projects[index]]);
     state.activeProjectId = snapshot.id;
     if (!state.projects[index].slides.some((slide) => slide.id === state.activeSlideId)) {
       state.activeSlideId = state.projects[index].slides[0]?.id || null;
     }
     setLayerSelection(selectedLayerKeys());
     state.croppingOverlayId = null;
+    await ensureProjectFontsLoaded(state.projects[index]).catch(() => {});
     renderEditor();
     try {
       await putProject(state.projects[index], { expectedRevision });
@@ -143,6 +147,7 @@ export function createEditorProjects({
 
   async function importMigratedProject(project) {
     const incoming = structuredClone(project);
+    normalizeLoadedProjects([incoming]);
     const result = await new Promise((resolve, reject) => {
       const transaction = state.db.transaction(STORE_NAME, "readwrite");
       const store = transaction.objectStore(STORE_NAME);
@@ -173,6 +178,7 @@ export function createEditorProjects({
 
   async function reloadProjectFromDb(projectId, { render = true } = {}) {
     const latest = await getProjectFromDb(projectId);
+    if (latest) normalizeLoadedProjects([latest]);
     const index = state.projects.findIndex((project) => project.id === projectId);
     if (!latest) {
       if (index >= 0) state.projects.splice(index, 1);
@@ -188,7 +194,10 @@ export function createEditorProjects({
     } else state.projects.push(latest);
     if (render) {
       if (!state.activeProjectId) renderDashboard();
-      else if (state.activeProjectId === projectId) renderEditor();
+      else if (state.activeProjectId === projectId) {
+        await ensureProjectFontsLoaded(latest).catch(() => {});
+        renderEditor();
+      }
     }
     return latest;
   }
@@ -371,7 +380,7 @@ export function createEditorProjects({
 
   function createProject() {
     const now = Date.now();
-    const project = { id: uid(), name: "New Project", createdAt: now, updatedAt: now, revision: 0, slides: [], assets: [] };
+    const project = { id: uid(), name: "New Project", createdAt: now, updatedAt: now, revision: 0, slides: [], assets: [], fonts: [] };
     state.projects.push(project);
     openProject(project.id);
     putProject(project).catch((error) => {
@@ -461,7 +470,7 @@ export function createEditorProjects({
     dashboardRefreshPromise = getAllProjects()
       .then((projects) => {
         if (state.activeProjectId) return;
-        state.projects = projects;
+        state.projects = normalizeLoadedProjects(projects);
         renderDashboard();
         bindGlobalActions();
       })

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -1,7 +1,6 @@
 import {
   OUTPUT_WIDTH,
   OUTPUT_HEIGHT,
-  TEXT_WEIGHT,
   FONT_SIZE_MIN,
   FONT_SIZE_MAX,
   CANVAS_ZOOM_MIN,
@@ -51,6 +50,11 @@ import {
   updateStageImage,
 } from "./editor-view.mjs";
 import { createLayerInteractions } from "./layer-interactions.mjs";
+import {
+  applyProjectFontToText,
+  createProjectFont,
+  ensureProjectFontsLoaded,
+} from "./project-fonts.mjs";
 
 export function createEditorUI({ projects, actions, output }) {
   const {
@@ -80,6 +84,7 @@ export function createEditorUI({ projects, actions, output }) {
     handleUpload,
     addSlidesFromFiles,
     imageFilesFromTransfer,
+    fileToDataUrl,
   } = actions;
   const {
     refreshAllProjectCovers,
@@ -265,6 +270,201 @@ export function createEditorUI({ projects, actions, output }) {
     state.toastTimer = setTimeout(() => element.remove(), 2600);
   }
 
+  let fontPickerRequest = 0;
+  let fontPickerSearchTimer = null;
+
+  function closeFontPicker() {
+    window.clearTimeout(fontPickerSearchTimer);
+    fontPickerRequest += 1;
+    document.querySelector(".font-picker-backdrop")?.remove();
+  }
+
+  async function applyFontToSelectedText(fontId) {
+    const project = activeProject();
+    const text = selectedText();
+    if (!project || !text) return;
+    const next = { ...text };
+    applyProjectFontToText(project, next, fontId);
+    await ensureProjectFontsLoaded(project, [next]);
+    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id) return;
+    recordHistory(project);
+    Object.assign(text, next);
+    refreshSelection();
+    updateTextBox(text);
+    ensureTextFits(text, { force: true });
+    scheduleSave();
+    const font = fontId ? project.fonts.find((item) => item.id === fontId) : null;
+    if (font?.localFontId) {
+      await window.carouselBotLocalMcpBridge?.markFontUsed?.(font.localFontId).catch((error) => {
+        console.warn(`Could not update recent font usage for ${font.localFontId}:`, error);
+      });
+    }
+  }
+
+  async function addLocalFontToSelectedText(face) {
+    const project = activeProject();
+    const text = selectedText();
+    const bridge = window.carouselBotLocalMcpBridge;
+    if (!project || !text || !bridge) return;
+    const existing = (project.fonts || []).find((item) => item.localFontId === face.localFontId) || null;
+    let font = existing;
+    let repaired = false;
+    if (existing) {
+      try {
+        await ensureProjectFontsLoaded(project, [{ fontId: existing.id }]);
+      } catch (error) {
+        if (error?.code !== "FONT_UNAVAILABLE") throw error;
+        repaired = true;
+      }
+    }
+    if (!font || repaired) {
+      const transfer = await bridge.fetchLocalFont(face.localFontId);
+      const source = transfer?.file instanceof Blob
+        ? transfer.file
+        : transfer instanceof Blob
+          ? transfer
+          : new Blob([transfer?.arrayBuffer || transfer?.buffer || transfer], { type: transfer?.mimeType || "font/otf" });
+      font = createProjectFont(transfer?.font || face, await fileToDataUrl(source), existing
+        ? { id: existing.id, addedAt: existing.addedAt }
+        : undefined);
+    }
+    const candidateFonts = existing && repaired
+      ? (project.fonts || []).map((item) => item.id === existing.id ? font : item)
+      : existing
+        ? project.fonts
+        : [...(project.fonts || []), font];
+    const candidateProject = candidateFonts === project.fonts ? project : { ...project, fonts: candidateFonts };
+    const next = { ...text };
+    applyProjectFontToText(candidateProject, next, font.id);
+    await ensureProjectFontsLoaded(candidateProject, [next]);
+    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id) return;
+    recordHistory(project);
+    if (existing && repaired) project.fonts.splice(project.fonts.findIndex((item) => item.id === existing.id), 1, font);
+    else if (!existing) (project.fonts ||= []).push(font);
+    Object.assign(text, next);
+    closeFontPicker();
+    refreshSelection();
+    updateTextBox(text);
+    ensureTextFits(text, { force: true });
+    scheduleSave();
+    await bridge.markFontUsed?.(font.localFontId).catch((error) => {
+      console.warn(`Could not update recent font usage for ${font.localFontId}:`, error);
+    });
+    toast(`${font.fullName || font.family} ${repaired ? "repaired" : existing ? "selected" : "added"}`);
+  }
+
+  function fontPickerShell() {
+    const backdrop = document.createElement("div");
+    backdrop.className = "modal-backdrop font-picker-backdrop";
+    backdrop.innerHTML = `
+      <section class="modal font-picker-modal" role="dialog" aria-modal="true" aria-labelledby="font-picker-title">
+        <div class="font-picker-header">
+          <div><p class="eyebrow">Local fonts</p><h2 id="font-picker-title">Choose a font</h2></div>
+          <button class="icon-button font-picker-close" type="button" aria-label="Close font picker">×</button>
+        </div>
+        <div class="font-picker-content"></div>
+      </section>`;
+    document.body.appendChild(backdrop);
+    backdrop.querySelector(".font-picker-close").addEventListener("click", closeFontPicker);
+    backdrop.addEventListener("pointerdown", (event) => { if (event.target === backdrop) closeFontPicker(); });
+    backdrop.addEventListener("keydown", (event) => { if (event.key === "Escape") closeFontPicker(); });
+    return backdrop;
+  }
+
+  async function renderInstalledFontResults(backdrop, query = "") {
+    const content = backdrop.querySelector(".font-picker-content");
+    const request = ++fontPickerRequest;
+    const list = content.querySelector(".font-results");
+    const status = content.querySelector(".font-picker-status");
+    status.textContent = "Looking through fonts on this Mac…";
+    list.replaceChildren();
+    try {
+      const result = await window.carouselBotLocalMcpBridge.listLocalFonts({ query, limit: 80, sort: query ? "alphabetical" : "recent_then_alphabetical" });
+      if (request !== fontPickerRequest || !backdrop.isConnected) return;
+      status.textContent = result.fonts.length ? `${result.fonts.length}${result.nextCursor ? "+" : ""} faces` : "No matching fonts";
+      result.fonts.forEach((face) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "font-result";
+        const names = document.createElement("span");
+        const family = document.createElement("strong");
+        const style = document.createElement("small");
+        family.textContent = face.family;
+        style.textContent = face.subfamily || "Regular";
+        names.append(family, style);
+        const use = document.createElement("span");
+        use.className = "font-result-use";
+        use.textContent = "Use";
+        button.append(names, use);
+        button.addEventListener("click", async () => {
+          button.disabled = true;
+          status.textContent = `Loading ${face.fullName || face.family}…`;
+          try {
+            await addLocalFontToSelectedText(face);
+          } catch (error) {
+            console.error(error);
+            button.disabled = false;
+            status.textContent = error.message?.replace(/^\[[A-Z_]+\]\s*/, "") || "That font couldn’t be loaded.";
+          }
+        });
+        list.appendChild(button);
+      });
+    } catch (error) {
+      if (request !== fontPickerRequest) return;
+      console.error(error);
+      status.textContent = error.message?.replace(/^\[[A-Z_]+\]\s*/, "") || "Couldn’t list local fonts.";
+    }
+  }
+
+  function showInstalledFontBrowser(backdrop) {
+    const content = backdrop.querySelector(".font-picker-content");
+    content.innerHTML = `
+      <label class="font-search-label" for="font-search">Search installed fonts</label>
+      <input id="font-search" class="font-search" type="search" autocomplete="off" placeholder="Try Didot, Avenir, Helvetica…" />
+      <div class="font-picker-status" role="status"></div>
+      <div class="font-results" role="list"></div>`;
+    const search = content.querySelector("#font-search");
+    search.addEventListener("input", () => {
+      window.clearTimeout(fontPickerSearchTimer);
+      fontPickerSearchTimer = window.setTimeout(() => void renderInstalledFontResults(backdrop, search.value), 140);
+    });
+    void renderInstalledFontResults(backdrop);
+    search.focus();
+  }
+
+  function openFontPicker() {
+    closeFontPicker();
+    const backdrop = fontPickerShell();
+    const bridge = window.carouselBotLocalMcpBridge;
+    const content = backdrop.querySelector(".font-picker-content");
+    const bridgeState = bridge?.getState?.();
+    if (!bridge || !bridgeState?.connected) {
+      content.innerHTML = `<p>Local fonts are provided by the CarouselBot companion. Connect this browser first; font files never leave this computer.</p><div class="modal-actions"><button class="button button--primary" type="button" data-connect-fonts>Connect AI</button></div>`;
+      content.querySelector("[data-connect-fonts]").addEventListener("click", () => {
+        closeFontPicker();
+        bridge?.open?.(app.querySelector('[data-action="connect-agent"]'));
+      });
+      return;
+    }
+    if (!bridgeState.localFontsEnabled) {
+      content.innerHTML = `<p><strong>Allow CarouselBot to use fonts installed on this Mac</strong></p><p>Font names and selected font data stay on this device. Nothing is uploaded.</p><div class="modal-actions"><button class="button button--quiet" type="button" data-cancel-fonts>Not now</button><button class="button button--primary" type="button" data-enable-fonts>Allow local fonts</button></div>`;
+      content.querySelector("[data-cancel-fonts]").addEventListener("click", closeFontPicker);
+      content.querySelector("[data-enable-fonts]").addEventListener("click", async (event) => {
+        event.currentTarget.disabled = true;
+        try {
+          await bridge.enableLocalFonts();
+          showInstalledFontBrowser(backdrop);
+        } catch (error) {
+          console.error(error);
+          event.currentTarget.disabled = false;
+          content.querySelector("p:last-of-type").textContent = "Couldn’t enable local fonts. Check the companion connection and try again.";
+        }
+      });
+      return;
+    }
+    showInstalledFontBrowser(backdrop);
+  }
+
   function renderDashboard() {
     hideAssetPreview();
     state.activeProjectId = null;
@@ -364,15 +564,17 @@ export function createEditorUI({ projects, actions, output }) {
 
   async function repaintTextAfterFontLoad(projectId, slideId) {
     try {
-      await document.fonts.load(`${TEXT_WEIGHT} 64px "TikTok Sans"`);
-      await document.fonts.ready;
+      const project = state.projects.find((item) => item.id === projectId);
+      if (!project) return;
+      await ensureProjectFontsLoaded(project, project.slides.find((item) => item.id === slideId)?.texts || []);
     } catch {
-      return;
+      // Missing fonts are shown with an explicit badge; the editor can still be
+      // used to replace the unavailable face.
     }
     if (state.activeProjectId !== projectId || state.activeSlideId !== slideId) return;
     requestAnimationFrame(() => {
       if (state.activeProjectId !== projectId || state.activeSlideId !== slideId) return;
-      activeSlide()?.texts.forEach(updateTextBox);
+      activeSlide()?.texts.forEach((text) => updateTextBox(text));
     });
   }
 
@@ -561,6 +763,25 @@ export function createEditorUI({ projects, actions, output }) {
       updateTextBox(text);
       ensureTextFits(text);
       scheduleSave();
+    });
+
+    const fontSelect = app.querySelector("#text-font");
+    fontSelect?.addEventListener("change", async () => {
+      if (fontSelect.value === "__add_local_font__") {
+        fontSelect.value = selectedText()?.fontId || "";
+        openFontPicker();
+        return;
+      }
+      fontSelect.disabled = true;
+      try {
+        await applyFontToSelectedText(fontSelect.value || null);
+      } catch (error) {
+        console.error(error);
+        toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "That font couldn’t be applied.");
+        fontSelect.value = selectedText()?.fontId || "";
+      } finally {
+        fontSelect.disabled = false;
+      }
     });
 
     app.querySelectorAll("[data-text-style]").forEach((button) => {
@@ -902,7 +1123,7 @@ export function createEditorUI({ projects, actions, output }) {
     updateStageImage(slide);
   }
 
-  function ensureTextFits(text) {
+  function ensureTextFits(text, { force = false } = {}) {
     requestAnimationFrame(() => {
       const box = app.querySelector(`.text-box[data-text-id="${text.id}"]`);
       const contentWrap = box?.querySelector(".text-content-wrap");
@@ -911,9 +1132,10 @@ export function createEditorUI({ projects, actions, output }) {
       contentWrap.style.maxHeight = "none";
       const neededPixels = contentWrap.scrollHeight + 4;
       contentWrap.style.maxHeight = previousMaxHeight;
-      if (neededPixels <= box.clientHeight) return;
+      if (!force && neededPixels <= box.clientHeight) return;
 
-      const nextHeight = Math.min(1, neededPixels / state.stageHeight);
+      const nextHeight = clamp(neededPixels / state.stageHeight, 0.045, 1);
+      if (Math.abs(nextHeight - text.height) < 0.0005) return;
       text.height = nextHeight;
       updateTextBox(text);
       scheduleSave();

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -3,7 +3,6 @@ import {
   OUTPUT_WIDTH,
   OUTPUT_HEIGHT,
   OUTLINE_RATIO,
-  TEXT_WEIGHT,
   TEXT_LINE_HEIGHT,
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
@@ -43,6 +42,16 @@ import {
   getOverlayMetrics,
   overlayClipCss,
 } from "./editor-state.mjs";
+import {
+  isTextFontAvailable,
+  isTextFontLoaded,
+  textCanvasFont,
+  textCssFontFamily,
+  textFontLabel,
+  textFontStyle,
+  textFontVariationCss,
+  textFontWeight,
+} from "./project-fonts.mjs";
 
 export function formatDate(timestamp) {
   const date = new Date(timestamp);
@@ -323,20 +332,27 @@ export function renderOverlayBox(overlay) {
 }
 
 export function renderTextBox(text) {
+  const project = activeProject();
   const selected = isLayerSelected("text", text.id);
   const background = text.background || "white";
   const backgroundShape = text.backgroundShape || "lines";
   const color = textColor(text);
   const outlineColor = outlineColorFor(color);
+  const fontMissing = Boolean(text.fontId && !isTextFontAvailable(project, text));
+  const fontLoading = Boolean(text.fontId && !fontMissing && !isTextFontLoaded(project, text));
+  const fontFamily = escapeHtml(textCssFontFamily(project, text));
+  const fontWeight = textFontWeight(project, text);
+  const fontStyle = textFontStyle(project, text);
+  const fontVariations = escapeHtml(textFontVariationCss(project, text));
   return `
     <div
-      class="text-box ${selected ? "is-selected" : ""}"
+      class="text-box ${selected ? "is-selected" : ""} ${fontMissing ? "is-font-missing" : ""} ${fontLoading ? "is-font-loading" : ""}"
       data-text-id="${text.id}"
       data-style="${text.style}"
       data-background="${background}"
       data-box-shape="${backgroundShape}"
       data-align="${textAlignment(text)}"
-      style="left:${text.x * 100}%;top:${text.y * 100}%;width:${text.width * 100}%;height:${text.height * 100}%;transform:rotate(${text.rotation || 0}deg);--text-color:${color};--outline-color:${outlineColor};--box-text-line-height:${BOX_TEXT_LINE_HEIGHT}em;--box-horizontal-padding:${BOX_HORIZONTAL_PADDING}em;"
+      style="left:${text.x * 100}%;top:${text.y * 100}%;width:${text.width * 100}%;height:${text.height * 100}%;transform:rotate(${text.rotation || 0}deg);--text-color:${color};--outline-color:${outlineColor};--box-text-line-height:${BOX_TEXT_LINE_HEIGHT}em;--box-horizontal-padding:${BOX_HORIZONTAL_PADDING}em;--text-font-family:${fontFamily};--text-font-weight:${fontWeight};--text-font-style:${fontStyle};--text-font-variations:${fontVariations};"
       tabindex="0"
       aria-label="Text layer: ${escapeHtml(text.text)}"
     >
@@ -355,6 +371,7 @@ export function renderTextBox(text) {
       <span class="resize-handle" data-corner="ne" aria-hidden="true"></span>
       <span class="resize-handle" data-corner="sw" aria-hidden="true"></span>
       <span class="resize-handle" data-corner="se" aria-hidden="true"></span>
+      ${fontMissing ? `<span class="missing-font-badge" title="${escapeHtml(textFontLabel(project, text))} is unavailable">Missing font</span>` : ""}
     </div>
   `;
 }
@@ -406,6 +423,15 @@ export function renderInspector() {
           <div class="control-group">
             <label class="control-label" for="text-value">Words</label>
             <textarea id="text-value" class="text-input" maxlength="500" placeholder="Type something…">${escapeHtml(text.text)}</textarea>
+          </div>
+          <div class="control-group">
+            <label class="control-label" for="text-font">Font</label>
+            <select id="text-font" class="font-select" aria-label="Text font">
+              <option value="" ${text.fontId ? "" : "selected"}>TikTok Sans</option>
+              ${(activeProject()?.fonts || []).map((font) => `<option value="${escapeHtml(font.id)}" ${text.fontId === font.id ? "selected" : ""}>${escapeHtml(font.fullName || `${font.family} ${font.subfamily || ""}`.trim())}</option>`).join("")}
+              <option value="__add_local_font__">Add font from Mac…</option>
+            </select>
+            ${text.fontId && !isTextFontAvailable(activeProject(), text) ? `<p class="font-warning">${escapeHtml(textFontLabel(activeProject(), text))} is unavailable on this device.</p>` : ""}
           </div>
           <div class="control-group">
             <div class="control-label">Style</div>
@@ -504,6 +530,7 @@ export function updateStageImage(slide) {
 }
 
 export function updateTextBox(text) {
+  const project = activeProject();
   const box = app.querySelector(`.text-box[data-text-id="${text.id}"]`);
   if (!box) return;
   box.style.left = `${text.x * 100}%`;
@@ -515,11 +542,27 @@ export function updateTextBox(text) {
   box.dataset.background = text.background || "white";
   box.dataset.boxShape = text.backgroundShape || "lines";
   box.dataset.align = textAlignment(text);
+  const fontMissing = Boolean(text.fontId && !isTextFontAvailable(project, text));
+  const fontLoading = Boolean(text.fontId && !fontMissing && !isTextFontLoaded(project, text));
+  box.classList.toggle("is-font-missing", fontMissing);
+  box.classList.toggle("is-font-loading", fontLoading);
+  let missingBadge = box.querySelector(".missing-font-badge");
+  if (fontMissing && !missingBadge) {
+    missingBadge = document.createElement("span");
+    missingBadge.className = "missing-font-badge";
+    missingBadge.textContent = "Missing font";
+    box.appendChild(missingBadge);
+  } else if (!fontMissing) missingBadge?.remove();
+  if (missingBadge) missingBadge.title = `${textFontLabel(project, text)} is unavailable`;
   const color = textColor(text);
   box.style.setProperty("--text-color", color);
   box.style.setProperty("--outline-color", outlineColorFor(color));
   box.style.setProperty("--box-text-line-height", `${BOX_TEXT_LINE_HEIGHT}em`);
   box.style.setProperty("--box-horizontal-padding", `${BOX_HORIZONTAL_PADDING}em`);
+  box.style.setProperty("--text-font-family", textCssFontFamily(project, text));
+  box.style.setProperty("--text-font-weight", String(textFontWeight(project, text)));
+  box.style.setProperty("--text-font-style", textFontStyle(project, text));
+  box.style.setProperty("--text-font-variations", textFontVariationCss(project, text));
   const insideVisual = box.querySelector(".text-visual--inside");
   if (insideVisual) insideVisual.style.clipPath = layerClipCss(text.x, text.y, text.width, text.height);
   box.querySelectorAll(".text-content-wrap").forEach((contentWrap) => {
@@ -529,7 +572,8 @@ export function updateTextBox(text) {
     content.style.textAlign = textAlignment(text);
     content.style.alignItems = textAlignment(text) === "left" ? "flex-start" : textAlignment(text) === "right" ? "flex-end" : "center";
     content.style.fontSize = `${text.size * (state.stageWidth / DESIGN_WIDTH)}px`;
-    paintTextContent(text, content, box);
+    if (fontLoading) content.textContent = text.text;
+    else paintTextContent(text, content, box);
   });
   const editor = box.querySelector(".text-editor");
   if (editor) {
@@ -543,7 +587,8 @@ export const measureCanvas = typeof document === "undefined" ? null : document.c
 export function measureFont(text) {
   const fontSize = text.size * ((state.stageWidth || DESIGN_WIDTH) / DESIGN_WIDTH);
   const context = measureCanvas.getContext("2d");
-  context.font = `${TEXT_WEIGHT} ${fontSize}px "TikTok Sans"`;
+  context.font = textCanvasFont(activeProject(), text, fontSize);
+  if ("fontVariationSettings" in context) context.fontVariationSettings = textFontVariationCss(activeProject(), text);
   return { context, fontSize };
 }
 
@@ -604,8 +649,10 @@ export function paintTextContent(text, content, box) {
       node.setAttribute("stroke-linejoin", "round");
       node.setAttribute("stroke-linecap", "round");
       node.setAttribute("paint-order", "stroke fill");
-      node.setAttribute("font-family", "TikTok Sans, sans-serif");
-      node.setAttribute("font-weight", String(TEXT_WEIGHT));
+      node.setAttribute("font-family", textCssFontFamily(activeProject(), text));
+      node.setAttribute("font-weight", String(textFontWeight(activeProject(), text)));
+      node.setAttribute("font-style", textFontStyle(activeProject(), text));
+      node.style.fontVariationSettings = textFontVariationCss(activeProject(), text);
       node.setAttribute("font-size", `${fontSize}px`);
       node.textContent = line || " ";
       svg.appendChild(node);

--- a/src/editor.mjs
+++ b/src/editor.mjs
@@ -71,7 +71,7 @@ export async function init() {
     toast("Browser storage is unavailable. Projects won’t persist.");
   }
   window.addEventListener("carouselbot:migration-complete", async (event) => {
-    state.projects = await getAllProjects();
+    state.projects = normalizeLoadedProjects(await getAllProjects());
     renderDashboard();
     const { imported = 0, updated = 0, skipped = 0 } = event.detail || {};
     toast(`Projects ready: ${imported} copied, ${updated} updated${skipped ? `, ${skipped} already current` : ""}.`);

--- a/src/project-fonts.mjs
+++ b/src/project-fonts.mjs
@@ -1,0 +1,478 @@
+import { TEXT_WEIGHT, clamp, uid } from "./editor-model.mjs";
+
+export const DEFAULT_FONT_FAMILY = "TikTok Sans";
+
+export const DEFAULT_FONT_WEIGHT = TEXT_WEIGHT;
+
+export const DEFAULT_FONT_STYLE = "normal";
+
+const FONT_ID_PREFIX = "font-";
+
+const fontRegistrations = new Map();
+
+function normalizedString(value, fallback = "", maxLength = 256) {
+  const normalized = String(value ?? "").trim();
+  return (normalized || fallback).slice(0, maxLength);
+}
+
+function normalizedFontWeight(value, fallback = DEFAULT_FONT_WEIGHT) {
+  const numeric = Number(value);
+  return Math.round(clamp(Number.isFinite(numeric) ? numeric : fallback, 1, 1000));
+}
+
+function normalizedFontStyle(value, fallback = DEFAULT_FONT_STYLE) {
+  if (value === "normal" || value === "italic") return value;
+  return fallback === "italic" ? "italic" : DEFAULT_FONT_STYLE;
+}
+
+function normalizedAxis(axis) {
+  const tag = normalizedString(axis?.tag, "", 4);
+  if (!/^[\x20-\x7e]{4}$/.test(tag)) return null;
+  const minimum = Number(axis?.min);
+  const maximum = Number(axis?.max);
+  const defaultValue = Number(axis?.default);
+  if (![minimum, maximum, defaultValue].every(Number.isFinite) || minimum > maximum) return null;
+  return {
+    tag,
+    name: normalizedString(axis?.name, tag, 120),
+    min: minimum,
+    max: maximum,
+    default: clamp(defaultValue, minimum, maximum),
+  };
+}
+
+function normalizedVariableAxes(value) {
+  if (!Array.isArray(value)) return [];
+  const axes = [];
+  const seen = new Set();
+  for (const candidate of value) {
+    const axis = normalizedAxis(candidate);
+    if (!axis || seen.has(axis.tag)) continue;
+    axes.push(axis);
+    seen.add(axis.tag);
+  }
+  return axes;
+}
+
+function normalizedVariationSettings(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const settings = {};
+  for (const [rawTag, rawValue] of Object.entries(value)) {
+    const tag = normalizedString(rawTag, "", 4);
+    const numeric = Number(rawValue);
+    if (!/^[\x20-\x7e]{4}$/.test(tag) || !Number.isFinite(numeric)) continue;
+    settings[tag] = numeric;
+  }
+  return settings;
+}
+
+function isFontDataUrl(value) {
+  if (typeof value !== "string") return false;
+  const comma = value.indexOf(",");
+  if (comma < 0) return false;
+  const header = value.slice(0, comma);
+  const payload = value.slice(comma + 1);
+  return /^data:[^,;]*(?:;[^,;=]+=[^,;]*)*;base64$/i.test(header) && payload.trim().length > 0;
+}
+
+function normalizedFontId(value, { generate = false } = {}) {
+  const id = normalizedString(value, "", 180);
+  if (id) return id;
+  return generate ? `${FONT_ID_PREFIX}${uid()}` : "";
+}
+
+function cssIdentifierPart(value) {
+  const normalized = normalizedString(value, "font", 180)
+    .replace(/[^a-z0-9_-]+/gi, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "font";
+}
+
+function cssFamilyForId(id) {
+  return `carousel-font-${cssIdentifierPart(id)}`;
+}
+
+function normalizedProjectFont(rawFont, { requireLocalId = false } = {}) {
+  if (!rawFont || typeof rawFont !== "object") return null;
+  const id = normalizedFontId(rawFont.id);
+  const localFontId = normalizedString(rawFont.localFontId, "", 512);
+  if (!id || (requireLocalId && !localFontId)) return null;
+  const family = normalizedString(rawFont.family, rawFont.fullName || "Local font", 256);
+  const subfamily = normalizedString(rawFont.subfamily, "Regular", 160);
+  const fullName = normalizedString(
+    rawFont.fullName,
+    subfamily.toLowerCase() === "regular" ? family : `${family} ${subfamily}`,
+    320,
+  );
+  const postscriptName = normalizedString(rawFont.postscriptName, fullName, 256);
+  const font = {
+    id,
+    source: "local",
+    localFontId,
+    family,
+    fullName,
+    postscriptName,
+    subfamily,
+    weight: normalizedFontWeight(rawFont.weight, 400),
+    italic: Boolean(rawFont.italic),
+    cssFamily: cssFamilyForId(id),
+    variableAxes: normalizedVariableAxes(rawFont.variableAxes),
+    fingerprint: normalizedString(rawFont.fingerprint, localFontId || id, 512),
+    dataRevision: normalizedString(rawFont.dataRevision, rawFont.fingerprint || localFontId || id, 512),
+    addedAt: Number.isFinite(Number(rawFont.addedAt)) ? Number(rawFont.addedAt) : Date.now(),
+  };
+  if (isFontDataUrl(rawFont.fontData)) font.fontData = rawFont.fontData;
+  return font;
+}
+
+export function normalizeTextFont(text, project = null) {
+  if (!text || typeof text !== "object") return text;
+  if (text.fontId != null) {
+    const id = normalizedString(text.fontId, "", 180);
+    if (id) text.fontId = id;
+    else delete text.fontId;
+  }
+  const projectFont = projectFontForText(project, text);
+  text.fontFamily = projectFont
+    ? normalizedString(projectFont.family, DEFAULT_FONT_FAMILY, 256)
+    : text.fontId
+      ? normalizedString(text.fontFamily, DEFAULT_FONT_FAMILY, 256)
+      : DEFAULT_FONT_FAMILY;
+  const weightAxis = projectFont?.variableAxes?.find((axis) => axis.tag === "wght");
+  text.fontWeight = projectFont
+    ? weightAxis
+      ? clamp(normalizedFontWeight(text.fontWeight, projectFont.weight), weightAxis.min, weightAxis.max)
+      : normalizedFontWeight(projectFont.weight, 400)
+    : normalizedFontWeight(text.fontWeight, DEFAULT_FONT_WEIGHT);
+  text.fontStyle = projectFont
+    ? projectFont.italic ? "italic" : DEFAULT_FONT_STYLE
+    : normalizedFontStyle(text.fontStyle, DEFAULT_FONT_STYLE);
+  const rawVariationSettings = normalizedVariationSettings(text.fontVariationSettings);
+  const variationSettings = projectFont
+    ? Object.fromEntries(Object.entries(rawVariationSettings).flatMap(([tag, value]) => {
+      const axis = projectFont.variableAxes.find((candidate) => candidate.tag === tag);
+      return axis ? [[tag, clamp(value, axis.min, axis.max)]] : [];
+    }))
+    : rawVariationSettings;
+  if (weightAxis && variationSettings.wght != null) text.fontWeight = variationSettings.wght;
+  if (Object.keys(variationSettings).length) text.fontVariationSettings = variationSettings;
+  else delete text.fontVariationSettings;
+  return text;
+}
+
+export function normalizeProjectFonts(project) {
+  if (!project || typeof project !== "object") return project;
+  const fonts = [];
+  const seenIds = new Set();
+  const seenLocalFaces = new Set();
+  for (const rawFont of Array.isArray(project.fonts) ? project.fonts : []) {
+    const font = normalizedProjectFont(rawFont);
+    if (!font || seenIds.has(font.id)) continue;
+    const localFaceKey = font.localFontId || null;
+    if (localFaceKey && seenLocalFaces.has(localFaceKey)) continue;
+    fonts.push(font);
+    seenIds.add(font.id);
+    if (localFaceKey) seenLocalFaces.add(localFaceKey);
+  }
+  project.fonts = fonts;
+  for (const slide of Array.isArray(project.slides) ? project.slides : []) {
+    for (const text of Array.isArray(slide?.texts) ? slide.texts : []) normalizeTextFont(text, project);
+  }
+  return project;
+}
+
+export function createProjectFont(face, dataUrl, { id = null, addedAt = Date.now(), dataRevision = uid() } = {}) {
+  const localFontId = normalizedString(face?.localFontId, "", 512);
+  if (!localFontId) throw new TypeError("A localFontId returned by the local companion is required.");
+  if (!isFontDataUrl(dataUrl)) throw new TypeError("Local font data must be a base64 data URL.");
+  const projectFont = normalizedProjectFont({
+    ...face,
+    id: normalizedFontId(id, { generate: true }),
+    localFontId,
+    fontData: dataUrl,
+    dataRevision,
+    addedAt,
+  }, { requireLocalId: true });
+  if (!projectFont) throw new TypeError("The selected local font metadata is invalid.");
+  return projectFont;
+}
+
+export function publicProjectFont(project, font) {
+  const normalized = normalizedProjectFont(font);
+  if (!normalized) return null;
+  const {
+    fontData: _fontData,
+    fingerprint: _fingerprint,
+    dataRevision: _dataRevision,
+    ...publicFont
+  } = normalized;
+  return {
+    ...publicFont,
+    available: isProjectFontAvailable(project, font),
+  };
+}
+
+export function projectFontForText(project, text) {
+  const fontId = normalizedString(text?.fontId, "", 180);
+  if (!fontId || !Array.isArray(project?.fonts)) return null;
+  return project.fonts.find((font) => font?.id === fontId) || null;
+}
+
+export function textFontFamily(project, text) {
+  const font = projectFontForText(project, text);
+  return normalizedString(font?.cssFamily || text?.fontFamily, DEFAULT_FONT_FAMILY, 256);
+}
+
+export function textFontWeight(project, text) {
+  const font = projectFontForText(project, text);
+  if (!font) return normalizedFontWeight(text?.fontWeight, DEFAULT_FONT_WEIGHT);
+  const weightAxis = font.variableAxes?.find((axis) => axis.tag === "wght");
+  return weightAxis
+    ? clamp(normalizedFontWeight(text?.fontVariationSettings?.wght ?? text?.fontWeight, font.weight), weightAxis.min, weightAxis.max)
+    : normalizedFontWeight(font.weight, 400);
+}
+
+export function textFontStyle(project, text) {
+  const font = projectFontForText(project, text);
+  return font
+    ? font.italic ? "italic" : DEFAULT_FONT_STYLE
+    : normalizedFontStyle(text?.fontStyle, DEFAULT_FONT_STYLE);
+}
+
+export function textFontVariationValues(projectOrText, maybeText = undefined) {
+  const project = maybeText === undefined ? null : projectOrText;
+  const text = maybeText === undefined ? projectOrText : maybeText;
+  const font = projectFontForText(project, text);
+  const settings = normalizedVariationSettings(text?.fontVariationSettings);
+  if (!font) return settings;
+  if (!font.variableAxes?.length) return {};
+  const axes = new Map(font.variableAxes.map((axis) => [axis.tag, axis]));
+  return Object.fromEntries(Object.entries(settings).flatMap(([tag, value]) => {
+    const axis = axes.get(tag);
+    return axis ? [[tag, clamp(value, axis.min, axis.max)]] : [];
+  }));
+}
+
+export function textFontVariationSettings(projectOrText, maybeText = undefined) {
+  return textFontVariationValues(projectOrText, maybeText);
+}
+
+export function textFontVariationCss(projectOrText, maybeText = undefined) {
+  const settings = textFontVariationValues(projectOrText, maybeText);
+  const entries = Object.entries(settings);
+  return entries.length
+    ? entries.map(([tag, value]) => `${quoteCssFontFamily(tag)} ${value}`).join(", ")
+    : "normal";
+}
+
+export function quoteCssFontFamily(value) {
+  const escaped = String(value || DEFAULT_FONT_FAMILY)
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replace(/[\n\r\f]/g, " ");
+  return `"${escaped}"`;
+}
+
+export function textCssFontFamily(project, text) {
+  const family = textFontFamily(project, text);
+  return family === DEFAULT_FONT_FAMILY
+    ? `${quoteCssFontFamily(DEFAULT_FONT_FAMILY)}, sans-serif`
+    : `${quoteCssFontFamily(family)}, ${quoteCssFontFamily(DEFAULT_FONT_FAMILY)}, sans-serif`;
+}
+
+export function textCanvasFont(project, text, size) {
+  const numericSize = Number(size);
+  const fontSize = Number.isFinite(numericSize) && numericSize > 0 ? numericSize : 1;
+  return `${textFontStyle(project, text)} ${textFontWeight(project, text)} ${fontSize}px ${quoteCssFontFamily(textFontFamily(project, text))}`;
+}
+
+export function textFontLabel(project, text) {
+  const font = projectFontForText(project, text);
+  return font
+    ? normalizedString(font.fullName, font.family || "Local font", 320)
+    : normalizedString(text?.fontFamily, DEFAULT_FONT_FAMILY, 320);
+}
+
+export function applyProjectFontToText(project, text, fontIdOrNull) {
+  if (!text || typeof text !== "object") throw new TypeError("A text layer is required.");
+  if (fontIdOrNull == null || fontIdOrNull === "") {
+    delete text.fontId;
+    delete text.fontVariationSettings;
+    text.fontFamily = DEFAULT_FONT_FAMILY;
+    text.fontWeight = DEFAULT_FONT_WEIGHT;
+    text.fontStyle = DEFAULT_FONT_STYLE;
+    return text;
+  }
+  const fontId = normalizedString(fontIdOrNull, "", 180);
+  const font = (project?.fonts || []).find((candidate) => candidate?.id === fontId);
+  if (!font) {
+    const error = new Error(`[FONT_NOT_FOUND] Project font not found: ${fontId}`);
+    error.code = "FONT_NOT_FOUND";
+    error.fontId = fontId;
+    throw error;
+  }
+  text.fontId = font.id;
+  text.fontFamily = normalizedString(font.family, DEFAULT_FONT_FAMILY, 256);
+  text.fontWeight = normalizedFontWeight(font.weight, 400);
+  text.fontStyle = font.italic ? "italic" : DEFAULT_FONT_STYLE;
+  delete text.fontVariationSettings;
+  return text;
+}
+
+function registrationKey(font) {
+  return font.cssFamily || cssFamilyForId(font.id);
+}
+
+function registrationSignature(font) {
+  return [
+    font.id,
+    font.fingerprint,
+    font.dataRevision,
+    font.weight,
+    font.italic ? "italic" : "normal",
+    font.fontData?.length || 0,
+  ].join(":");
+}
+
+function fontFaceWeightDescriptor(font) {
+  const weightAxis = font.variableAxes?.find((axis) => axis.tag === "wght");
+  if (!weightAxis) return String(normalizedFontWeight(font.weight, 400));
+  return `${clamp(weightAxis.min, 1, 1000)} ${clamp(weightAxis.max, 1, 1000)}`;
+}
+
+function fontUnavailableError(font, text = null, cause = null) {
+  const label = normalizedString(font?.fullName || text?.fontFamily, font?.family || text?.fontId || "This font", 320);
+  const error = new Error(`[FONT_UNAVAILABLE] ${label} is not available on this device.`);
+  error.code = "FONT_UNAVAILABLE";
+  error.fontId = font?.id || text?.fontId || null;
+  error.fontLabel = label;
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function fontDataArrayBuffer(dataUrl) {
+  if (!isFontDataUrl(dataUrl)) throw new TypeError("Stored font data is missing or invalid.");
+  const payload = dataUrl.slice(dataUrl.indexOf(",") + 1).replace(/\s+/g, "");
+  let decoded;
+  try {
+    decoded = globalThis.atob(payload);
+  } catch (error) {
+    throw new TypeError(`Stored font data could not be decoded: ${error.message}`);
+  }
+  const bytes = new Uint8Array(decoded.length);
+  for (let index = 0; index < decoded.length; index += 1) bytes[index] = decoded.charCodeAt(index);
+  return bytes.buffer;
+}
+
+async function registerProjectFont(font) {
+  const key = registrationKey(font);
+  const signature = registrationSignature(font);
+  const existing = fontRegistrations.get(key);
+  if (existing?.signature === signature) {
+    if (existing.status === "loaded") return existing.face;
+    if (existing.status === "loading") return existing.promise;
+    throw existing.error;
+  }
+
+  const fontSet = globalThis.document?.fonts;
+  const FontFaceConstructor = globalThis.FontFace;
+  if (!fontSet?.add || typeof FontFaceConstructor !== "function") {
+    const error = fontUnavailableError(font, null, new Error("The browser FontFace API is unavailable."));
+    fontRegistrations.set(key, { signature, status: "missing", error });
+    throw error;
+  }
+
+  if (existing?.face && typeof fontSet.delete === "function") fontSet.delete(existing.face);
+  const registration = { signature, status: "loading", face: null, error: null, promise: null };
+  registration.promise = (async () => {
+    try {
+      const face = new FontFaceConstructor(font.cssFamily, fontDataArrayBuffer(font.fontData), {
+        weight: fontFaceWeightDescriptor(font),
+        style: font.italic ? "italic" : DEFAULT_FONT_STYLE,
+      });
+      const loadedFace = await face.load();
+      if (loadedFace?.status !== "loaded" && face.status !== "loaded") {
+        throw new Error(`FontFace finished with status ${loadedFace?.status || face.status || "unknown"}.`);
+      }
+      fontSet.add(loadedFace || face);
+      registration.face = loadedFace || face;
+      registration.status = "loaded";
+      return registration.face;
+    } catch (cause) {
+      registration.status = "missing";
+      registration.error = fontUnavailableError(font, null, cause);
+      throw registration.error;
+    }
+  })();
+  fontRegistrations.set(key, registration);
+  return registration.promise;
+}
+
+export function isTextFontAvailable(project, text) {
+  if (!text?.fontId) return true;
+  const font = projectFontForText(project, text);
+  return isProjectFontAvailable(project, font);
+}
+
+export function isTextFontLoaded(project, text) {
+  if (!text?.fontId) return true;
+  const font = projectFontForText(project, text);
+  if (!font) return false;
+  const registration = fontRegistrations.get(registrationKey(font));
+  return registration?.signature === registrationSignature(font) && registration.status === "loaded";
+}
+
+export function isProjectFontAvailable(project, font) {
+  if (!font || !project?.fonts?.some((candidate) => candidate?.id === font.id)) return false;
+  const registration = fontRegistrations.get(registrationKey(font));
+  if (registration?.signature !== registrationSignature(font)) return isFontDataUrl(font.fontData);
+  if (registration?.status === "missing") return false;
+  return registration?.status === "loaded" || isFontDataUrl(font.fontData);
+}
+
+function allProjectTextLayers(project) {
+  return (project?.slides || []).flatMap((slide) => Array.isArray(slide?.texts) ? slide.texts : []);
+}
+
+async function ensureDefaultFontLoaded(textLayers) {
+  if (!textLayers.some((text) => !text?.fontId)) return;
+  const fontSet = globalThis.document?.fonts;
+  if (!fontSet?.load) return;
+  await fontSet.load(`${DEFAULT_FONT_WEIGHT} 64px ${quoteCssFontFamily(DEFAULT_FONT_FAMILY)}`);
+  if (fontSet.ready) await fontSet.ready;
+}
+
+export async function ensureProjectFontsLoaded(project, textLayers = undefined) {
+  normalizeProjectFonts(project);
+  const layers = Array.isArray(textLayers) ? textLayers : allProjectTextLayers(project);
+  await ensureDefaultFontLoaded(layers);
+
+  const fonts = new Map();
+  const missing = [];
+  for (const text of layers) {
+    if (!text?.fontId || fonts.has(text.fontId)) continue;
+    const font = projectFontForText(project, text);
+    if (!font) {
+      missing.push(fontUnavailableError(null, text));
+      continue;
+    }
+    fonts.set(text.fontId, font);
+  }
+
+  const results = await Promise.allSettled([...fonts.values()].map(registerProjectFont));
+  results.forEach((result) => {
+    if (result.status === "rejected") missing.push(result.reason);
+  });
+  if (missing.length) {
+    const error = missing[0];
+    error.missingFonts = missing.map((item) => ({
+      fontId: item.fontId || null,
+      label: item.fontLabel,
+    }));
+    throw error;
+  }
+  return {
+    loadedFontIds: [...fonts.keys()],
+    missingFonts: [],
+  };
+}

--- a/src/slide-renderer.mjs
+++ b/src/slide-renderer.mjs
@@ -3,7 +3,6 @@ import {
   OUTPUT_WIDTH,
   OUTPUT_HEIGHT,
   OUTLINE_RATIO,
-  TEXT_WEIGHT,
   TEXT_LINE_HEIGHT,
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
@@ -21,6 +20,7 @@ import {
   wrapText,
 } from "./editor-model.mjs";
 import { activeProject, getOverlayMetrics } from "./editor-state.mjs";
+import { ensureProjectFontsLoaded, textCanvasFont, textFontVariationCss } from "./project-fonts.mjs";
 
 export function canvasToBlob(canvas) {
   return new Promise((resolve, reject) => {
@@ -53,7 +53,7 @@ export function loadImage(src) {
 }
 
 export async function renderSlideCanvas(slide, width = OUTPUT_WIDTH, height = OUTPUT_HEIGHT, project = activeProject()) {
-  await document.fonts.load(`${TEXT_WEIGHT} 64px "TikTok Sans"`);
+  await ensureProjectFontsLoaded(project, slide.texts || []);
   const image = await loadImage(slide.imageData);
   const canvas = document.createElement("canvas");
   canvas.width = width;
@@ -68,7 +68,7 @@ export async function renderSlideCanvas(slide, width = OUTPUT_WIDTH, height = OU
 export async function drawSlideLayers(context, slide, canvasWidth, canvasHeight, project = activeProject()) {
   for (const { kind, item } of slideItems(slide)) {
     if (kind === "overlay") await drawOneOverlay(context, item, canvasWidth, canvasHeight, project);
-    else drawTextLayer(context, item, canvasWidth, canvasHeight);
+    else drawTextLayer(context, item, canvasWidth, canvasHeight, project);
   }
 }
 
@@ -93,7 +93,7 @@ export async function drawOneOverlay(context, overlay, canvasWidth, canvasHeight
   context.restore();
 }
 
-export function drawTextLayer(context, text, imageWidth, imageHeight) {
+export function drawTextLayer(context, text, imageWidth, imageHeight, project = activeProject()) {
   const width = text.width * imageWidth;
   const height = text.height * imageHeight;
   const centerX = (text.x + text.width / 2) * imageWidth;
@@ -112,7 +112,8 @@ export function drawTextLayer(context, text, imageWidth, imageHeight) {
   context.save();
   context.translate(centerX, centerY);
   context.rotate(((text.rotation || 0) * Math.PI) / 180);
-  context.font = `${TEXT_WEIGHT} ${fontSize}px "TikTok Sans"`;
+  context.font = textCanvasFont(project, text, fontSize);
+  if ("fontVariationSettings" in context) context.fontVariationSettings = textFontVariationCss(project, text);
   context.textAlign = align;
   context.textBaseline = "middle";
   context.lineJoin = "round";

--- a/styles.css
+++ b/styles.css
@@ -2074,13 +2074,39 @@ button:disabled {
   padding: 0.14em 0.3em;
   overflow: hidden;
   color: var(--text-color, #fff);
-  font-family: "TikTok Sans", sans-serif;
-  font-weight: 500;
+  font-family: var(--text-font-family, "TikTok Sans", sans-serif);
+  font-style: var(--text-font-style, normal);
+  font-weight: var(--text-font-weight, 500);
+  font-variation-settings: var(--text-font-variations, normal);
   line-height: 1.12;
   text-align: center;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   pointer-events: none;
+}
+
+.missing-font-badge {
+  position: absolute;
+  z-index: 4;
+  top: -24px;
+  left: 50%;
+  padding: 3px 7px;
+  border: 1px solid var(--ink);
+  border-radius: 999px;
+  color: #fff;
+  background: var(--danger);
+  font-family: "TikTok Sans", sans-serif;
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 1.2;
+  white-space: nowrap;
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.text-box.is-font-loading .text-visual {
+  visibility: hidden;
 }
 
 .text-box[data-align="left"] .text-content-wrap,
@@ -2458,6 +2484,32 @@ button:disabled {
 .text-input:focus {
   border-color: var(--ink);
   box-shadow: 0 0 0 3px rgba(37, 244, 238, 0.22);
+}
+
+.font-select {
+  width: 100%;
+  height: 42px;
+  padding: 0 34px 0 11px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  outline: 0;
+  color: var(--ink);
+  background: var(--white);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.font-select:focus {
+  border-color: var(--ink);
+  box-shadow: 0 0 0 3px rgba(37, 244, 238, 0.22);
+}
+
+.font-warning {
+  margin: 8px 0 0;
+  color: var(--danger);
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .style-options {
@@ -2943,6 +2995,119 @@ input[type="range"]::-webkit-slider-thumb {
   gap: 9px;
   margin-top: 20px;
   justify-content: flex-end;
+}
+
+.font-picker-modal {
+  display: flex;
+  width: min(520px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.font-picker-header {
+  display: flex;
+  padding: 23px 24px 17px;
+  align-items: flex-start;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--soft-line);
+}
+
+.font-picker-header .eyebrow {
+  margin: 0 0 5px;
+}
+
+.font-picker-header h2 {
+  margin: 0;
+}
+
+.font-picker-close {
+  flex: 0 0 auto;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.font-picker-content {
+  min-height: 0;
+  padding: 20px 24px 24px;
+  overflow-y: auto;
+}
+
+.font-search-label {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.font-picker-modal .font-search {
+  height: 44px;
+  font-size: 14px;
+}
+
+.font-picker-status {
+  min-height: 19px;
+  margin: 10px 2px 8px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.font-results {
+  display: grid;
+  gap: 6px;
+}
+
+.font-result {
+  display: flex;
+  width: 100%;
+  min-height: 56px;
+  padding: 8px 11px;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--white);
+  text-align: left;
+  cursor: pointer;
+}
+
+.font-result:hover {
+  border-color: var(--ink);
+  box-shadow: 2px 2px 0 var(--cyan);
+}
+
+.font-result > span:first-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.font-result strong,
+.font-result small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.font-result strong {
+  font-size: 14px;
+}
+
+.font-result small {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.font-result-use {
+  margin-left: 12px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 
 .layer-menu {

--- a/test/agent-font-patch.test.mjs
+++ b/test/agent-font-patch.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { reconcileAgentFontWeightPatch } from "../src/agent-font-patch.mjs";
+
+test("keeps agent fontWeight and the wght variation axis synchronized", () => {
+  const variationOnly = { fontWeight: 500, fontVariationSettings: { wght: 725, wdth: 90 } };
+  reconcileAgentFontWeightPatch(variationOnly, { fontVariationSettings: { wght: 725, wdth: 90 } });
+  assert.equal(variationOnly.fontWeight, 725);
+
+  const existingSettings = { wght: 500, wdth: 90 };
+  const weightOnly = { fontWeight: 650, fontVariationSettings: existingSettings };
+  reconcileAgentFontWeightPatch(weightOnly, { fontWeight: 650 });
+  assert.deepEqual(weightOnly.fontVariationSettings, { wght: 650, wdth: 90 });
+  assert.deepEqual(existingSettings, { wght: 500, wdth: 90 }, "candidate reconciliation must not mutate the stored layer before commit");
+
+  const matching = { fontWeight: 700, fontVariationSettings: { wght: 700 } };
+  assert.equal(reconcileAgentFontWeightPatch(matching, { fontWeight: 700, fontVariationSettings: { wght: 700 } }), matching);
+});
+
+test("rejects contradictory agent fontWeight and wght values", () => {
+  const text = { fontWeight: 600, fontVariationSettings: { wght: 700 } };
+  assert.throws(
+    () => reconcileAgentFontWeightPatch(text, { fontWeight: 600, fontVariationSettings: { wght: 700 } }),
+    (error) => error.code === "FONT_WEIGHT_CONFLICT" && /same value/.test(error.message),
+  );
+});

--- a/test/build-contract.test.mjs
+++ b/test/build-contract.test.mjs
@@ -12,6 +12,7 @@ test("every local module import resolves to a committed source file", async () =
   const moduleNames = (await readdir(sourceDirectory)).filter((name) => name.endsWith(".mjs"));
   assert.deepEqual(moduleNames.sort(), [
     "agent-commands.mjs",
+    "agent-font-patch.mjs",
     "editor-actions.mjs",
     "editor-model.mjs",
     "editor-output.mjs",
@@ -22,6 +23,7 @@ test("every local module import resolves to a committed source file", async () =
     "editor.mjs",
     "layer-interactions.mjs",
     "main.mjs",
+    "project-fonts.mjs",
     "project-store.mjs",
     "slide-renderer.mjs",
   ]);

--- a/test/editor-font-view.test.mjs
+++ b/test/editor-font-view.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+globalThis.document = {
+  querySelector: () => null,
+  createElement: () => ({ getContext: () => ({}) }),
+};
+
+const { state } = await import("../src/editor-state.mjs");
+const { renderTextBox } = await import("../src/editor-view.mjs");
+const { createProjectFont } = await import("../src/project-fonts.mjs");
+
+function textLayer(fontId) {
+  return {
+    id: "text-font-view",
+    text: "speed limit",
+    fontId,
+    fontFamily: "Didot",
+    fontWeight: 400,
+    fontStyle: "normal",
+    x: 0.1,
+    y: 0.2,
+    width: 0.8,
+    height: 0.12,
+    size: 72,
+    style: "plain",
+    color: "#FFFFFF",
+    align: "center",
+  };
+}
+
+test("marks unavailable project fonts visibly instead of claiming exact rendering", () => {
+  const font = {
+    id: "missing-didot",
+    source: "local",
+    localFontId: "font_missing_didot",
+    family: "Didot",
+    fullName: "Didot Regular",
+    postscriptName: "Didot",
+    subfamily: "Regular",
+    weight: 400,
+    italic: false,
+    cssFamily: "carousel-font-missing-didot",
+    variableAxes: [],
+  };
+  const text = textLayer(font.id);
+  state.projects = [{ id: "project", fonts: [font], slides: [{ id: "slide", texts: [text], overlays: [] }] }];
+  state.activeProjectId = "project";
+  state.activeSlideId = "slide";
+  state.selectedLayerKeys = [];
+
+  const html = renderTextBox(text);
+
+  assert.match(html, /is-font-missing/);
+  assert.match(html, /missing-font-badge/);
+  assert.match(html, /Didot Regular is unavailable/);
+  assert.doesNotMatch(html, /is-font-loading/);
+});
+
+test("hides a stored project face until its exact bytes finish loading", () => {
+  const font = createProjectFont({
+    localFontId: "font_loading_didot",
+    family: "Didot",
+    fullName: "Didot Regular",
+    postscriptName: "Didot",
+    subfamily: "Regular",
+    weight: 400,
+    italic: false,
+    variableAxes: [],
+  }, "data:font/ttf;base64,AAECAw==", { id: "loading-didot" });
+  const text = textLayer(font.id);
+  state.projects = [{ id: "project", fonts: [font], slides: [{ id: "slide", texts: [text], overlays: [] }] }];
+
+  const html = renderTextBox(text);
+
+  assert.match(html, /is-font-loading/);
+  assert.doesNotMatch(html, /is-font-missing/);
+  assert.doesNotMatch(html, /missing-font-badge/);
+});

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -91,14 +91,23 @@ test("clones nested project data without retaining aliases", () => {
   const original = {
     id: "project",
     assets: [{ id: "asset", name: "Original" }],
-    slides: [{ id: "slide", texts: [{ id: "text", text: "One" }], overlays: [{ id: "image", x: 0.1 }] }],
+    fonts: [{ id: "font", fontData: "data:font/ttf;base64,AA==", variableAxes: [{ tag: "wght", default: 400 }] }],
+    slides: [{
+      id: "slide",
+      texts: [{ id: "text", text: "One", fontVariationSettings: { wght: 500 } }],
+      overlays: [{ id: "image", x: 0.1 }],
+    }],
   };
   const copy = cloneProject(original);
   copy.assets[0].name = "Changed";
+  copy.fonts[0].variableAxes[0].default = 700;
   copy.slides[0].texts[0].text = "Two";
+  copy.slides[0].texts[0].fontVariationSettings.wght = 700;
   copy.slides[0].overlays[0].x = 0.5;
   assert.equal(original.assets[0].name, "Original");
+  assert.equal(original.fonts[0].variableAxes[0].default, 400);
   assert.equal(original.slides[0].texts[0].text, "One");
+  assert.equal(original.slides[0].texts[0].fontVariationSettings.wght, 500);
   assert.equal(original.slides[0].overlays[0].x, 0.1);
 });
 

--- a/test/editor-projects.test.mjs
+++ b/test/editor-projects.test.mjs
@@ -33,6 +33,7 @@ test("normalizes legacy projects in place without replacing existing records", (
   assert.equal(result[0].slides[0].texts[0], text);
   assert.equal(project.revision, 0);
   assert.deepEqual(project.assets, []);
+  assert.deepEqual(project.fonts, []);
   assert.equal(slide.imageScale, 1);
   assert.equal(slide.imageX, 0);
   assert.equal(slide.imageY, 0);
@@ -135,6 +136,9 @@ test("restores every legacy text default while preserving valid values", () => {
     align: "center",
     rotation: 0,
     z: 2,
+    fontFamily: "TikTok Sans",
+    fontWeight: 500,
+    fontStyle: "normal",
   });
   assert.equal(legacyBoxed.color, "#FFFFFF");
   assert.equal(legacyBoxed.outlineWidth, 12);
@@ -154,6 +158,9 @@ test("restores every legacy text default while preserving valid values", () => {
     align: "right",
     rotation: 25,
     z: 40,
+    fontFamily: "TikTok Sans",
+    fontWeight: 500,
+    fontStyle: "normal",
   });
   assert.equal(projects[0].slides[0].imageScale, 0);
 });

--- a/test/project-fonts.test.mjs
+++ b/test/project-fonts.test.mjs
@@ -1,0 +1,370 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_STYLE,
+  DEFAULT_FONT_WEIGHT,
+  applyProjectFontToText,
+  createProjectFont,
+  ensureProjectFontsLoaded,
+  isTextFontAvailable,
+  isTextFontLoaded,
+  normalizeProjectFonts,
+  projectFontForText,
+  publicProjectFont,
+  quoteCssFontFamily,
+  textCanvasFont,
+  textCssFontFamily,
+  textFontFamily,
+  textFontLabel,
+  textFontStyle,
+  textFontVariationCss,
+  textFontVariationSettings,
+  textFontVariationValues,
+  textFontWeight,
+} from "../src/project-fonts.mjs";
+
+const FONT_DATA = "data:font/otf;base64,AAECA/8=";
+
+function localFace(overrides = {}) {
+  return {
+    localFontId: "font_local_didot_regular",
+    family: "Didot",
+    fullName: "Didot Regular",
+    postscriptName: "Didot",
+    subfamily: "Regular",
+    weight: 400,
+    italic: false,
+    fingerprint: "didot-fingerprint",
+    variableAxes: [],
+    ...overrides,
+  };
+}
+
+function projectWithFont(font, text = {}) {
+  return {
+    id: "project-font-test",
+    fonts: [font],
+    slides: [{ id: "slide", texts: [{ id: "text", text: "speed limit", fontId: font.id, ...text }] }],
+  };
+}
+
+function installFakeFontEnvironment({ loadFace = null } = {}) {
+  const previousDocument = globalThis.document;
+  const previousFontFace = globalThis.FontFace;
+  const constructed = [];
+  const added = [];
+  const deleted = [];
+  const defaultLoads = [];
+  class FakeFontFace {
+    constructor(family, source, descriptors) {
+      this.family = family;
+      this.source = source;
+      this.descriptors = descriptors;
+      this.status = "unloaded";
+      constructed.push(this);
+    }
+
+    async load() {
+      if (loadFace) return loadFace(this);
+      this.status = "loaded";
+      return this;
+    }
+  }
+  globalThis.FontFace = FakeFontFace;
+  globalThis.document = {
+    fonts: {
+      ready: Promise.resolve(),
+      async load(value) {
+        defaultLoads.push(value);
+        return [];
+      },
+      add(face) { added.push(face); },
+      delete(face) { deleted.push(face); },
+    },
+  };
+  return {
+    constructed,
+    added,
+    deleted,
+    defaultLoads,
+    restore() {
+      if (previousDocument === undefined) delete globalThis.document;
+      else globalThis.document = previousDocument;
+      if (previousFontFace === undefined) delete globalThis.FontFace;
+      else globalThis.FontFace = previousFontFace;
+    },
+  };
+}
+
+test("normalizes legacy text to CarouselBot's actual bundled default", () => {
+  const project = {
+    id: "legacy",
+    slides: [{
+      id: "slide",
+      texts: [
+        { id: "plain", text: "Default" },
+        { id: "italic", text: "Existing", fontFamily: "Existing family", fontWeight: 725, fontStyle: "italic" },
+      ],
+    }],
+  };
+
+  assert.equal(normalizeProjectFonts(project), project);
+  assert.deepEqual(project.fonts, []);
+  assert.deepEqual(project.slides[0].texts[0], {
+    id: "plain",
+    text: "Default",
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontWeight: DEFAULT_FONT_WEIGHT,
+    fontStyle: DEFAULT_FONT_STYLE,
+  });
+  assert.equal(DEFAULT_FONT_FAMILY, "TikTok Sans");
+  assert.equal(DEFAULT_FONT_WEIGHT, 500);
+  assert.equal(project.slides[0].texts[1].fontFamily, DEFAULT_FONT_FAMILY);
+  assert.equal(project.slides[0].texts[1].fontWeight, 725);
+  assert.equal(project.slides[0].texts[1].fontStyle, "italic");
+});
+
+test("creates a deterministic, path-free project font record from companion metadata", () => {
+  const font = createProjectFont(localFace({
+    pathInternal: "/System/Library/Fonts/Supplemental/Didot.ttc",
+    variableAxes: [
+      { tag: "wght", name: "Weight", min: 100, max: 900, default: 400 },
+      { tag: "wght", name: "Duplicate", min: 1, max: 2, default: 1 },
+      { tag: "bad", name: "Bad", min: 0, max: 1, default: 0 },
+    ],
+  }), FONT_DATA, { id: "project face", addedAt: 123, dataRevision: "revision-1" });
+
+  assert.deepEqual(font, {
+    id: "project face",
+    source: "local",
+    localFontId: "font_local_didot_regular",
+    family: "Didot",
+    fullName: "Didot Regular",
+    postscriptName: "Didot",
+    subfamily: "Regular",
+    weight: 400,
+    italic: false,
+    cssFamily: "carousel-font-project-face",
+    variableAxes: [{ tag: "wght", name: "Weight", min: 100, max: 900, default: 400 }],
+    fingerprint: "didot-fingerprint",
+    dataRevision: "revision-1",
+    addedAt: 123,
+    fontData: FONT_DATA,
+  });
+  assert.equal("pathInternal" in font, false);
+  assert.throws(() => createProjectFont({}, FONT_DATA), /localFontId/);
+  assert.throws(() => createProjectFont(localFace(), "https://example.com/font.otf"), /base64 data URL/);
+});
+
+test("normalizes and deduplicates stored project fonts without discarding dangling text refs", () => {
+  const first = createProjectFont(localFace(), FONT_DATA, { id: "first", addedAt: 1 });
+  const duplicateFace = { ...first, id: "duplicate", cssFamily: "unsafe family" };
+  const project = {
+    id: "stored",
+    fonts: [first, duplicateFace, null, { id: "", localFontId: "bad" }],
+    slides: [{ id: "slide", texts: [{ id: "text", fontId: "missing", fontFamily: "Gone font" }] }],
+  };
+
+  normalizeProjectFonts(project);
+
+  assert.equal(project.fonts.length, 1);
+  assert.equal(project.fonts[0].id, "first");
+  assert.equal(project.fonts[0].cssFamily, "carousel-font-first");
+  assert.equal(project.slides[0].texts[0].fontId, "missing");
+  assert.equal(project.slides[0].texts[0].fontFamily, "Gone font");
+  assert.equal(project.slides[0].texts[0].fontWeight, DEFAULT_FONT_WEIGHT);
+  assert.equal(textFontLabel(project, project.slides[0].texts[0]), "Gone font");
+});
+
+test("resolves one shared descriptor for DOM, canvas, labels, and variable settings", () => {
+  const font = createProjectFont(localFace({
+    fullName: "Didot Variable",
+    weight: 450,
+    italic: true,
+    variableAxes: [{ tag: "wght", name: "Weight", min: 300, max: 700, default: 450 }],
+  }), FONT_DATA, { id: "didot-variable" });
+  const text = {
+    id: "text",
+    fontId: font.id,
+    fontWeight: 625,
+    fontStyle: "normal",
+    fontVariationSettings: { wght: 900, nope: 20, bad: "x" },
+  };
+  const project = { id: "project", fonts: [font], slides: [] };
+
+  assert.equal(projectFontForText(project, text), font);
+  assert.equal(textFontFamily(project, text), "carousel-font-didot-variable");
+  assert.equal(textFontWeight(project, text), 700);
+  assert.equal(textFontStyle(project, text), "italic");
+  assert.deepEqual(textFontVariationValues(project, text), { wght: 700 });
+  assert.deepEqual(textFontVariationSettings(project, text), { wght: 700 });
+  assert.equal(textFontVariationCss(project, text), '"wght" 700');
+  assert.equal(textFontVariationCss(text), '"wght" 900, "nope" 20');
+  assert.equal(textFontLabel(project, text), "Didot Variable");
+  assert.equal(textCssFontFamily(project, text), '"carousel-font-didot-variable", "TikTok Sans", sans-serif');
+  assert.equal(textCanvasFont(project, text, 64), 'italic 700 64px "carousel-font-didot-variable"');
+  assert.equal(quoteCssFontFamily('Face "One"\nTwo'), '"Face \\"One\\" Two"');
+});
+
+test("applies a project face by ID and resets cleanly to the built-in face", () => {
+  const font = createProjectFont(localFace({ weight: 700, italic: true }), FONT_DATA, { id: "didot-bold-italic" });
+  const project = { id: "project", fonts: [font], slides: [] };
+  const text = { id: "text", fontVariationSettings: { wght: 600 } };
+
+  assert.equal(applyProjectFontToText(project, text, font.id), text);
+  assert.deepEqual(text, {
+    id: "text",
+    fontId: font.id,
+    fontFamily: "Didot",
+    fontWeight: 700,
+    fontStyle: "italic",
+  });
+
+  applyProjectFontToText(project, text, null);
+  assert.deepEqual(text, {
+    id: "text",
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontWeight: DEFAULT_FONT_WEIGHT,
+    fontStyle: DEFAULT_FONT_STYLE,
+  });
+  assert.throws(
+    () => applyProjectFontToText(project, text, "guessed-font-id"),
+    (error) => error.code === "FONT_NOT_FOUND" && error.fontId === "guessed-font-id",
+  );
+});
+
+test("redacts private bytes and fingerprints from public project font records", () => {
+  const font = createProjectFont(localFace(), FONT_DATA, { id: "public-font" });
+  const project = { id: "project", fonts: [font], slides: [] };
+  const value = publicProjectFont(project, font);
+
+  assert.equal(value.id, font.id);
+  assert.equal(value.localFontId, font.localFontId);
+  assert.equal(value.available, true);
+  assert.equal("fontData" in value, false);
+  assert.equal("fingerprint" in value, false);
+  assert.equal("dataRevision" in value, false);
+  assert.equal(JSON.stringify(value).includes("AAECA"), false);
+});
+
+test("registers exact stored bytes once and waits for the bundled default font", async () => {
+  const environment = installFakeFontEnvironment();
+  try {
+    const font = createProjectFont(localFace({ localFontId: "register-once" }), FONT_DATA, { id: "register-once" });
+    const project = projectWithFont(font);
+    const customText = project.slides[0].texts[0];
+    const defaultText = { id: "default", text: "Default" };
+    assert.equal(isTextFontLoaded(project, customText), false);
+
+    const [first, second] = await Promise.all([
+      ensureProjectFontsLoaded(project, [customText, defaultText]),
+      ensureProjectFontsLoaded(project, [customText, defaultText]),
+    ]);
+
+    assert.deepEqual(first.loadedFontIds, [font.id]);
+    assert.deepEqual(second.loadedFontIds, [font.id]);
+    assert.equal(environment.constructed.length, 1);
+    assert.equal(environment.added.length, 1);
+    assert.equal(environment.constructed[0].family, font.cssFamily);
+    assert.deepEqual(environment.constructed[0].descriptors, { weight: "400", style: "normal" });
+    assert.deepEqual([...new Uint8Array(environment.constructed[0].source)], [0, 1, 2, 3, 255]);
+    assert.ok(environment.defaultLoads.every((value) => value === '500 64px "TikTok Sans"'));
+    assert.equal(isTextFontAvailable(project, customText), true);
+    assert.equal(isTextFontLoaded(project, customText), true);
+  } finally {
+    environment.restore();
+  }
+});
+
+test("registers a variable weight face across its supported range", async () => {
+  const environment = installFakeFontEnvironment();
+  try {
+    const font = createProjectFont(localFace({
+      localFontId: "variable-weight-face",
+      variableAxes: [{ tag: "wght", name: "Weight", min: 300, max: 725, default: 450 }],
+    }), FONT_DATA, { id: "variable-weight-face" });
+    const project = projectWithFont(font);
+
+    await ensureProjectFontsLoaded(project);
+
+    assert.equal(environment.constructed[0].descriptors.weight, "300 725");
+  } finally {
+    environment.restore();
+  }
+});
+
+test("reports unavailable and dangling fonts honestly with stable error codes", async () => {
+  const environment = installFakeFontEnvironment({
+    loadFace: async () => { throw new Error("invalid OpenType data"); },
+  });
+  try {
+    const corrupt = createProjectFont(
+      localFace({ localFontId: "corrupt-face", fullName: "Corrupt Face", fingerprint: "corrupt" }),
+      FONT_DATA,
+      { id: "corrupt-face" },
+    );
+    const corruptProject = projectWithFont(corrupt);
+    await assert.rejects(
+      ensureProjectFontsLoaded(corruptProject),
+      (error) => error.code === "FONT_UNAVAILABLE"
+        && error.fontId === corrupt.id
+        && error.message.includes("Corrupt Face")
+        && error.missingFonts.length === 1,
+    );
+    assert.equal(isTextFontAvailable(corruptProject, corruptProject.slides[0].texts[0]), false);
+    assert.equal(publicProjectFont(corruptProject, corrupt).available, false);
+
+    const dangling = {
+      id: "dangling-project",
+      fonts: [],
+      slides: [{ id: "slide", texts: [{ id: "text", fontId: "removed-font", fontFamily: "Removed Face" }] }],
+    };
+    await assert.rejects(
+      ensureProjectFontsLoaded(dangling),
+      (error) => error.code === "FONT_UNAVAILABLE"
+        && error.fontId === "removed-font"
+        && error.message.includes("Removed Face"),
+    );
+    assert.equal(isTextFontAvailable(dangling, dangling.slides[0].texts[0]), false);
+  } finally {
+    environment.restore();
+  }
+});
+
+test("re-registers a repaired face with the same project font ID", async () => {
+  let shouldFail = true;
+  const environment = installFakeFontEnvironment({
+    loadFace: async (face) => {
+      if (shouldFail) throw new Error("corrupt stored bytes");
+      face.status = "loaded";
+      return face;
+    },
+  });
+  try {
+    const broken = createProjectFont(
+      localFace({ localFontId: "repair-face", fingerprint: "same-source" }),
+      FONT_DATA,
+      { id: "stable-project-font", dataRevision: "broken-revision" },
+    );
+    const project = projectWithFont(broken);
+    await assert.rejects(ensureProjectFontsLoaded(project), (error) => error.code === "FONT_UNAVAILABLE");
+
+    shouldFail = false;
+    const repaired = createProjectFont(
+      localFace({ localFontId: "repair-face", fingerprint: "same-source" }),
+      FONT_DATA,
+      { id: broken.id, addedAt: broken.addedAt, dataRevision: "repaired-revision" },
+    );
+    project.fonts = [repaired];
+    await ensureProjectFontsLoaded(project);
+
+    assert.equal(project.slides[0].texts[0].fontId, broken.id);
+    assert.equal(isTextFontLoaded(project, project.slides[0].texts[0]), true);
+    assert.equal(environment.constructed.length, 2);
+    assert.equal(environment.added.length, 1);
+  } finally {
+    environment.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- index installed macOS fonts locally, including exact TTC face extraction
- add local-only project font persistence, exact FontFace loading, missing-font handling, and a compact picker
- expose deterministic MCP font discovery/import/application tools
- bump carouselbot and slides-studio-mcp to 0.3.0

## Verification
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local

Real Didot acceptance: 3 TTC faces, 2,712 changed pixels, 23.0365 px glyph-width delta, zero pixel changes after reload, and byte-identical full-resolution export.