### PR TITLE
Tighten project card footers

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -936,7 +936,7 @@ try {
     "A missing deep route did not return to the dashboard with feedback.",
   );
 
-  const filmstripProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Filmstrip preview project' })`);
+  const filmstripProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Filmstrip preview project with an intentionally long title' })`);
   const filmstripSlideIds = await callPageFunction(cdp, `async function(projectId) {
     const colors = ['#FE2C55', '#25F4EE', '#25282E', '#F4C95D', '#8A5CF5', '#3DBE78', '#F28C45', '#496DDB'];
     const ids = [];
@@ -958,7 +958,13 @@ try {
     const slides = [...(strip?.querySelectorAll('[data-project-preview-slide-id]') || [])];
     const previous = shell?.querySelector('[data-project-preview-direction="previous"]');
     const next = shell?.querySelector('[data-project-preview-direction="next"]');
+    const meta = card?.querySelector('.project-meta');
+    const title = meta?.querySelector('strong');
+    const details = meta?.lastElementChild;
     if (!card || !shell || !strip || slides.length !== 8 || slides.some((slide) => !slide.querySelector('img'))) return false;
+    const stripRect = strip.getBoundingClientRect();
+    const titleRect = title?.getBoundingClientRect();
+    const detailsRect = details?.getBoundingClientRect();
     return {
       slideIds: slides.map((slide) => slide.dataset.projectPreviewSlideId),
       ratios: slides.map((slide) => {
@@ -976,6 +982,12 @@ try {
       buttonTypes: [previous?.type, next?.type],
       labels: [previous?.getAttribute('aria-label'), next?.getAttribute('aria-label')],
       touchTargets: [previous, next].map((button) => Number.parseFloat(getComputedStyle(button).width)),
+      footerGap: titleRect?.top - stripRect.bottom,
+      footerSameRow: Math.abs((titleRect?.bottom || 0) - (detailsRect?.bottom || 0)) < 2,
+      titleTruncated: title && title.scrollWidth > title.clientWidth,
+      detailsWhiteSpace: details && getComputedStyle(details).whiteSpace,
+      detailsWrapped: details && details.scrollHeight > details.clientHeight + 1,
+      metaOverflows: meta && meta.scrollWidth > meta.clientWidth + 1,
     };
   })()`), "The dashboard project filmstrip did not render all slide thumbnails.");
   if (
@@ -988,8 +1000,15 @@ try {
     || !filmstrip.controlsOutsideLink
     || !filmstrip.cardLabel?.includes("8 slides")
     || filmstrip.buttonTypes.some((type) => type !== "button")
-    || filmstrip.labels.some((label) => !label?.includes("Filmstrip preview project slide previews"))
+    || filmstrip.labels.some((label) => !label?.includes("Filmstrip preview project") || !label.includes("slide previews"))
     || filmstrip.touchTargets.some((size) => size < 44)
+    || filmstrip.footerGap < 8
+    || filmstrip.footerGap > 24
+    || !filmstrip.footerSameRow
+    || !filmstrip.titleTruncated
+    || filmstrip.detailsWhiteSpace !== "nowrap"
+    || filmstrip.detailsWrapped
+    || filmstrip.metaOverflows
   ) {
     throw new Error(`Dashboard project filmstrip markup was incorrect: ${JSON.stringify(filmstrip)}`);
   }
@@ -1055,14 +1074,29 @@ try {
     strip.scrollLeft = 0;
     strip.dispatchEvent(new Event('scroll'));
     const next = shell.querySelector('[data-project-preview-direction="next"]');
+    const meta = shell.querySelector('.project-meta');
+    const title = meta?.querySelector('strong');
+    const details = meta?.lastElementChild;
     return !next.hidden ? {
       viewportWidth: innerWidth,
       documentWidth: document.documentElement.scrollWidth,
       cardWidth: shell.getBoundingClientRect().width,
       overflow: strip.scrollWidth > strip.clientWidth + 2,
+      titleTruncated: title && title.scrollWidth > title.clientWidth,
+      detailsWhiteSpace: details && getComputedStyle(details).whiteSpace,
+      detailsWrapped: details && details.scrollHeight > details.clientHeight + 1,
+      metaOverflows: meta && meta.scrollWidth > meta.clientWidth + 1,
     } : false;
   })()`), "The project filmstrip controls did not adapt to the narrow dashboard layout.");
-  if (narrowFilmstrip.documentWidth > narrowFilmstrip.viewportWidth + 1 || !narrowFilmstrip.overflow || narrowFilmstrip.cardWidth > narrowFilmstrip.viewportWidth) {
+  if (
+    narrowFilmstrip.documentWidth > narrowFilmstrip.viewportWidth + 1
+    || !narrowFilmstrip.overflow
+    || narrowFilmstrip.cardWidth > narrowFilmstrip.viewportWidth
+    || !narrowFilmstrip.titleTruncated
+    || narrowFilmstrip.detailsWhiteSpace !== "nowrap"
+    || narrowFilmstrip.detailsWrapped
+    || narrowFilmstrip.metaOverflows
+  ) {
     throw new Error(`The narrow project filmstrip caused page-level overflow: ${JSON.stringify(narrowFilmstrip)}`);
   }
   await cdp.send("Emulation.clearDeviceMetricsOverride");

--- a/styles.css
+++ b/styles.css
@@ -1022,6 +1022,7 @@ button:disabled {
 }
 
 .project-card-shell {
+  --dashboard-card-meta-height: 52px;
   position: relative;
   min-width: 0;
   min-height: 250px;
@@ -1068,9 +1069,13 @@ button:disabled {
   text-decoration: none;
 }
 
+.folder-card {
+  --dashboard-card-meta-height: 52px;
+}
+
 .project-preview {
   position: absolute;
-  inset: 0 0 74px;
+  inset: 0 0 var(--dashboard-card-meta-height);
   display: flex;
   gap: 8px;
   padding: 10px;
@@ -1115,7 +1120,7 @@ button:disabled {
 .project-preview-scroll-button {
   position: absolute;
   z-index: 3;
-  top: calc((100% - 74px) / 2);
+  top: calc((100% - var(--dashboard-card-meta-height)) / 2);
   display: grid;
   width: 44px;
   height: 44px;
@@ -1156,7 +1161,7 @@ button:disabled {
 
 .folder-preview {
   position: absolute;
-  inset: 0 0 74px;
+  inset: 0 0 var(--dashboard-card-meta-height);
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: repeat(2, minmax(0, 1fr));
@@ -1220,18 +1225,22 @@ button:disabled {
 .project-meta {
   position: absolute;
   right: 18px;
-  bottom: 16px;
+  bottom: 13px;
   left: 18px;
   display: flex;
-  align-items: end;
+  gap: 12px;
+  align-items: baseline;
   justify-content: space-between;
 }
 
 .project-meta strong {
   display: block;
-  max-width: 70%;
+  min-width: 0;
+  max-width: none;
+  flex: 1 1 auto;
   overflow: hidden;
   font-size: 15px;
+  line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1239,6 +1248,12 @@ button:disabled {
 .project-meta span {
   color: var(--muted);
   font-size: 12px;
+}
+
+.project-meta > span {
+  flex: 0 0 auto;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .folder-meta-name {


### PR DESCRIPTION
Reduces excess spacing above project and folder titles, keeps slide/date metadata on one line, and makes long titles ellipsize before metadata wraps. Adds desktop and 375px real-browser regression coverage.\n\nVerified with the complete Node, build, editor-browser, migration-browser, and local MCP-browser gates.