### PR TITLE
Fix outline text scaling

### DIFF
--- a/packages/mcp/src/mcp-server.mjs
+++ b/packages/mcp/src/mcp-server.mjs
@@ -36,7 +36,9 @@ const textFields = {
   text: z.string().max(4000).optional(), x: unit.optional(), y: unit.optional(), width: positiveUnit.optional(), height: positiveUnit.optional(),
   role: z.enum(["title", "subtitle", "body", "caption"]).optional().describe("Semantic size role. Recommended ranges: title 92-124, subtitle 68-84, body 54-68, caption 44-52."),
   size: z.number().min(20).max(180).optional(), style: z.enum(["plain", "outline", "boxed"]).optional(),
-  outlineWidth: z.number().min(0).max(40).optional(), color: color.optional(), background: z.enum(["white", "black"]).optional(),
+  outlineWidth: z.number().min(0).max(40).optional()
+    .describe("Relative outline thickness. The default 12 renders at 17% of the font size; all values scale proportionally with the font."),
+  color: color.optional(), background: z.enum(["white", "black"]).optional(),
   backgroundShape: z.enum(["lines", "full"]).optional(), align: z.enum(["left", "center", "right"]).optional(),
   fontId,
   fontWeight: z.number().int().min(1).max(1000).optional(),

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
+import { DEFAULT_OUTLINE_WIDTH, OUTLINE_RATIO } from "../src/editor-model.mjs";
 
 const root = new URL("..", import.meta.url);
 const rootPath = decodeURIComponent(root.pathname);
@@ -568,13 +569,16 @@ try {
     const before = agent.inspect({ includeAllProjects: false });
     const text = before.slide?.texts?.[0];
     if (!text) throw new Error('The editable text layer was unavailable for the outline-width regression.');
-    const original = { style: text.style, outlineWidth: text.outlineWidth };
+    const original = { style: text.style, size: text.size, outlineWidth: text.outlineWidth };
     const readDomOutline = () => {
       const box = [...document.querySelectorAll('.text-box')].find((item) => item.dataset.textId === text.id);
       return {
         stageWidth: document.querySelector('.stage')?.getBoundingClientRect().width || 0,
-        strokeWidths: [...(box?.querySelectorAll('.outline-line text') || [])]
-          .map((node) => Number(node.getAttribute('stroke-width'))),
+        outlines: [...(box?.querySelectorAll('.outline-line text') || [])]
+          .map((node) => ({
+            strokeWidth: Number(node.getAttribute('stroke-width')),
+            fontSize: Number.parseFloat(node.getAttribute('font-size')),
+          })),
       };
     };
     let result;
@@ -611,27 +615,57 @@ try {
         type: 'text.update',
         projectId: before.project.id,
         slideId: before.slide.id,
-        updates: [{ id: text.id, style: 'outline', outlineWidth: 40 }],
+        updates: [{ id: text.id, style: 'outline', size: 40, outlineWidth: ${DEFAULT_OUTLINE_WIDTH} }],
       });
-      const thickText = agent.inspect({ includeAllProjects: false }).slide.texts.find((item) => item.id === text.id);
-      const thickDom = readDomOutline();
-      const thickRender = await agent.execute({
+      const smallText = agent.inspect({ includeAllProjects: false }).slide.texts.find((item) => item.id === text.id);
+      const smallDom = readDomOutline();
+      const smallRender = await agent.execute({
         type: 'slide.render',
         projectId: before.project.id,
         slideId: before.slide.id,
         width: 270,
       });
+
+      await agent.execute({
+        type: 'text.update',
+        projectId: before.project.id,
+        slideId: before.slide.id,
+        updates: [{ id: text.id, style: 'outline', size: 80, outlineWidth: ${DEFAULT_OUTLINE_WIDTH} }],
+      });
+      const largeText = agent.inspect({ includeAllProjects: false }).slide.texts.find((item) => item.id === text.id);
+      const largeDom = readDomOutline();
+      const largeRender = await agent.execute({
+        type: 'slide.render',
+        projectId: before.project.id,
+        slideId: before.slide.id,
+        width: 270,
+      });
+
+      await agent.execute({
+        type: 'text.update',
+        projectId: before.project.id,
+        slideId: before.slide.id,
+        updates: [{ id: text.id, outlineWidth: 24 }],
+      });
+      const customText = agent.inspect({ includeAllProjects: false }).slide.texts.find((item) => item.id === text.id);
+      const customDom = readDomOutline();
       result = {
         zeroModelWidth: zeroText?.outlineWidth,
-        thickModelWidth: thickText?.outlineWidth,
+        smallModel: { size: smallText?.size, outlineWidth: smallText?.outlineWidth },
+        largeModel: { size: largeText?.size, outlineWidth: largeText?.outlineWidth },
+        customModel: { size: customText?.size, outlineWidth: customText?.outlineWidth },
         zeroDom,
-        thickDom,
+        smallDom,
+        largeDom,
+        customDom,
         render: {
           plain: { mimeType: plainRender?.mimeType, width: plainRender?.width, height: plainRender?.height, dataLength: plainRender?.data?.length || 0 },
           zero: { mimeType: zeroRender?.mimeType, width: zeroRender?.width, height: zeroRender?.height, dataLength: zeroRender?.data?.length || 0 },
-          thick: { mimeType: thickRender?.mimeType, width: thickRender?.width, height: thickRender?.height, dataLength: thickRender?.data?.length || 0 },
+          small: { mimeType: smallRender?.mimeType, width: smallRender?.width, height: smallRender?.height, dataLength: smallRender?.data?.length || 0 },
+          large: { mimeType: largeRender?.mimeType, width: largeRender?.width, height: largeRender?.height, dataLength: largeRender?.data?.length || 0 },
           zeroMatchesPlain: zeroRender?.data === plainRender?.data,
-          changed: zeroRender?.data !== thickRender?.data,
+          smallChanged: zeroRender?.data !== smallRender?.data,
+          sizeChanged: smallRender?.data !== largeRender?.data,
         },
       };
     } finally {
@@ -644,30 +678,47 @@ try {
     }
     return result;
   })()`);
-  const expectedThickDomWidth = 40 * outlineWidthRegression.thickDom.stageWidth / 1080;
+  const hasExpectedOutlineRatio = (entry, size, outlineWidth = DEFAULT_OUTLINE_WIDTH) => (
+    entry.stageWidth > 0
+    && entry.outlines.length >= 1
+    && entry.outlines.every(({ strokeWidth, fontSize }) => (
+      Math.abs(fontSize - size * entry.stageWidth / 1080) <= 0.01
+      && Math.abs(strokeWidth / fontSize - OUTLINE_RATIO * outlineWidth / DEFAULT_OUTLINE_WIDTH) <= 0.0001
+    ))
+  );
   if (
     outlineWidthRegression.zeroModelWidth !== 0
-    || outlineWidthRegression.thickModelWidth !== 40
-    || outlineWidthRegression.thickDom.stageWidth <= 0
-    || outlineWidthRegression.zeroDom.strokeWidths.length < 1
-    || outlineWidthRegression.zeroDom.strokeWidths.some((width) => width !== 0)
-    || outlineWidthRegression.thickDom.strokeWidths.length !== outlineWidthRegression.zeroDom.strokeWidths.length
-    || outlineWidthRegression.thickDom.strokeWidths.some((width) => Math.abs(width - expectedThickDomWidth) > 0.01)
+    || outlineWidthRegression.smallModel.size !== 40
+    || outlineWidthRegression.smallModel.outlineWidth !== DEFAULT_OUTLINE_WIDTH
+    || outlineWidthRegression.largeModel.size !== 80
+    || outlineWidthRegression.largeModel.outlineWidth !== DEFAULT_OUTLINE_WIDTH
+    || outlineWidthRegression.customModel.size !== 80
+    || outlineWidthRegression.customModel.outlineWidth !== 24
+    || outlineWidthRegression.zeroDom.outlines.length < 1
+    || outlineWidthRegression.zeroDom.outlines.some(({ strokeWidth }) => strokeWidth !== 0)
+    || !hasExpectedOutlineRatio(outlineWidthRegression.smallDom, 40)
+    || !hasExpectedOutlineRatio(outlineWidthRegression.largeDom, 80)
+    || !hasExpectedOutlineRatio(outlineWidthRegression.customDom, 80, 24)
     || outlineWidthRegression.render.plain.mimeType !== "image/png"
     || outlineWidthRegression.render.zero.mimeType !== "image/png"
-    || outlineWidthRegression.render.thick.mimeType !== "image/png"
+    || outlineWidthRegression.render.small.mimeType !== "image/png"
+    || outlineWidthRegression.render.large.mimeType !== "image/png"
     || outlineWidthRegression.render.plain.width !== 270
     || outlineWidthRegression.render.zero.width !== 270
-    || outlineWidthRegression.render.thick.width !== 270
+    || outlineWidthRegression.render.small.width !== 270
+    || outlineWidthRegression.render.large.width !== 270
     || outlineWidthRegression.render.plain.height !== outlineWidthRegression.render.zero.height
-    || outlineWidthRegression.render.zero.height !== outlineWidthRegression.render.thick.height
+    || outlineWidthRegression.render.zero.height !== outlineWidthRegression.render.small.height
+    || outlineWidthRegression.render.small.height !== outlineWidthRegression.render.large.height
     || outlineWidthRegression.render.plain.dataLength < 100
     || outlineWidthRegression.render.zero.dataLength < 100
-    || outlineWidthRegression.render.thick.dataLength < 100
+    || outlineWidthRegression.render.small.dataLength < 100
+    || outlineWidthRegression.render.large.dataLength < 100
     || !outlineWidthRegression.render.zeroMatchesPlain
-    || !outlineWidthRegression.render.changed
+    || !outlineWidthRegression.render.smallChanged
+    || !outlineWidthRegression.render.sizeChanged
   ) {
-    throw new Error(`Outline width did not reach editable SVG text and canvas rendering: ${JSON.stringify(outlineWidthRegression)}`);
+    throw new Error(`Outline width did not stay proportional in editable SVG text and canvas rendering: ${JSON.stringify(outlineWidthRegression)}`);
   }
 
   const pointerInteraction = await evaluate(cdp, `(() => {

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -294,6 +294,16 @@ export function outlineColorFor(hex) {
   return luminance > 0.55 ? "#111111" : "#FFFFFF";
 }
 
+export function outlineWidthForFontSize(fontSize, outlineWidth = DEFAULT_OUTLINE_WIDTH) {
+  const size = Number(fontSize);
+  if (!Number.isFinite(size) || size <= 0) return 0;
+  const requestedWidth = Number(outlineWidth);
+  const relativeWidth = Number.isFinite(requestedWidth)
+    ? Math.max(0, requestedWidth) / DEFAULT_OUTLINE_WIDTH
+    : 1;
+  return size * OUTLINE_RATIO * relativeWidth;
+}
+
 export function ensureBoxedTextContrast(text) {
   if (text?.style !== "boxed") return;
   const backgroundColor = text.background === "black" ? "#111111" : "#FFFFFF";
@@ -654,7 +664,6 @@ export function remapLayerGeometryBetweenCanvases(item, sourceCanvas, targetCanv
     remapped.width = originalWidth * capScale;
     remapped.x = centerX - remapped.width / 2;
     if (Number.isFinite(originalFontSize) && originalFontSize > 0) remapped.size = originalFontSize * capScale;
-    if (Number.isFinite(Number(item?.outlineWidth))) remapped.outlineWidth = Number(item.outlineWidth) * capScale;
   }
   return remapped;
 }

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -1,6 +1,5 @@
 import {
   DESIGN_WIDTH,
-  DEFAULT_OUTLINE_WIDTH,
   SUPPORTED_ASPECT_RATIOS,
   TEXT_LINE_HEIGHT,
   BOX_TEXT_LINE_HEIGHT,
@@ -18,6 +17,7 @@ import {
   textColor,
   formatRgb,
   outlineColorFor,
+  outlineWidthForFontSize,
   overlayCrop,
   textAlignment,
   layerClipCss,
@@ -681,10 +681,7 @@ export function paintTextContent(text, content, box) {
       node.setAttribute("dominant-baseline", "middle");
       node.setAttribute("fill", textColor(text));
       node.setAttribute("stroke", outlineColorFor(textColor(text)));
-      const outlineWidth = Number.isFinite(Number(text.outlineWidth))
-        ? Math.max(0, Number(text.outlineWidth))
-        : DEFAULT_OUTLINE_WIDTH;
-      node.setAttribute("stroke-width", String(outlineWidth * ((state.stageWidth || DESIGN_WIDTH) / DESIGN_WIDTH)));
+      node.setAttribute("stroke-width", String(outlineWidthForFontSize(fontSize, text.outlineWidth)));
       node.setAttribute("stroke-linejoin", "round");
       node.setAttribute("stroke-linecap", "round");
       node.setAttribute("paint-order", "stroke fill");

--- a/src/slide-renderer.mjs
+++ b/src/slide-renderer.mjs
@@ -1,6 +1,5 @@
 import {
   DESIGN_WIDTH,
-  DEFAULT_OUTLINE_WIDTH,
   TEXT_LINE_HEIGHT,
   BOX_TEXT_LINE_HEIGHT,
   BOX_LINE_HEIGHT,
@@ -12,6 +11,7 @@ import {
   scaleCanvasDimensions,
   textColor,
   outlineColorFor,
+  outlineWidthForFontSize,
   overlayCrop,
   textAlignment,
   slideItems,
@@ -174,12 +174,9 @@ export function drawTextLayer(context, text, imageWidth, imageHeight, project = 
     const lineY = startY + index * lineHeight;
     if (text.style === "outline") {
       context.strokeStyle = outlineColorFor(color);
-      const outlineWidth = Number.isFinite(Number(text.outlineWidth))
-        ? Math.max(0, Number(text.outlineWidth))
-        : DEFAULT_OUTLINE_WIDTH;
-      const scaledOutlineWidth = outlineWidth * exportScale;
-      if (scaledOutlineWidth > 0) {
-        context.lineWidth = scaledOutlineWidth;
+      const outlineWidth = outlineWidthForFontSize(fontSize, text.outlineWidth);
+      if (outlineWidth > 0) {
+        context.lineWidth = outlineWidth;
         context.strokeText(line, textX, lineY);
       }
       context.fillStyle = color;

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -5,6 +5,8 @@ import {
   ASPECT_RATIO_PRESETS,
   ASPECT_RATIO_INPUT_MAX_LENGTH,
   DEFAULT_ASPECT_RATIO,
+  DEFAULT_OUTLINE_WIDTH,
+  OUTLINE_RATIO,
   SUPPORTED_ASPECT_RATIOS,
   aspectRatioFromDimensions,
   adjacentSlideId,
@@ -31,6 +33,7 @@ import {
   normalizeFolderPath,
   normalizeHexColor,
   outlineColorFor,
+  outlineWidthForFontSize,
   overlayCrop,
   parseCopiedLayer,
   parseLayerKey,
@@ -133,9 +136,22 @@ test("scales capped cross-format layers uniformly instead of distorting or clipp
   assert.ok(Math.abs(remapped.height - 2.4) < 1e-12);
   assert.ok(Math.abs(remapped.width - original.width * scale) < 1e-12);
   assert.ok(Math.abs(remapped.size - original.size * scale) < 1e-12);
-  assert.ok(Math.abs(remapped.outlineWidth - original.outlineWidth * scale) < 1e-12);
+  assert.equal(remapped.outlineWidth, original.outlineWidth);
   assert.ok(Math.abs((remapped.x + remapped.width / 2) - (original.x + original.width / 2)) < 1e-12);
   assert.ok(Math.abs((remapped.y + remapped.height / 2) - (original.y + original.height / 2)) < 1e-12);
+});
+
+test("keeps outline thickness proportional to font size", () => {
+  for (const size of [20, 64, 180]) {
+    const width = outlineWidthForFontSize(size);
+    assert.ok(Math.abs(width / size - OUTLINE_RATIO) < Number.EPSILON);
+  }
+  assert.equal(outlineWidthForFontSize(64, 0), 0);
+  assert.ok(Math.abs(
+    outlineWidthForFontSize(120, 40) / 120
+      - OUTLINE_RATIO * (40 / DEFAULT_OUTLINE_WIDTH),
+  ) < Number.EPSILON);
+  assert.equal(outlineWidthForFontSize("invalid"), 0);
 });
 
 test("keeps extreme custom-format remaps within the layer height limit", () => {

--- a/test/slide-renderer.test.mjs
+++ b/test/slide-renderer.test.mjs
@@ -20,8 +20,40 @@ globalThis.document = {
   },
 };
 
-const { renderSlideCanvas } = await import("../src/slide-renderer.mjs");
+const { drawTextLayer, renderSlideCanvas } = await import("../src/slide-renderer.mjs");
+const { OUTLINE_RATIO, outlineWidthForFontSize } = await import("../src/editor-model.mjs");
 const { canonicalSolidBackgroundColor, solidBackgroundDataUrl } = await import("../src/slide-background.mjs");
+
+function recordedOutlineWidths(size, outlineWidth = undefined, canvasWidth = 1080) {
+  const widths = [];
+  const context = {
+    save() {},
+    translate() {},
+    rotate() {},
+    restore() {},
+    measureText(value) {
+      return { width: String(value).length * 10 };
+    },
+    strokeText() {
+      widths.push(this.lineWidth);
+    },
+    fillText() {},
+  };
+  drawTextLayer(context, {
+    id: "outline",
+    text: "Outline",
+    x: 0.1,
+    y: 0.1,
+    width: 0.8,
+    height: 0.4,
+    size,
+    style: "outline",
+    outlineWidth,
+    color: "#FFFFFF",
+    align: "center",
+  }, canvasWidth, canvasWidth * 16 / 9, { fonts: [] });
+  return widths;
+}
 
 test("renders each slide at its own format and scales an omitted height from that format", async () => {
   const project = { id: "project", aspectRatio: "9:16", assets: [], fonts: [], slides: [] };
@@ -58,4 +90,19 @@ test("does not accept a project-sized solid payload for a differently sized slid
   };
 
   assert.equal(canonicalSolidBackgroundColor(slide, project), null);
+});
+
+test("renders canvas outlines as a stable percentage of the font size", () => {
+  const [small] = recordedOutlineWidths(40);
+  const [large] = recordedOutlineWidths(160);
+  const [scaledExport] = recordedOutlineWidths(160, undefined, 270);
+  const [custom] = recordedOutlineWidths(160, 24);
+
+  assert.equal(small, outlineWidthForFontSize(40));
+  assert.equal(large, outlineWidthForFontSize(160));
+  assert.ok(Math.abs(small / 40 - OUTLINE_RATIO) < Number.EPSILON);
+  assert.ok(Math.abs(large / 160 - OUTLINE_RATIO) < Number.EPSILON);
+  assert.ok(Math.abs(scaledExport - large / 4) < Number.EPSILON);
+  assert.ok(Math.abs(custom - large * 2) < Number.EPSILON);
+  assert.deepEqual(recordedOutlineWidths(160, 0), []);
 });


### PR DESCRIPTION
## Summary
- restore TikTok-style outlines as a font-relative 17% stroke
- keep custom outline thickness proportional and preserve it across slide-format remaps
- share the calculation between SVG preview and canvas export
- add model, renderer, and real-browser regression coverage

## Verification
- npm run test:editor
- npm test
- npm run build
- npm run test:editor:browser
- npm run test:migration:browser
- npm run test:mcp:browser:local