### PR TITLE
Preview slides inside a TikTok viewport

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -316,12 +316,19 @@ try {
   const formatUi = await waitFor(
     () => evaluate(cdp, `(() => {
       const stage = document.querySelector('.stage');
+      const screen = document.querySelector('.tiktok-screen-preview');
       const thumbnail = document.querySelector('.thumb-image');
       const stageRect = stage?.getBoundingClientRect();
+      const screenRect = screen?.getBoundingClientRect();
       const thumbnailRect = thumbnail?.getBoundingClientRect();
-      if (!stageRect?.width || !thumbnailRect?.width) return null;
+      if (!stageRect?.width || !screenRect?.width || !thumbnailRect?.width) return null;
       return {
         stageRatio: stageRect.width / stageRect.height,
+        screenRatio: screenRect.width / screenRect.height,
+        blackBarTop: stageRect.top - screenRect.top,
+        blackBarBottom: screenRect.bottom - stageRect.bottom,
+        screenBackground: getComputedStyle(screen).backgroundColor,
+        screenLabel: document.querySelector('.tiktok-screen-note')?.textContent?.trim(),
         thumbnailRatio: thumbnailRect.width / thumbnailRect.height,
         dimensions: document.querySelector('.stage-size-label')?.textContent?.trim(),
         overlayDisabled: document.querySelector('[data-action="toggle-tiktok-overlay"]')?.disabled,
@@ -332,6 +339,11 @@ try {
   );
   if (
     Math.abs(formatUi.stageRatio - (3 / 4)) > 0.01
+    || Math.abs(formatUi.screenRatio - (9 / 16)) > 0.01
+    || formatUi.blackBarTop < 8
+    || Math.abs(formatUi.blackBarTop - formatUi.blackBarBottom) > 1
+    || formatUi.screenBackground !== "rgb(5, 5, 5)"
+    || formatUi.screenLabel !== "9:16 preview · black not exported"
     || Math.abs(formatUi.thumbnailRatio - (3 / 4)) > 0.01
     || formatUi.dimensions !== "1080 × 1440 · 3:4"
     || !formatUi.overlayDisabled

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -1149,9 +1149,11 @@ export function createEditorUI({ projects, actions, output }) {
   function sizeStage() {
     const inner = app.querySelector(".workspace-inner");
     const workspace = app.querySelector(".workspace");
+    const screenPreview = app.querySelector(".tiktok-screen-preview");
+    const stageFrame = app.querySelector(".stage-frame");
     const stage = app.querySelector(".stage");
     const slide = activeSlide();
-    if (!inner || !workspace || !stage || !slide) return;
+    if (!inner || !workspace || !screenPreview || !stageFrame || !stage || !slide) return;
     const innerStyle = getComputedStyle(inner);
     const horizontalPadding = (parseFloat(innerStyle.paddingLeft) || 0) + (parseFloat(innerStyle.paddingRight) || 0);
     const verticalPadding = (parseFloat(innerStyle.paddingTop) || 0) + (parseFloat(innerStyle.paddingBottom) || 0);
@@ -1162,17 +1164,32 @@ export function createEditorUI({ projects, actions, output }) {
     const toolbarGap = composition ? parseFloat(getComputedStyle(composition).columnGap) || 0 : 0;
     const canvasWidth = Math.max(1, availableWidth - (actions?.offsetWidth || 0) - toolbarGap);
     const canvas = slideCanvasDimensions(activeProject(), slide);
-    const ratio = canvas.width / canvas.height;
-    let width = canvasWidth;
-    let height = width / ratio;
-    if (height > availableHeight) {
-      height = availableHeight;
-      width = height * ratio;
+    const screenRatio = 9 / 16;
+    let screenWidth = canvasWidth;
+    let screenHeight = screenWidth / screenRatio;
+    if (screenHeight > availableHeight) {
+      screenHeight = availableHeight;
+      screenWidth = screenHeight * screenRatio;
     }
-    width *= state.canvasZoom;
-    height *= state.canvasZoom;
+    screenWidth *= state.canvasZoom;
+    screenHeight *= state.canvasZoom;
+
+    const slideRatio = canvas.width / canvas.height;
+    let width;
+    let height;
+    if (slideRatio >= screenRatio) {
+      width = screenWidth;
+      height = width / slideRatio;
+    } else {
+      height = screenHeight;
+      width = height * slideRatio;
+    }
     state.stageWidth = width;
     state.stageHeight = height;
+    screenPreview.style.width = `${screenWidth}px`;
+    screenPreview.style.height = `${screenHeight}px`;
+    stageFrame.style.width = `${width}px`;
+    stageFrame.style.height = `${height}px`;
     stage.style.width = `${width}px`;
     stage.style.height = `${height}px`;
     stage.style.setProperty("--stage-scale", width / canvas.width);

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -250,16 +250,19 @@ export function renderStage(slide, project = activeProject()) {
   return `
     <div class="canvas-composition">
       <div class="stage-wrap">
-        <div class="stage-frame ${selectedLayers().length > 1 ? "has-multi-selection" : ""} ${state.photoAdjustMode ? "is-adjusting-photo" : ""}">
-          <img class="stage-image-ghost" src="${slide.imageData}" alt="" draggable="false" aria-hidden="true" />
-          <div class="stage ${state.photoAdjustMode ? "is-adjusting" : ""}" data-natural-width="${slide.width}" data-natural-height="${slide.height}">
-            <img class="stage-image" src="${slide.imageData}" alt="${escapeHtml(slide.name)}" draggable="false" />
-            ${supportsTikTokOverlay ? renderTikTokOverlay() : ""}
-          </div>
-          <div class="layer-stack">
-            ${slideItems(slide).map(({ kind, item }) => (kind === "overlay" ? renderOverlayBox(item) : renderTextBox(item))).join("")}
+        <div class="tiktok-screen-preview ${supportsTikTokOverlay ? "is-native-format" : "has-letterbox"}" aria-label="9:16 TikTok screen preview. Black area is outside the slide and is not exported.">
+          <div class="stage-frame ${selectedLayers().length > 1 ? "has-multi-selection" : ""} ${state.photoAdjustMode ? "is-adjusting-photo" : ""}">
+            <img class="stage-image-ghost" src="${slide.imageData}" alt="" draggable="false" aria-hidden="true" />
+            <div class="stage ${state.photoAdjustMode ? "is-adjusting" : ""}" data-natural-width="${slide.width}" data-natural-height="${slide.height}">
+              <img class="stage-image" src="${slide.imageData}" alt="${escapeHtml(slide.name)}" draggable="false" />
+              ${supportsTikTokOverlay ? renderTikTokOverlay() : ""}
+            </div>
+            <div class="layer-stack">
+              ${slideItems(slide).map(({ kind, item }) => (kind === "overlay" ? renderOverlayBox(item) : renderTextBox(item))).join("")}
+            </div>
           </div>
         </div>
+        ${supportsTikTokOverlay ? "" : `<span class="tiktok-screen-note">9:16 preview · black not exported</span>`}
         <span class="stage-dimensions">
           <span class="stage-size-label">${canvas.width} × ${canvas.height} · ${escapeHtml(canvas.aspectRatio)}</span>
           <label class="slide-format-control" for="slide-aspect-ratio">

--- a/styles.css
+++ b/styles.css
@@ -1778,8 +1778,20 @@ button:disabled {
   filter: drop-shadow(0 24px 30px rgba(26, 24, 20, 0.18));
 }
 
+.tiktok-screen-preview {
+  position: relative;
+  display: grid;
+  overflow: hidden;
+  place-items: center;
+  background: #050505;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2), inset 0 0 0 1px rgba(0, 0, 0, 0.92);
+  user-select: none;
+}
+
 .stage-frame {
   position: relative;
+  flex: none;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.34);
 }
 
 .stage-image-ghost {
@@ -1872,6 +1884,19 @@ button:disabled {
   font-weight: 650;
   letter-spacing: 0.08em;
   white-space: nowrap;
+}
+
+.tiktok-screen-note {
+  position: absolute;
+  top: -20px;
+  left: 0;
+  color: #555850;
+  font-size: 9px;
+  font-weight: 780;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  white-space: nowrap;
+  text-transform: uppercase;
 }
 
 .slide-format-control {


### PR DESCRIPTION
## Summary
- center every slide inside a fixed black 9:16 screen preview
- keep the actual slide as the only interactive canvas and preserve the existing format/zoom controls
- label non-9:16 framing as preview-only and not exported
- add real-browser coverage for screen ratio, centered bars, label, and unchanged slide/thumbnail formats

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local