### PR TITLE
Add scrollable project slide previews

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -936,6 +936,154 @@ try {
     "A missing deep route did not return to the dashboard with feedback.",
   );
 
+  const filmstripProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Filmstrip preview project' })`);
+  const filmstripSlideIds = await callPageFunction(cdp, `async function(projectId) {
+    const colors = ['#FE2C55', '#25F4EE', '#25282E', '#F4C95D', '#8A5CF5', '#3DBE78', '#F28C45', '#496DDB'];
+    const ids = [];
+    for (const [index, backgroundColor] of colors.entries()) {
+      const result = await this.carouselBotAgent.execute({
+        type: 'slide.add',
+        projectId,
+        name: 'Preview ' + (index + 1),
+        backgroundColor,
+      });
+      ids.push(result.createdSlideId);
+    }
+    return ids;
+  }`, [filmstripProject.projectId]);
+  const filmstrip = await waitFor(() => evaluate(cdp, `(() => {
+    const card = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]');
+    const shell = card?.closest('.project-card-shell');
+    const strip = shell?.querySelector('[data-project-preview-strip]');
+    const slides = [...(strip?.querySelectorAll('[data-project-preview-slide-id]') || [])];
+    const previous = shell?.querySelector('[data-project-preview-direction="previous"]');
+    const next = shell?.querySelector('[data-project-preview-direction="next"]');
+    if (!card || !shell || !strip || slides.length !== 8 || slides.some((slide) => !slide.querySelector('img'))) return false;
+    return {
+      slideIds: slides.map((slide) => slide.dataset.projectPreviewSlideId),
+      ratios: slides.map((slide) => {
+        const rect = slide.getBoundingClientRect();
+        return rect.width / rect.height;
+      }),
+      scrollLeft: strip.scrollLeft,
+      maxScrollLeft: strip.scrollWidth - strip.clientWidth,
+      overflow: strip.scrollWidth > strip.clientWidth + 2,
+      renderedCount: slides.filter((slide) => slide.querySelector('img.thumb-rendered')).length,
+      previousHidden: previous?.hidden,
+      nextHidden: next?.hidden,
+      controlsOutsideLink: !card.contains(previous) && !card.contains(next),
+      cardLabel: card.getAttribute('aria-label'),
+      buttonTypes: [previous?.type, next?.type],
+      labels: [previous?.getAttribute('aria-label'), next?.getAttribute('aria-label')],
+      touchTargets: [previous, next].map((button) => Number.parseFloat(getComputedStyle(button).width)),
+    };
+  })()`), "The dashboard project filmstrip did not render all slide thumbnails.");
+  if (
+    JSON.stringify(filmstrip.slideIds) !== JSON.stringify(filmstripSlideIds)
+    || filmstrip.ratios.some((ratio) => Math.abs(ratio - (9 / 16)) > 0.02)
+    || !filmstrip.overflow
+    || filmstrip.renderedCount < 1
+    || filmstrip.previousHidden !== true
+    || filmstrip.nextHidden !== false
+    || !filmstrip.controlsOutsideLink
+    || !filmstrip.cardLabel?.includes("8 slides")
+    || filmstrip.buttonTypes.some((type) => type !== "button")
+    || filmstrip.labels.some((label) => !label?.includes("Filmstrip preview project slide previews"))
+    || filmstrip.touchTargets.some((size) => size < 44)
+  ) {
+    throw new Error(`Dashboard project filmstrip markup was incorrect: ${JSON.stringify(filmstrip)}`);
+  }
+
+  await callPageFunction(cdp, `function(projectId, slideId) {
+    return this.carouselBotAgent.execute({ type: 'slide.update', projectId, slideId, backgroundColor: '#0A0A0A' });
+  }`, [filmstripProject.projectId, filmstripSlideIds[5]]);
+  await evaluate(cdp, `document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]').closest('.project-card-shell').querySelector('[data-project-preview-direction="next"]').click()`);
+  const filmstripAfterNext = await waitFor(() => evaluate(cdp, `(() => {
+    const shell = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]')?.closest('.project-card-shell');
+    const strip = shell?.querySelector('[data-project-preview-strip]');
+    const previous = shell?.querySelector('[data-project-preview-direction="previous"]');
+    const revealedSlide = strip?.querySelector('[data-project-preview-slide-id=${JSON.stringify(filmstripSlideIds[5])}] img.thumb-rendered');
+    return strip?.scrollLeft > 2 && previous && !previous.hidden && revealedSlide
+      ? { pathname: location.pathname, scrollLeft: strip.scrollLeft }
+      : false;
+  })()`), "The project filmstrip did not scroll right or reveal its previous control.");
+  if (filmstripAfterNext.pathname !== "/") throw new Error(`The filmstrip control opened the project: ${JSON.stringify(filmstripAfterNext)}`);
+  const revealedPixel = await evaluate(cdp, `(async () => {
+    const image = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"] [data-project-preview-slide-id=${JSON.stringify(filmstripSlideIds[5])}] img.thumb-rendered');
+    await image.decode();
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    context.drawImage(image, 0, 0, 1, 1);
+    return [...context.getImageData(0, 0, 1, 1).data];
+  })()`);
+  if (revealedPixel.some((channel, index) => Math.abs(channel - [10, 10, 10, 255][index]) > 3)) {
+    throw new Error(`A stale off-screen render replaced the updated filmstrip slide: ${JSON.stringify(revealedPixel)}`);
+  }
+
+  const filmstripAtEnd = await evaluate(cdp, `(() => {
+    const shell = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]').closest('.project-card-shell');
+    const strip = shell.querySelector('[data-project-preview-strip]');
+    const next = shell.querySelector('[data-project-preview-direction="next"]');
+    next.focus();
+    strip.scrollLeft = strip.scrollWidth;
+    strip.dispatchEvent(new Event('scroll'));
+    const previous = shell.querySelector('[data-project-preview-direction="previous"]');
+    return { scrollLeft: strip.scrollLeft, maxScrollLeft: strip.scrollWidth - strip.clientWidth, previousHidden: previous.hidden, nextHidden: next.hidden, focusDirection: document.activeElement?.dataset.projectPreviewDirection };
+  })()`);
+  if (Math.abs(filmstripAtEnd.scrollLeft - filmstripAtEnd.maxScrollLeft) > 2 || filmstripAtEnd.previousHidden || !filmstripAtEnd.nextHidden || filmstripAtEnd.focusDirection !== "previous") {
+    throw new Error(`The project filmstrip controls did not reflect its final edge: ${JSON.stringify(filmstripAtEnd)}`);
+  }
+  await waitFor(
+    () => evaluate(cdp, `Boolean(document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"] [data-project-preview-slide-id=${JSON.stringify(filmstripSlideIds.at(-1))}] img.thumb-rendered'))`),
+    "The project filmstrip did not render the newly revealed final slide.",
+  );
+  await evaluate(cdp, `document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]').closest('.project-card-shell').querySelector('[data-project-preview-direction="previous"]').click()`);
+  await waitFor(
+    () => evaluate(cdp, `(() => {
+      const strip = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]')?.closest('.project-card-shell')?.querySelector('[data-project-preview-strip]');
+      return strip && strip.scrollLeft < strip.scrollWidth - strip.clientWidth - 2;
+    })()`),
+    "The project filmstrip did not scroll back to the left.",
+  );
+  await cdp.send("Emulation.setDeviceMetricsOverride", { width: 375, height: 900, deviceScaleFactor: 1, mobile: false });
+  const narrowFilmstrip = await waitFor(() => evaluate(cdp, `(() => {
+    const shell = document.querySelector('.project-card[data-project-id="${filmstripProject.projectId}"]')?.closest('.project-card-shell');
+    const strip = shell?.querySelector('[data-project-preview-strip]');
+    if (!strip) return false;
+    strip.scrollLeft = 0;
+    strip.dispatchEvent(new Event('scroll'));
+    const next = shell.querySelector('[data-project-preview-direction="next"]');
+    return !next.hidden ? {
+      viewportWidth: innerWidth,
+      documentWidth: document.documentElement.scrollWidth,
+      cardWidth: shell.getBoundingClientRect().width,
+      overflow: strip.scrollWidth > strip.clientWidth + 2,
+    } : false;
+  })()`), "The project filmstrip controls did not adapt to the narrow dashboard layout.");
+  if (narrowFilmstrip.documentWidth > narrowFilmstrip.viewportWidth + 1 || !narrowFilmstrip.overflow || narrowFilmstrip.cardWidth > narrowFilmstrip.viewportWidth) {
+    throw new Error(`The narrow project filmstrip caused page-level overflow: ${JSON.stringify(narrowFilmstrip)}`);
+  }
+  await cdp.send("Emulation.clearDeviceMetricsOverride");
+  await waitFor(() => evaluate(cdp, "innerWidth > 1000"), "The browser viewport did not return to its desktop size.");
+  const nonOverflowingPreview = await waitFor(() => evaluate(cdp, `(() => {
+    const shell = document.querySelector('.project-card[data-project-id=${JSON.stringify(projectId)}]')?.closest('.project-card-shell');
+    const strip = shell?.querySelector('[data-project-preview-strip]');
+    if (!strip) return false;
+    const value = {
+      overflow: strip.scrollWidth > strip.clientWidth + 2,
+      visibleControls: [...shell.querySelectorAll('[data-project-preview-direction]')].filter((button) => !button.hidden).length,
+    };
+    return !value.overflow && value.visibleControls === 0 ? value : false;
+  })()`), "A non-overflowing project preview did not hide its scroll controls after resizing.");
+  if (!nonOverflowingPreview || nonOverflowingPreview.overflow || nonOverflowingPreview.visibleControls !== 0) {
+    throw new Error(`A non-overflowing project preview showed scroll controls: ${JSON.stringify(nonOverflowingPreview)}`);
+  }
+  await callPageFunction(cdp, `function(projectId) {
+    return this.carouselBotAgent.execute({ type: 'project.delete', projectId });
+  }`, [filmstripProject.projectId]);
+
   const folderUiProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Folder UI project' })`);
   const folderUiSlide = await callPageFunction(cdp, `function(projectId) {
     return this.carouselBotAgent.execute({
@@ -1065,6 +1213,7 @@ try {
     nativeSlideLifecycle: true,
     nativeOutputActions: true,
     nativeProjectDeletion: true,
+    dashboardProjectFilmstrip: true,
     nativeFolderOrganization: true,
     deepRouteReload: true,
     missingRouteFallback: true,

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -770,7 +770,7 @@ try {
   }
   const stressEditors = (await tool("list_editors")).structuredContent.editors;
   if (stressEditors.length < 7) throw new Error(`Seven-tab transport stress setup connected only ${stressEditors.length} editors.`);
-  const previousCoverUrl = await waitFor(() => evaluate(secondCdp, `document.querySelector('[data-project-cover-id="${createdProject.projectId}"] img[data-composite-cover="true"]')?.src || ""`), "The dashboard did not render its initial composed project cover.");
+  const previousThumbnailUrl = await waitFor(() => evaluate(secondCdp, `document.querySelector('.project-card[data-project-id="${createdProject.projectId}"] [data-project-preview-slide-id="${addedSlide.createdSlideId}"] img.thumb-rendered')?.src || ""`), "The dashboard did not render its initial project slide thumbnail.");
   await evaluate(secondCdp, `(() => {
     window.__carouselBotOriginalRequestAnimationFrame = window.requestAnimationFrame;
     window.requestAnimationFrame = () => 0;
@@ -786,10 +786,11 @@ try {
     })()`), "A tool action performed in another editor was not announced in this tab.");
     if (crossTabActivity.label !== "Codex" || !crossTabActivity.icon?.includes("codex-logo-colored")) throw new Error(`Cross-tab activity used the wrong client identity: ${JSON.stringify(crossTabActivity)}`);
     await waitFor(() => evaluate(secondCdp, `[...document.querySelectorAll('.project-card .project-meta strong')].some((item) => item.textContent === "Cross-tab sync verified")`), "The dashboard did not receive the cross-tab project update.");
+    await tool("update_slide", { projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, backgroundColor: "#101820" });
     await waitFor(() => evaluate(secondCdp, `(() => {
-      const image = document.querySelector('[data-project-cover-id="${createdProject.projectId}"] img[data-composite-cover="true"]');
-      return image?.src && image.src !== ${JSON.stringify(previousCoverUrl)};
-    })()`), "The dashboard did not refresh its composed cover while animation frames were paused.");
+      const image = document.querySelector('.project-card[data-project-id="${createdProject.projectId}"] [data-project-preview-slide-id="${addedSlide.createdSlideId}"] img.thumb-rendered');
+      return image?.src && image.src !== ${JSON.stringify(previousThumbnailUrl)};
+    })()`), "The dashboard did not refresh its slide thumbnail while animation frames were paused.");
   } finally {
     await evaluate(secondCdp, `(() => {
       window.requestAnimationFrame = window.__carouselBotOriginalRequestAnimationFrame;
@@ -802,7 +803,7 @@ try {
     .catch((error) => { if (!/revision changed/.test(error.message)) throw error; });
   await tool("end_edit_session", { editSessionId });
   editSessionId = null;
-  process.stdout.write(`${JSON.stringify({ connected: true, optInRequired: true, reconnectAfterReload: true, localFonts: localFontAcceptance, sevenTabConnectionStress: true, crossTabSync: true, crossTabActionNotifications: true, composedDashboardCover: true, dashboardProjectNotification: true, folderCreateAndMove: true, pendingUiSavePreservedDuringMcpMove: true, connectionStatusLeftAligned: true, backgroundEditsPreserveView: true, roleBasedTextDefaults: true, automaticTextHeightFitting: true, agentIdentityNotificationIcon: true, compactToolbar: true, fittedFullBox: true, symmetricPerLinePaddingAfterReload: true, projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, textLayers: 2, imageLayers: 1, operationsCovered: 45, previewBytes: imageContent.data.length, exportBytes: (await stat(exportPath)).size, projectExports: exportedProject.fileCount }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ connected: true, optInRequired: true, reconnectAfterReload: true, localFonts: localFontAcceptance, sevenTabConnectionStress: true, crossTabSync: true, crossTabActionNotifications: true, dashboardSlideFilmstrip: true, dashboardProjectNotification: true, folderCreateAndMove: true, pendingUiSavePreservedDuringMcpMove: true, connectionStatusLeftAligned: true, backgroundEditsPreserveView: true, roleBasedTextDefaults: true, automaticTextHeightFitting: true, agentIdentityNotificationIcon: true, compactToolbar: true, fittedFullBox: true, symmetricPerLinePaddingAfterReload: true, projectId: createdProject.projectId, slideId: addedSlide.createdSlideId, textLayers: 2, imageLayers: 1, operationsCovered: 46, previewBytes: imageContent.data.length, exportBytes: (await stat(exportPath)).size, projectExports: exportedProject.fileCount }, null, 2)}\n`);
 } finally {
   await closeChromeGracefully();
   for (const extraCdp of additionalCdps) extraCdp.close();

--- a/src/agent-commands.mjs
+++ b/src/agent-commands.mjs
@@ -515,6 +515,7 @@ async function executeCarouselBotAgentOperation(operation) {
     const expectedRevision = Number(project.revision) || 0;
     await deleteProjectFromDb(project.id, { expectedRevision });
     state.projects = state.projects.filter((item) => item.id !== project.id);
+    project.slides.forEach((slide) => clearSlideThumbnail(slide.id, project.id));
     clearProjectCover(project.id);
     if (state.activeFolderPath && !state.projects.some((item) => item.folderPath === state.activeFolderPath)) {
       state.activeFolderPath = null;
@@ -565,7 +566,7 @@ async function executeCarouselBotAgentOperation(operation) {
       if (operation.imageX != null) slide.imageX = Number(operation.imageX) || 0;
       if (operation.imageY != null) slide.imageY = Number(operation.imageY) || 0;
       constrainImagePosition(slide);
-      clearSlideThumbnail(slide.id);
+      clearSlideThumbnail(slide.id, project.id);
       return { updatedSlideId: slide.id, name: slide.name };
     }, "AI agent updated the slide");
   }
@@ -600,7 +601,7 @@ async function executeCarouselBotAgentOperation(operation) {
     const index = project.slides.indexOf(slide);
     return agentCommit(project, slide, () => {
       project.slides.splice(index, 1);
-      clearSlideThumbnail(slide.id);
+      clearSlideThumbnail(slide.id, project.id);
       state.activeSlideId = project.slides[index]?.id || project.slides[index - 1]?.id || null;
       return { deletedSlideId: slide.id };
     }, "AI agent deleted a slide");

--- a/src/editor-actions.mjs
+++ b/src/editor-actions.mjs
@@ -215,7 +215,7 @@ export function createEditorActions({
       slide.height = dimensions.height;
       slide.backgroundRevision = uid();
       constrainImagePosition(slide);
-      clearSlideThumbnail(slide.id);
+      clearSlideThumbnail(slide.id, project.id);
       scheduleSave();
       renderEditor();
       toast("Slide background changed");
@@ -233,7 +233,7 @@ export function createEditorActions({
 
     recordHistory();
     project.slides.splice(index, 1);
-    clearSlideThumbnail(slideId);
+    clearSlideThumbnail(slideId, project.id);
 
     if (state.activeSlideId === slideId) {
       state.activeSlideId = project.slides[index]?.id || project.slides[index - 1]?.id || null;

--- a/src/editor-output.mjs
+++ b/src/editor-output.mjs
@@ -4,11 +4,31 @@ import {
   app,
   activeProject,
   activeSlide,
+  slideThumbnailKey,
 } from "./editor-state.mjs";
 import { renderSlideThumbnail } from "./editor-view.mjs";
 import { canvasToBlob, renderSlideCanvas } from "./slide-renderer.mjs";
 
 export function createEditorOutput({ toast }) {
+  const thumbnailRenderQueue = [];
+  let activeThumbnailRenders = 0;
+  let dashboardThumbnailObserver = null;
+  let dashboardThumbnailKeys = new Set();
+
+  function acquireThumbnailRenderSlot() {
+    if (activeThumbnailRenders < 4) {
+      activeThumbnailRenders += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => thumbnailRenderQueue.push(resolve));
+  }
+
+  function releaseThumbnailRenderSlot() {
+    const next = thumbnailRenderQueue.shift();
+    if (next) next();
+    else activeThumbnailRenders = Math.max(0, activeThumbnailRenders - 1);
+  }
+
   function projectCoverSignature(project) {
     const slide = project.slides[0];
     return slide ? `${Number(project.revision) || 0}:${slide.id}:${thumbnailSignature(slide, project)}` : "";
@@ -116,57 +136,172 @@ export function createEditorOutput({ toast }) {
     ]);
   }
 
-  async function refreshSlideThumbnail(slide) {
-    const target = app.querySelector(`[data-thumbnail-slide-id="${slide.id}"]`);
-    if (!target) return;
-    const signature = thumbnailSignature(slide);
-    const cachedUrl = state.thumbnailUrls.get(slide.id);
-    if (cachedUrl && state.thumbnailSignatures.get(slide.id) === signature) {
-      const image = target.querySelector(".thumb-rendered");
-      if (image?.src !== cachedUrl) image.src = cachedUrl;
+  function slideThumbnailTargets(slideId, project) {
+    return [...app.querySelectorAll("[data-thumbnail-slide-id][data-thumbnail-project-id]")]
+      .filter((target) => target.dataset.thumbnailSlideId === String(slideId)
+        && target.dataset.thumbnailProjectId === String(project?.id || ""));
+  }
+
+  async function refreshSlideThumbnail(slide, project = activeProject()) {
+    const targets = slideThumbnailTargets(slide.id, project);
+    if (!targets.length) return;
+    const cacheKey = slideThumbnailKey(project?.id, slide.id);
+    const signature = thumbnailSignature(slide, project);
+    const renderToken = Symbol("slide-thumbnail-render");
+    state.thumbnailVersions.set(cacheKey, renderToken);
+    const cachedUrl = state.thumbnailUrls.get(cacheKey);
+    if (cachedUrl && state.thumbnailSignatures.get(cacheKey) === signature) {
+      targets.forEach((target) => {
+        const image = target.querySelector(".thumb-rendered");
+        if (image) {
+          if (image.src !== cachedUrl) image.src = cachedUrl;
+        } else {
+          target.innerHTML = renderSlideThumbnail(slide, project);
+        }
+        target.classList.remove("is-rendering");
+      });
       return;
     }
 
-    const version = (state.thumbnailVersions.get(slide.id) || 0) + 1;
-    state.thumbnailVersions.set(slide.id, version);
-    target.classList.add("is-rendering");
+    targets.forEach((target) => target.classList.add("is-rendering"));
+    await acquireThumbnailRenderSlot();
     try {
-      const canvas = await renderSlideCanvas(slide, 540, 960);
+      if (state.thumbnailVersions.get(cacheKey) !== renderToken || !slideThumbnailTargets(slide.id, project).length) return;
+      const canvas = await renderSlideCanvas(slide, 540, 960, project);
       const blob = await canvasToBlob(canvas);
-      if (state.thumbnailVersions.get(slide.id) !== version) return;
+      if (state.thumbnailVersions.get(cacheKey) !== renderToken) return;
       const url = URL.createObjectURL(blob);
-      const previousUrl = state.thumbnailUrls.get(slide.id);
-      state.thumbnailUrls.set(slide.id, url);
-      state.thumbnailSignatures.set(slide.id, signature);
+      const previousUrl = state.thumbnailUrls.get(cacheKey);
+      state.thumbnailUrls.set(cacheKey, url);
+      state.thumbnailSignatures.set(cacheKey, signature);
       if (previousUrl) URL.revokeObjectURL(previousUrl);
-      const currentTarget = app.querySelector(`[data-thumbnail-slide-id="${slide.id}"]`);
-      if (currentTarget) {
-        currentTarget.innerHTML = renderSlideThumbnail(slide);
+      slideThumbnailTargets(slide.id, project).forEach((currentTarget) => {
+        currentTarget.innerHTML = renderSlideThumbnail(slide, project);
         currentTarget.removeAttribute("title");
         currentTarget.classList.remove("is-rendering");
-      }
+      });
     } catch (error) {
+      if (state.thumbnailVersions.get(cacheKey) !== renderToken) return;
       console.error(error);
-      clearSlideThumbnail(slide.id);
-      const currentTarget = app.querySelector(`[data-thumbnail-slide-id="${slide.id}"]`);
-      if (currentTarget) {
+      clearSlideThumbnail(slide.id, project?.id);
+      slideThumbnailTargets(slide.id, project).forEach((currentTarget) => {
         currentTarget.classList.remove("is-rendering");
         currentTarget.title = error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Preview unavailable";
-        currentTarget.innerHTML = renderSlideThumbnail(slide);
-      }
+        if (currentTarget.classList.contains("project-preview-slide") && slide.imageData) {
+          const image = document.createElement("img");
+          image.className = "project-preview-source";
+          image.src = slide.imageData;
+          image.alt = "";
+          image.draggable = false;
+          image.loading = "lazy";
+          image.decoding = "async";
+          image.setAttribute("aria-hidden", "true");
+          currentTarget.replaceChildren(image);
+        } else {
+          currentTarget.innerHTML = renderSlideThumbnail(slide, project);
+        }
+      });
+    } finally {
+      releaseThumbnailRenderSlot();
     }
   }
 
-  function refreshAllSlideThumbnails(slides) {
-    slides.forEach((slide) => refreshSlideThumbnail(slide));
+  function refreshAllSlideThumbnails(slides, project = activeProject()) {
+    disconnectDashboardSlideThumbnails();
+    slides.forEach((slide) => { void refreshSlideThumbnail(slide, project); });
   }
 
-  function clearSlideThumbnail(slideId) {
-    const thumbnailUrl = state.thumbnailUrls.get(slideId);
+  function refreshDashboardSlideThumbnails(projects) {
+    disconnectDashboardSlideThumbnails();
+    const projectsById = new Map(projects.map((project) => [project.id, project]));
+    const targets = [...app.querySelectorAll(".project-preview-slide[data-thumbnail-project-id][data-thumbnail-slide-id]")];
+    dashboardThumbnailKeys = new Set(targets.map((target) => slideThumbnailKey(
+      target.dataset.thumbnailProjectId,
+      target.dataset.thumbnailSlideId,
+    )));
+    dashboardThumbnailKeys.forEach((cacheKey) => {
+      state.thumbnailVersions.set(cacheKey, Symbol("dashboard-thumbnail-generation"));
+    });
+    const refreshTarget = (target) => {
+      const project = projectsById.get(target.dataset.thumbnailProjectId);
+      const slide = project?.slides.find((item) => item.id === target.dataset.thumbnailSlideId);
+      if (slide) void refreshSlideThumbnail(slide, project);
+    };
+
+    const eagerProjectIds = new Set();
+    const deferredTargets = [];
+    targets.forEach((target) => {
+      if (!eagerProjectIds.has(target.dataset.thumbnailProjectId)) {
+        eagerProjectIds.add(target.dataset.thumbnailProjectId);
+        refreshTarget(target);
+      } else {
+        deferredTargets.push(target);
+      }
+    });
+    if (!deferredTargets.length) return;
+    if (typeof IntersectionObserver !== "function") {
+      deferredTargets.forEach(refreshTarget);
+      return;
+    }
+
+    dashboardThumbnailObserver = new IntersectionObserver((entries, observer) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        observer.unobserve(entry.target);
+        refreshTarget(entry.target);
+      });
+    }, { rootMargin: "160px", threshold: 0.01 });
+    deferredTargets.forEach((target) => dashboardThumbnailObserver.observe(target));
+  }
+
+  function disconnectDashboardSlideThumbnails() {
+    dashboardThumbnailObserver?.disconnect();
+    dashboardThumbnailObserver = null;
+    dashboardThumbnailKeys.forEach((cacheKey) => {
+      if (state.thumbnailVersions.has(cacheKey)) {
+        state.thumbnailVersions.set(cacheKey, Symbol("dashboard-thumbnail-disconnected"));
+      }
+    });
+    dashboardThumbnailKeys = new Set();
+  }
+
+  function clearThumbnailCacheKey(cacheKey) {
+    const thumbnailUrl = state.thumbnailUrls.get(cacheKey);
     if (thumbnailUrl) URL.revokeObjectURL(thumbnailUrl);
-    state.thumbnailUrls.delete(slideId);
-    state.thumbnailSignatures.delete(slideId);
-    state.thumbnailVersions.delete(slideId);
+    state.thumbnailUrls.delete(cacheKey);
+    state.thumbnailSignatures.delete(cacheKey);
+    state.thumbnailVersions.delete(cacheKey);
+  }
+
+  function clearSlideThumbnail(slideId, projectId = state.activeProjectId) {
+    if (projectId) {
+      clearThumbnailCacheKey(slideThumbnailKey(projectId, slideId));
+      return;
+    }
+    const knownKeys = new Set([
+      ...state.thumbnailUrls.keys(),
+      ...state.thumbnailSignatures.keys(),
+      ...state.thumbnailVersions.keys(),
+    ]);
+    knownKeys.forEach((cacheKey) => {
+      try {
+        if (JSON.parse(cacheKey)[1] === String(slideId)) clearThumbnailCacheKey(cacheKey);
+      } catch {
+        if (cacheKey === slideId) clearThumbnailCacheKey(cacheKey);
+      }
+    });
+  }
+
+  function pruneSlideThumbnails(projects = state.projects) {
+    const liveKeys = new Set(projects.flatMap((project) => project.slides.map((slide) => slideThumbnailKey(project.id, slide.id))));
+    const knownKeys = new Set([
+      ...state.thumbnailUrls.keys(),
+      ...state.thumbnailSignatures.keys(),
+      ...state.thumbnailVersions.keys(),
+    ]);
+    knownKeys.forEach((cacheKey) => {
+      if (!liveKeys.has(cacheKey)) clearThumbnailCacheKey(cacheKey);
+    });
   }
 
   async function renderSlideBlob(slide = activeSlide()) {
@@ -304,7 +439,10 @@ export function createEditorOutput({ toast }) {
     refreshAllProjectCovers,
     clearProjectCover,
     refreshAllSlideThumbnails,
+    refreshDashboardSlideThumbnails,
+    disconnectDashboardSlideThumbnails,
     clearSlideThumbnail,
+    pruneSlideThumbnails,
     exportActiveSlide,
     shareActiveSlide,
     shareAllSlides,

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -83,9 +83,12 @@ export function createEditorProjects({
   scheduleThumbnailRefresh,
   clearProjectCover,
   clearSlideThumbnail,
+  pruneSlideThumbnails,
 }) {
   let migrationModalDismissed = false;
   let dashboardRefreshPromise = null;
+  let dashboardPreviewResizeObserver = null;
+  let dashboardPreviewResizeHandler = null;
   let pendingSaveProject = null;
   let saveInFlight = null;
   const dirtySaveProjects = new Map();
@@ -224,7 +227,9 @@ export function createEditorProjects({
     dirtySaveProjects.delete(projectId);
     if (latest) normalizeLoadedProjects([latest]);
     const index = state.projects.findIndex((project) => project.id === projectId);
+    const previous = index >= 0 ? state.projects[index] : null;
     if (!latest) {
+      previous?.slides.forEach((slide) => clearSlideThumbnail(slide.id, projectId));
       if (index >= 0) state.projects.splice(index, 1);
       clearProjectCover(projectId);
       if (state.activeProjectId === projectId) {
@@ -234,6 +239,8 @@ export function createEditorProjects({
         updateBrowserRoute("/", "replace");
       }
     } else if (index >= 0) {
+      const latestSlideIds = new Set(latest.slides.map((slide) => slide.id));
+      previous.slides.filter((slide) => !latestSlideIds.has(slide.id)).forEach((slide) => clearSlideThumbnail(slide.id, projectId));
       state.projects[index] = latest;
       if (state.activeProjectId === projectId && !latest.slides.some((slide) => slide.id === state.activeSlideId)) state.activeSlideId = latest.slides[0]?.id || null;
     } else state.projects.push(latest);
@@ -729,7 +736,7 @@ export function createEditorProjects({
       try {
         await flushPendingSave();
         await deleteProjectFromDb(projectId, { expectedRevision: Number(project.revision) || 0 });
-        project.slides.forEach((slide) => clearSlideThumbnail(slide.id));
+        project.slides.forEach((slide) => clearSlideThumbnail(slide.id, project.id));
         clearProjectCover(projectId);
         state.slideRailScrollPositions.delete(projectId);
         state.projects = state.projects.filter((item) => item.id !== projectId);
@@ -806,8 +813,61 @@ export function createEditorProjects({
     });
   }
 
+  function clearDashboardPreviewResizeTracking() {
+    dashboardPreviewResizeObserver?.disconnect();
+    dashboardPreviewResizeObserver = null;
+    if (dashboardPreviewResizeHandler) window.removeEventListener("resize", dashboardPreviewResizeHandler);
+    dashboardPreviewResizeHandler = null;
+  }
+
   function bindDashboardEvents() {
     bindGlobalActions();
+    clearDashboardPreviewResizeTracking();
+
+    const previewStrips = [...app.querySelectorAll("[data-project-preview-strip]")];
+    const syncPreviewControls = (strip) => {
+      const shell = strip.closest(".project-card-shell");
+      if (!shell) return;
+      const maxScrollLeft = Math.max(0, strip.scrollWidth - strip.clientWidth);
+      const edgeTolerance = 2;
+      const previous = shell.querySelector('[data-project-preview-direction="previous"]');
+      const next = shell.querySelector('[data-project-preview-direction="next"]');
+      const focusedControl = document.activeElement === previous || document.activeElement === next
+        ? document.activeElement
+        : null;
+      if (previous) previous.hidden = maxScrollLeft <= edgeTolerance || strip.scrollLeft <= edgeTolerance;
+      if (next) next.hidden = maxScrollLeft <= edgeTolerance || strip.scrollLeft >= maxScrollLeft - edgeTolerance;
+      if (focusedControl?.hidden) {
+        const fallback = focusedControl === previous ? next : previous;
+        (fallback && !fallback.hidden ? fallback : shell.querySelector(".project-card"))?.focus({ preventScroll: true });
+      }
+    };
+    previewStrips.forEach((strip) => {
+      strip.scrollLeft = 0;
+      strip.addEventListener("scroll", () => syncPreviewControls(strip), { passive: true });
+      syncPreviewControls(strip);
+    });
+    app.querySelectorAll("[data-project-preview-direction]").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const strip = button.closest(".project-card-shell")?.querySelector("[data-project-preview-strip]");
+        if (!strip) return;
+        const direction = button.dataset.projectPreviewDirection === "previous" ? -1 : 1;
+        const behavior = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+        strip.scrollBy({ left: direction * Math.max(80, strip.clientWidth - 32), behavior });
+      });
+    });
+    if (typeof ResizeObserver === "function") {
+      dashboardPreviewResizeObserver = new ResizeObserver((entries) => {
+        entries.forEach((entry) => syncPreviewControls(entry.target));
+      });
+      previewStrips.forEach((strip) => dashboardPreviewResizeObserver.observe(strip));
+    } else {
+      dashboardPreviewResizeHandler = () => previewStrips.forEach(syncPreviewControls);
+      window.addEventListener("resize", dashboardPreviewResizeHandler, { passive: true });
+    }
+
     const migrationModal = app.querySelector("[data-migration-modal]");
     const dismissMigrationModal = () => {
       if (!migrationModal) return;
@@ -888,6 +948,7 @@ export function createEditorProjects({
   }
 
   function bindGlobalActions() {
+    if (!app.querySelector(".dashboard")) clearDashboardPreviewResizeTracking();
     const homeLink = app.querySelector('[data-action="home"]');
     homeLink?.addEventListener("click", (event) => {
       if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
@@ -909,7 +970,9 @@ export function createEditorProjects({
       .then(() => getAllProjects())
       .then((projects) => {
         if (state.activeProjectId) return;
-        state.projects = normalizeLoadedProjects(projects);
+        const refreshedProjects = normalizeLoadedProjects(projects);
+        pruneSlideThumbnails(refreshedProjects);
+        state.projects = refreshedProjects;
         leaveMissingActiveFolder();
         renderDashboard();
       })

--- a/src/editor-state.mjs
+++ b/src/editor-state.mjs
@@ -54,6 +54,10 @@ export const history = {
 
 export const app = document.querySelector("#app");
 
+export function slideThumbnailKey(projectId, slideId) {
+  return JSON.stringify([String(projectId || ""), String(slideId || "")]);
+}
+
 export function activeProject() {
   return state.projects.find((project) => project.id === state.activeProjectId) || null;
 }

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -26,6 +26,7 @@ import {
   app,
   activeProject,
   activeSlide,
+  slideThumbnailKey,
   selectedText,
   selectedOverlay,
   selectedLayerKeys,
@@ -42,6 +43,7 @@ import {
   renderHeader,
   renderLegacyMigrationNotice,
   renderSlideRail,
+  renderSlideThumbnail,
   renderAssetRail,
   renderEmptyStage,
   renderStage,
@@ -90,6 +92,8 @@ export function createEditorUI({ projects, actions, output }) {
   const {
     refreshAllProjectCovers,
     refreshAllSlideThumbnails,
+    refreshDashboardSlideThumbnails,
+    disconnectDashboardSlideThumbnails,
     exportActiveSlide,
     shareActiveSlide,
     shareAllSlides,
@@ -490,18 +494,30 @@ export function createEditorUI({ projects, actions, output }) {
       : sortedProjects.filter((project) => !project.folderPath);
 
     const renderProjectCard = (project) => {
-      const slide = project.slides[0];
-      const cover = slide ? state.projectCoverUrls.get(project.id) || slide.imageData : null;
+      const previewId = `project-preview-${project.id}`;
+      const slides = project.slides.map((slide) => `
+        <span class="project-preview-slide" data-project-preview-slide-id="${slide.id}" data-thumbnail-slide-id="${slide.id}" data-thumbnail-project-id="${project.id}">
+          ${state.thumbnailUrls.has(slideThumbnailKey(project.id, slide.id))
+            ? renderSlideThumbnail(slide, project)
+            : `<img class="project-preview-source" src="${slide.imageData}" alt="" draggable="false" loading="lazy" decoding="async" aria-hidden="true" />`}
+        </span>
+      `).join("");
       return `
-        <a class="project-card" href="${projectPath(project.id)}" data-project-id="${project.id}" aria-haspopup="menu" aria-label="Open ${escapeHtml(project.name)}. Right-click for actions." title="Right-click for actions">
-          <span class="project-preview" data-project-cover-id="${project.id}">
-            ${cover ? `<img src="${cover}" alt=""${state.projectCoverUrls.has(project.id) ? " data-composite-cover=\"true\"" : ""} />` : `<span class="project-preview-empty">No slides yet</span>`}
-          </span>
-          <span class="project-meta">
-            <strong>${escapeHtml(project.name)}</strong>
-            <span>${project.slides.length} ${project.slides.length === 1 ? "slide" : "slides"} · ${formatDate(project.updatedAt)}</span>
-          </span>
-        </a>
+        <div class="project-card-shell">
+          <a class="project-card" href="${projectPath(project.id)}" data-project-id="${project.id}" aria-haspopup="menu" aria-label="Open ${escapeHtml(project.name)}, ${project.slides.length} ${project.slides.length === 1 ? "slide" : "slides"}. Right-click for actions." title="Right-click for actions">
+            <span class="project-preview" id="${previewId}" data-project-preview-strip aria-hidden="true">
+              ${slides || `<span class="project-preview-empty">No slides yet</span>`}
+            </span>
+            <span class="project-meta">
+              <strong>${escapeHtml(project.name)}</strong>
+              <span>${project.slides.length} ${project.slides.length === 1 ? "slide" : "slides"} · ${formatDate(project.updatedAt)}</span>
+            </span>
+          </a>
+          ${project.slides.length > 1 ? `
+            <button class="project-preview-scroll-button project-preview-scroll-button--previous" type="button" data-project-preview-direction="previous" aria-controls="${previewId}" aria-label="Scroll ${escapeHtml(project.name)} slide previews left" hidden>${icon("back")}</button>
+            <button class="project-preview-scroll-button project-preview-scroll-button--next" type="button" data-project-preview-direction="next" aria-controls="${previewId}" aria-label="Scroll ${escapeHtml(project.name)} slide previews right" hidden>${icon("forward")}</button>
+          ` : ""}
+        </div>
       `;
     };
 
@@ -579,10 +595,12 @@ export function createEditorUI({ projects, actions, output }) {
     // background tabs are not left with raw solid-color slide backgrounds while
     // requestAnimationFrame is throttled or paused by the browser.
     refreshAllProjectCovers(sortedProjects);
+    refreshDashboardSlideThumbnails(visibleProjects);
   }
 
 
   function renderEditor() {
+    disconnectDashboardSlideThumbnails();
     const project = activeProject();
     if (!project) return renderDashboard();
     document.title = `${project.name} · CarouselBot`;

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -34,6 +34,7 @@ import {
   app,
   activeProject,
   activeSlide,
+  slideThumbnailKey,
   selectedText,
   selectedOverlay,
   isLayerSelected,
@@ -65,6 +66,7 @@ export function formatDate(timestamp) {
 export function icon(name) {
   const icons = {
     back: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
+    forward: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>',
     download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>',
     airdrop: '<img class="airdrop-icon" src="/assets/airdrop.svg" alt="" />',
     trash: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M9 7V4h6v3"/><path d="m7 7 1 14h8l1-14"/></svg>',
@@ -170,7 +172,7 @@ export function renderSlideRail(project) {
         ${project.slides.map((slide, index) => `
           <button class="slide-thumb ${slide.id === state.activeSlideId ? "is-active" : ""}" type="button" data-slide-id="${slide.id}" draggable="true" aria-haspopup="menu" aria-label="Open slide ${index + 1}. Drag to reorder. Right-click for actions." title="Drag to reorder · Right-click for actions">
             <span class="slide-number">${String(index + 1).padStart(2, "0")}</span>
-            <span class="thumb-image" data-thumbnail-slide-id="${slide.id}">${renderSlideThumbnail(slide)}</span>
+            <span class="thumb-image" data-thumbnail-slide-id="${slide.id}" data-thumbnail-project-id="${project.id}">${renderSlideThumbnail(slide, project)}</span>
           </button>
         `).join("")}
       </div>
@@ -179,10 +181,10 @@ export function renderSlideRail(project) {
   `;
 }
 
-export function renderSlideThumbnail(slide) {
-  const source = state.thumbnailUrls.get(slide.id);
+export function renderSlideThumbnail(slide, project = activeProject()) {
+  const source = state.thumbnailUrls.get(slideThumbnailKey(project?.id, slide.id));
   return source
-    ? `<img class="thumb-rendered" src="${source}" alt="" draggable="false" aria-hidden="true" />`
+    ? `<img class="thumb-rendered" src="${source}" alt="" draggable="false" decoding="async" aria-hidden="true" />`
     : `<span class="thumb-rendering-placeholder" aria-hidden="true"><span></span></span>`;
 }
 

--- a/src/editor.mjs
+++ b/src/editor.mjs
@@ -28,6 +28,7 @@ const editorProjects = createEditorProjects({
   scheduleThumbnailRefresh: editorOutput.scheduleThumbnailRefresh,
   clearProjectCover: editorOutput.clearProjectCover,
   clearSlideThumbnail: editorOutput.clearSlideThumbnail,
+  pruneSlideThumbnails: editorOutput.pruneSlideThumbnails,
 });
 
 editorActions = createEditorActions({
@@ -72,7 +73,9 @@ export async function init() {
     toast("Browser storage is unavailable. Projects won’t persist.");
   }
   window.addEventListener("carouselbot:migration-complete", async (event) => {
-    state.projects = normalizeLoadedProjects(await getAllProjects());
+    const migratedProjects = normalizeLoadedProjects(await getAllProjects());
+    editorOutput.pruneSlideThumbnails(migratedProjects);
+    state.projects = migratedProjects;
     renderDashboard();
     const { imported = 0, updated = 0, skipped = 0 } = event.detail || {};
     toast(`Projects ready: ${imported} copied, ${updated} updated${skipped ? `, ${skipped} already current` : ""}.`);

--- a/styles.css
+++ b/styles.css
@@ -1021,6 +1021,19 @@ button:disabled {
   gap: 18px;
 }
 
+.project-card-shell {
+  position: relative;
+  min-width: 0;
+  min-height: 250px;
+  transition: transform 200ms ease;
+}
+
+.project-card-shell > .project-card {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .project-card,
 .folder-card,
 .new-project-card {
@@ -1036,11 +1049,16 @@ button:disabled {
   transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
 }
 
-.project-card:hover,
+.project-card-shell:hover .project-card,
 .folder-card:hover,
 .new-project-card:hover {
   border-color: #aaa8a0;
   box-shadow: var(--shadow);
+}
+
+.project-card-shell:hover,
+.folder-card:hover,
+.new-project-card:hover {
   transform: translateY(-4px);
 }
 
@@ -1053,18 +1071,87 @@ button:disabled {
 .project-preview {
   position: absolute;
   inset: 0 0 74px;
-  overflow: hidden;
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  align-items: stretch;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-inline: contain;
   background: #dad8d1;
+  scroll-padding-inline: 10px;
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
 }
 
-.project-preview img {
+.project-preview::-webkit-scrollbar {
+  display: none;
+}
+
+.project-preview-slide {
+  position: relative;
+  display: block;
+  height: 100%;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid rgba(21, 21, 21, 0.14);
+  border-radius: 8px;
+  background: #e6e4dd;
+  aspect-ratio: 9 / 16;
+  scroll-snap-align: start;
+}
+
+.project-preview-slide img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.project-preview.is-rendering img:not([data-composite-cover="true"]) {
+.project-preview-slide.is-rendering .project-preview-source {
   opacity: 0.82;
+}
+
+.project-preview-scroll-button {
+  position: absolute;
+  z-index: 3;
+  top: calc((100% - 74px) / 2);
+  display: grid;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(21, 21, 21, 0.82);
+  box-shadow: 0 5px 16px rgba(21, 21, 21, 0.24);
+  cursor: pointer;
+  transform: translateY(-50%);
+  transition: background 150ms ease, box-shadow 150ms ease, scale 150ms ease;
+}
+
+.project-preview-scroll-button[hidden] {
+  display: none;
+}
+
+.project-preview-scroll-button:hover {
+  background: rgba(21, 21, 21, 0.96);
+  box-shadow: 0 7px 20px rgba(21, 21, 21, 0.32);
+  scale: 1.06;
+}
+
+.project-preview-scroll-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+.project-preview-scroll-button--previous {
+  left: 8px;
+}
+
+.project-preview-scroll-button--next {
+  right: 8px;
 }
 
 .folder-preview {
@@ -3410,6 +3497,7 @@ input[type="range"]::-webkit-slider-thumb {
     --shadow: 0 20px 58px rgba(0, 0, 0, 0.44);
   }
 
+  .project-card-shell:hover .project-card,
   .project-card:hover,
   .folder-card:hover,
   .new-project-card:hover,
@@ -3431,6 +3519,11 @@ input[type="range"]::-webkit-slider-thumb {
     background:
       linear-gradient(135deg, transparent 49%, rgba(255, 255, 255, 0.1) 49.5%, rgba(255, 255, 255, 0.1) 50.5%, transparent 51%),
       #30322d;
+  }
+
+  .project-preview-slide {
+    border-color: rgba(255, 255, 255, 0.16);
+    background: #30322d;
   }
 
   .project-preview-empty {

--- a/test/editor-state.test.mjs
+++ b/test/editor-state.test.mjs
@@ -16,6 +16,7 @@ const {
   selectedText,
   selectOnlyLayer,
   setLayerSelection,
+  slideThumbnailKey,
   state,
   toggleLayerSelection,
 } = await import("../src/editor-state.mjs");
@@ -54,6 +55,11 @@ function installProject() {
 }
 
 test.beforeEach(resetState);
+
+test("scopes rendered slide thumbnails to their owning project", () => {
+  assert.notEqual(slideThumbnailKey("project-1", "shared-slide"), slideThumbnailKey("project-2", "shared-slide"));
+  assert.equal(slideThumbnailKey("project-1", "shared-slide"), slideThumbnailKey("project-1", "shared-slide"));
+});
 
 test("resolves the active project, slide, asset, and selected layers", () => {
   installProject();


### PR DESCRIPTION
Project cards now show every slide in a horizontally scrollable 9:16 filmstrip with conditional previous/next controls. Folder mosaics remain unchanged. Includes lazy composite thumbnail rendering, cache lifecycle safeguards, responsive and accessible controls, and browser/MCP regression coverage.\n\nVerified with the complete Node, build, editor-browser, migration-browser, and local MCP-browser gates.