### PR TITLE
Show sidebar slides in uniform 9:16 previews

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -321,7 +321,8 @@ try {
       const stageRect = stage?.getBoundingClientRect();
       const screenRect = screen?.getBoundingClientRect();
       const thumbnailRect = thumbnail?.getBoundingClientRect();
-      if (!stageRect?.width || !screenRect?.width || !thumbnailRect?.width) return null;
+      const thumbnailRendered = thumbnail?.querySelector('img');
+      if (!stageRect?.width || !screenRect?.width || !thumbnailRect?.width || !thumbnailRendered) return null;
       return {
         stageRatio: stageRect.width / stageRect.height,
         screenRatio: screenRect.width / screenRect.height,
@@ -330,6 +331,8 @@ try {
         screenBackground: getComputedStyle(screen).backgroundColor,
         screenLabel: document.querySelector('.tiktok-screen-note')?.textContent?.trim(),
         thumbnailRatio: thumbnailRect.width / thumbnailRect.height,
+        thumbnailBackground: getComputedStyle(thumbnail).backgroundColor,
+        thumbnailFit: getComputedStyle(thumbnailRendered).objectFit,
         dimensions: document.querySelector('.stage-size-label')?.textContent?.trim(),
         overlayDisabled: document.querySelector('[data-action="toggle-tiktok-overlay"]')?.disabled,
         overlayPresent: Boolean(document.querySelector('.tiktok-overlay')),
@@ -344,7 +347,9 @@ try {
     || Math.abs(formatUi.blackBarTop - formatUi.blackBarBottom) > 1
     || formatUi.screenBackground !== "rgb(5, 5, 5)"
     || formatUi.screenLabel !== "9:16 preview · black not exported"
-    || Math.abs(formatUi.thumbnailRatio - (3 / 4)) > 0.01
+    || Math.abs(formatUi.thumbnailRatio - (9 / 16)) > 0.01
+    || formatUi.thumbnailBackground !== "rgb(5, 5, 5)"
+    || formatUi.thumbnailFit !== "contain"
     || formatUi.dimensions !== "1080 × 1440 · 3:4"
     || !formatUi.overlayDisabled
     || formatUi.overlayPresent
@@ -931,11 +936,15 @@ try {
   const mixedSlideFormatUi = await waitFor(
     () => evaluate(cdp, `(() => {
       const stage = document.querySelector('.stage')?.getBoundingClientRect();
-      const thumbs = [...document.querySelectorAll('.thumb-image')].map((item) => item.getBoundingClientRect());
-      if (!stage?.width || thumbs.some((item) => !item.width)) return null;
+      const thumbnailElements = [...document.querySelectorAll('.thumb-image')];
+      const thumbs = thumbnailElements.map((item) => item.getBoundingClientRect());
+      const thumbnailRendered = thumbnailElements.map((item) => item.querySelector('.thumb-rendered'));
+      if (!stage?.width || thumbs.some((item) => !item.width) || thumbnailRendered.some((item) => !item)) return null;
       return {
         stageRatio: stage.width / stage.height,
         thumbnailRatios: thumbs.map((item) => item.width / item.height),
+        thumbnailFits: thumbnailRendered.map((item) => getComputedStyle(item).objectFit),
+        thumbnailBackgrounds: thumbnailElements.map((item) => getComputedStyle(item).backgroundColor),
         dimensions: document.querySelector('.stage-size-label')?.textContent?.trim(),
         overlayDisabled: document.querySelector('[data-action="toggle-tiktok-overlay"]')?.disabled,
         overlayPresent: Boolean(document.querySelector('.tiktok-overlay')),
@@ -945,8 +954,9 @@ try {
   );
   if (
     Math.abs(mixedSlideFormatUi.stageRatio - 1) > 0.01
-    || Math.abs(mixedSlideFormatUi.thumbnailRatios[0] - 1) > 0.01
-    || Math.abs(mixedSlideFormatUi.thumbnailRatios[1] - (2 / 3)) > 0.01
+    || mixedSlideFormatUi.thumbnailRatios.some((ratio) => Math.abs(ratio - (9 / 16)) > 0.01)
+    || mixedSlideFormatUi.thumbnailFits.some((fit) => fit !== "contain")
+    || mixedSlideFormatUi.thumbnailBackgrounds.some((background) => background !== "rgb(5, 5, 5)")
     || mixedSlideFormatUi.dimensions !== "1080 × 1080 · 1:1"
     || !mixedSlideFormatUi.overlayDisabled
     || mixedSlideFormatUi.overlayPresent

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -171,11 +171,10 @@ export function renderSlideRail(project) {
       <div class="rail-heading"><h2>Slides</h2><span>${project.slides.length}</span></div>
       <div class="slide-list">
         ${project.slides.map((slide, index) => {
-          const canvas = slideCanvasDimensions(project, slide);
           return `
             <button class="slide-thumb ${slide.id === state.activeSlideId ? "is-active" : ""}" type="button" data-slide-id="${slide.id}" draggable="true" aria-haspopup="menu" aria-label="Open slide ${index + 1}. Drag to reorder. Right-click for actions." title="Drag to reorder · Right-click for actions">
               <span class="slide-number">${String(index + 1).padStart(2, "0")}</span>
-              <span class="thumb-image" data-thumbnail-slide-id="${slide.id}" data-thumbnail-project-id="${project.id}" style="aspect-ratio:${canvas.width} / ${canvas.height}">${renderSlideThumbnail(slide, project)}</span>
+              <span class="thumb-image" data-thumbnail-slide-id="${slide.id}" data-thumbnail-project-id="${project.id}" aria-label="9:16 screen preview; black area is not exported">${renderSlideThumbnail(slide, project)}</span>
             </button>
           `;
         }).join("")}

--- a/styles.css
+++ b/styles.css
@@ -1459,7 +1459,7 @@ button:disabled {
   width: 100%;
   overflow: hidden;
   border-radius: 7px;
-  background: #dedcd5;
+  background: #050505;
   aspect-ratio: 9 / 16;
   pointer-events: none;
 }
@@ -1468,7 +1468,8 @@ button:disabled {
   display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
+  object-position: center;
   pointer-events: none;
   user-select: none;
 }


### PR DESCRIPTION
## Summary
- show every editor sidebar thumbnail inside the same black 9:16 screen frame
- center each slide at its native aspect ratio without cropping or stretching
- keep preview bars out of exported slide content
- cover uniform preview geometry and styling in the real-browser regression test

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local