### PR TITLE
Make Hermes setup profile-aware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1829,7 +1829,7 @@
     },
     "packages/mcp": {
       "name": "carouselbot",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0",
@@ -1844,10 +1844,10 @@
       }
     },
     "packages/slides-studio-mcp": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "carouselbot": "0.3.1"
+        "carouselbot": "0.3.2"
       },
       "bin": {
         "slides-studio-mcp": "bin/cli.mjs"

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,7 +8,9 @@ npx carouselbot@latest setup
 
 Setup pins that exact package version in the generated MCP configuration, refreshes
 the agent skill, and automatically upgrades an older shared daemon. Rerun the
-command when you intentionally want to update.
+command when you intentionally want to update. When setup runs inside a named
+Hermes profile, it also installs the skill into that profile's active
+HERMES_HOME and non-interactively enables the discovered CarouselBot tools.
 
 For non-interactive agent setup, select the current client explicitly:
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carouselbot",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first MCP companion for the hosted CarouselBot editor",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/src/setup.mjs
+++ b/packages/mcp/src/setup.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { cp, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { EDITOR_URL, PACKAGE_NAME, PACKAGE_ROOT, PACKAGE_VERSION } from "./config.mjs";
 import { companionUpgrade } from "./companion.mjs";
@@ -44,13 +44,35 @@ function openCodeSnippet(specifier, version = commandVersion("opencode")) {
     : { mcp: { [serverName]: { ...server, enabled: true } } }, null, 2);
 }
 
+export function setupSkillTargets(homeDirectory = homedir(), hermesHome = process.env.HERMES_HOME) {
+  const targets = [
+    join(homeDirectory, ".agents", "skills", "carouselbot"),
+    join(homeDirectory, ".claude", "skills", "carouselbot"),
+    join(homeDirectory, ".hermes", "skills", "carouselbot"),
+  ];
+  if (hermesHome?.trim()) targets.push(join(resolve(hermesHome.trim()), "skills", "carouselbot"));
+  return [...new Set(targets)];
+}
+
+export function clientSpawnOptions(client) {
+  if (client === "hermes") {
+    // Hermes tool discovery prompts even after the caller approved CarouselBot
+    // setup, and an existing entry adds an overwrite prompt first. Feed both
+    // approvals explicitly; EOF otherwise looks like a successful cancel.
+    return { input: "y\ny\n", stdio: ["pipe", "inherit", "inherit"] };
+  }
+  return { stdio: "inherit" };
+}
+
+function clientConfigurationPresent(client) {
+  if (client !== "hermes") return true;
+  const result = spawnSync("hermes", ["mcp", "list"], { encoding: "utf8" });
+  return result.status === 0 && /(?:^|\s)carouselbot(?:\s|$)/m.test(String(result.stdout || "") + String(result.stderr || ""));
+}
+
 async function installSkill() {
   const source = join(PACKAGE_ROOT, "skill", "carouselbot");
-  const targets = [
-    join(homedir(), ".agents", "skills", "carouselbot"),
-    join(homedir(), ".claude", "skills", "carouselbot"),
-    join(homedir(), ".hermes", "skills", "carouselbot"),
-  ];
+  const targets = setupSkillTargets();
   for (const target of targets) {
     await mkdir(target, { recursive: true });
     await cp(source, target, { recursive: true, force: true });
@@ -93,10 +115,17 @@ export async function runSetup(arguments_) {
   for (const client of clients) {
     const command = shellCommand(client, specifier);
     if (!command) continue;
-    for (const remove of removeCommands(client)) spawnSync(remove[0], remove.slice(1), { stdio: "ignore" });
-    const result = spawnSync(command[0], command.slice(1), { stdio: "inherit" });
-    if (result.status === 0) configured.push(client);
-    else process.stderr.write(`Could not configure ${client}; its command is printed above for manual setup.\n`);
+    if (client !== "hermes") {
+      for (const remove of removeCommands(client)) spawnSync(remove[0], remove.slice(1), { stdio: "ignore" });
+    }
+    const result = spawnSync(command[0], command.slice(1), clientSpawnOptions(client));
+    if (result.status === 0 && clientConfigurationPresent(client)) {
+      configured.push(client);
+      if (client === "hermes") {
+        const legacyRemove = removeCommands(client).find((remove) => remove.at(-1) === legacyServerName);
+        if (legacyRemove) spawnSync(legacyRemove[0], legacyRemove.slice(1), { input: "y\n", stdio: ["pipe", "ignore", "ignore"] });
+      }
+    } else process.stderr.write(`Could not verify ${client}'s CarouselBot config; the existing config was preserved and its command is printed above for manual setup.\n`);
   }
   const skillTargets = await installSkill();
   const companion = await companionUpgrade();

--- a/packages/mcp/test/setup.test.mjs
+++ b/packages/mcp/test/setup.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { clientSpawnOptions, setupSkillTargets } from "../src/setup.mjs";
+
+test("non-interactive Hermes setup approves its tool-discovery prompt", () => {
+  assert.deepEqual(clientSpawnOptions("hermes"), {
+    input: "y\ny\n",
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+  assert.deepEqual(clientSpawnOptions("codex"), { stdio: "inherit" });
+});
+
+test("setup installs the skill into the active Hermes profile as well as shared locations", () => {
+  assert.deepEqual(
+    setupSkillTargets("/Users/test", "/Users/test/.hermes/profiles/slideshow-bot"),
+    [
+      "/Users/test/.agents/skills/carouselbot",
+      "/Users/test/.claude/skills/carouselbot",
+      "/Users/test/.hermes/skills/carouselbot",
+      "/Users/test/.hermes/profiles/slideshow-bot/skills/carouselbot",
+    ],
+  );
+});

--- a/packages/slides-studio-mcp/package.json
+++ b/packages/slides-studio-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slides-studio-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Compatibility package for the renamed CarouselBot MCP",
   "type": "module",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "carouselbot": "0.3.1"
+    "carouselbot": "0.3.2"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- answer Hermes' discovery and overwrite prompts during approved non-interactive setup
- verify the canonical MCP entry exists before removing the legacy entry
- install the CarouselBot skill into the active Hermes profile's HERMES_HOME
- bump both npm package names to 0.3.2

## Verification
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local
- npm pack --workspace carouselbot --dry-run
- npm pack --workspace slides-studio-mcp --dry-run
- node scripts/verify-release.mjs v0.3.2 false