### PR TITLE
Differentiate folder and project previews

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -965,6 +965,8 @@ try {
     const stripRect = strip.getBoundingClientRect();
     const titleRect = title?.getBoundingClientRect();
     const detailsRect = details?.getBoundingClientRect();
+    const stripStyle = getComputedStyle(strip);
+    const slideStyles = slides.map((slide) => getComputedStyle(slide));
     return {
       slideIds: slides.map((slide) => slide.dataset.projectPreviewSlideId),
       ratios: slides.map((slide) => {
@@ -988,6 +990,11 @@ try {
       detailsWhiteSpace: details && getComputedStyle(details).whiteSpace,
       detailsWrapped: details && details.scrollHeight > details.clientHeight + 1,
       metaOverflows: meta && meta.scrollWidth > meta.clientWidth + 1,
+      stripGap: Number.parseFloat(stripStyle.gap),
+      stripPadding: Number.parseFloat(stripStyle.paddingTop),
+      slideRadii: slideStyles.map((style) => Number.parseFloat(style.borderTopLeftRadius)),
+      dividerWidths: slideStyles.map((style) => Number.parseFloat(style.borderRightWidth)),
+      dividerColors: slideStyles.map((style) => style.borderRightColor),
     };
   })()`), "The dashboard project filmstrip did not render all slide thumbnails.");
   if (
@@ -1009,6 +1016,12 @@ try {
     || filmstrip.detailsWhiteSpace !== "nowrap"
     || filmstrip.detailsWrapped
     || filmstrip.metaOverflows
+    || filmstrip.stripGap !== 0
+    || filmstrip.stripPadding !== 0
+    || filmstrip.slideRadii.some((radius) => radius !== 0)
+    || filmstrip.dividerWidths.slice(0, -1).some((width) => width !== 1)
+    || filmstrip.dividerWidths.at(-1) !== 0
+    || filmstrip.dividerColors.slice(0, -1).some((color) => color !== "rgb(255, 255, 255)")
   ) {
     throw new Error(`Dashboard project filmstrip markup was incorrect: ${JSON.stringify(filmstrip)}`);
   }
@@ -1146,9 +1159,24 @@ try {
     const card = document.querySelector('.folder-card[data-folder-path="/native-folder"]');
     if (!card || card.querySelectorAll('.folder-preview-slot').length !== 8 || !card.querySelector('.folder-meta-name svg')) return false;
     if ([...document.querySelectorAll('.project-card .project-meta strong')].some((item) => item.textContent === 'Folder UI project')) return false;
-    return { href: card.getAttribute('href'), name: card.querySelector('.folder-meta-name')?.textContent.trim() };
+    const preview = card.querySelector('.folder-preview');
+    const slots = [...card.querySelectorAll('.folder-preview-slot')];
+    const previewStyle = getComputedStyle(preview);
+    return {
+      href: card.getAttribute('href'),
+      name: card.querySelector('.folder-meta-name')?.textContent.trim(),
+      gap: Number.parseFloat(previewStyle.gap),
+      padding: Number.parseFloat(previewStyle.paddingTop),
+      slotRadii: slots.map((slot) => Number.parseFloat(getComputedStyle(slot).borderTopLeftRadius)),
+    };
   })()`), "Moving a project into a new folder did not render its eight-slot folder card.");
-  if (nativeFolderCard.name !== "/native-folder" || nativeFolderCard.href !== "/folders/native-folder") throw new Error(`Folder card metadata was incorrect: ${JSON.stringify(nativeFolderCard)}`);
+  if (
+    nativeFolderCard.name !== "/native-folder"
+    || nativeFolderCard.href !== "/folders/native-folder"
+    || nativeFolderCard.gap !== 6
+    || nativeFolderCard.padding !== 8
+    || nativeFolderCard.slotRadii.some((radius) => radius !== 7)
+  ) throw new Error(`Folder card metadata or preview styling was incorrect: ${JSON.stringify(nativeFolderCard)}`);
   await waitFor(
     () => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/native-folder"] [data-project-cover-id="${folderUiProject.projectId}"] img[data-composite-cover="true"]'))`),
     "The folder card did not compose the first slide into its mosaic.",

--- a/styles.css
+++ b/styles.css
@@ -1077,14 +1077,14 @@ button:disabled {
   position: absolute;
   inset: 0 0 var(--dashboard-card-meta-height);
   display: flex;
-  gap: 8px;
-  padding: 10px;
+  gap: 0;
+  padding: 0;
   align-items: stretch;
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-inline: contain;
   background: #dad8d1;
-  scroll-padding-inline: 10px;
+  scroll-padding-inline: 0;
   scroll-snap-type: x proximity;
   scrollbar-width: none;
 }
@@ -1099,11 +1099,16 @@ button:disabled {
   height: 100%;
   flex: 0 0 auto;
   overflow: hidden;
-  border: 1px solid rgba(21, 21, 21, 0.14);
-  border-radius: 8px;
+  border: 0;
+  border-right: 1px solid #fff;
+  border-radius: 0;
   background: #e6e4dd;
   aspect-ratio: 9 / 16;
   scroll-snap-align: start;
+}
+
+.project-preview-slide:last-child {
+  border-right-width: 0;
 }
 
 .project-preview-slide img {
@@ -1165,8 +1170,8 @@ button:disabled {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: 2px;
-  padding: 2px;
+  gap: 6px;
+  padding: 8px;
   overflow: hidden;
   background: #dad8d1;
 }
@@ -1176,6 +1181,7 @@ button:disabled {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  border-radius: 7px;
   background:
     linear-gradient(135deg, transparent 49%, rgba(21, 21, 21, 0.075) 49.5%, rgba(21, 21, 21, 0.075) 50.5%, transparent 51%),
     #e6e4dd;
@@ -3537,7 +3543,7 @@ input[type="range"]::-webkit-slider-thumb {
   }
 
   .project-preview-slide {
-    border-color: rgba(255, 255, 255, 0.16);
+    border-right-color: #fff;
     background: #30322d;
   }
 


### PR DESCRIPTION
Folder cards retain the eight-slot first-slide mosaic with compact padding, small gaps, and rounded covers. Project cards now show square, edge-to-edge slide previews separated only by one-pixel white dividers. Adds real-browser assertions for both styles.\n\nVerified with the complete Node, build, editor-browser, migration-browser, and local MCP-browser gates.