### PR TITLE
Calibrate outline text to TikTok

### DIFF
--- a/packages/mcp/src/mcp-server.mjs
+++ b/packages/mcp/src/mcp-server.mjs
@@ -37,7 +37,7 @@ const textFields = {
   role: z.enum(["title", "subtitle", "body", "caption"]).optional().describe("Semantic size role. Recommended ranges: title 92-124, subtitle 68-84, body 54-68, caption 44-52."),
   size: z.number().min(20).max(180).optional(), style: z.enum(["plain", "outline", "boxed"]).optional(),
   outlineWidth: z.number().min(0).max(40).optional()
-    .describe("Relative outline thickness. The default 12 renders at 17% of the font size; all values scale proportionally with the font."),
+    .describe("Relative outline thickness. The default 12 renders at 14.4% of the font size; all values scale proportionally with the font."),
   color: color.optional(), background: z.enum(["white", "black"]).optional(),
   backgroundShape: z.enum(["lines", "full"]).optional(), align: z.enum(["left", "center", "right"]).optional(),
   fontId,

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -576,6 +576,7 @@ try {
         stageWidth: document.querySelector('.stage')?.getBoundingClientRect().width || 0,
         outlines: [...(box?.querySelectorAll('.outline-line text') || [])]
           .map((node) => ({
+            stroke: node.getAttribute('stroke'),
             strokeWidth: Number(node.getAttribute('stroke-width')),
             fontSize: Number.parseFloat(node.getAttribute('font-size')),
           })),
@@ -681,8 +682,9 @@ try {
   const hasExpectedOutlineRatio = (entry, size, outlineWidth = DEFAULT_OUTLINE_WIDTH) => (
     entry.stageWidth > 0
     && entry.outlines.length >= 1
-    && entry.outlines.every(({ strokeWidth, fontSize }) => (
-      Math.abs(fontSize - size * entry.stageWidth / 1080) <= 0.01
+    && entry.outlines.every(({ stroke, strokeWidth, fontSize }) => (
+      stroke === '#000000'
+      && Math.abs(fontSize - size * entry.stageWidth / 1080) <= 0.01
       && Math.abs(strokeWidth / fontSize - OUTLINE_RATIO * outlineWidth / DEFAULT_OUTLINE_WIDTH) <= 0.0001
     ))
   );

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -28,9 +28,13 @@ export const INITIAL_OVERLAY_MAX_SIZE = 0.82;
 
 export const DEFAULT_OUTLINE_WIDTH = 12;
 
-export const OUTLINE_RATIO = 0.17;
+// SVG and canvas strokes straddle the glyph edge. Painting the fill last hides
+// the inner half, leaving a native TikTok-sized visible border of about 7.2%.
+export const OUTLINE_RATIO = 0.144;
 
-export const TEXT_WEIGHT = 500;
+// The native TikTok Sans outline silhouette resolves closest to this point on
+// the bundled font's variable weight axis.
+export const TEXT_WEIGHT = 535;
 
 export const TEXT_LINE_HEIGHT = 1.12;
 
@@ -291,7 +295,7 @@ export function formatRgb(hex) {
 export function outlineColorFor(hex) {
   const { r, g, b } = hexToRgb(hex);
   const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return luminance > 0.55 ? "#111111" : "#FFFFFF";
+  return luminance > 0.55 ? "#000000" : "#FFFFFF";
 }
 
 export function outlineWidthForFontSize(fontSize, outlineWidth = DEFAULT_OUTLINE_WIDTH) {
@@ -307,7 +311,7 @@ export function outlineWidthForFontSize(fontSize, outlineWidth = DEFAULT_OUTLINE
 export function ensureBoxedTextContrast(text) {
   if (text?.style !== "boxed") return;
   const backgroundColor = text.background === "black" ? "#111111" : "#FFFFFF";
-  if (textColor(text) === backgroundColor) text.color = outlineColorFor(backgroundColor);
+  if (textColor(text) === backgroundColor) text.color = text.background === "black" ? "#FFFFFF" : "#111111";
 }
 
 export function layerKey(kind, id) {

--- a/styles.css
+++ b/styles.css
@@ -2386,7 +2386,7 @@ button:disabled {
   color: var(--text-color, #fff);
   font-family: var(--text-font-family, "TikTok Sans", sans-serif);
   font-style: var(--text-font-style, normal);
-  font-weight: var(--text-font-weight, 500);
+  font-weight: var(--text-font-weight, 535);
   font-variation-settings: var(--text-font-variations, normal);
   line-height: 1.12;
   text-align: center;

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -142,6 +142,7 @@ test("scales capped cross-format layers uniformly instead of distorting or clipp
 });
 
 test("keeps outline thickness proportional to font size", () => {
+  assert.equal(OUTLINE_RATIO, 0.144);
   for (const size of [20, 64, 180]) {
     const width = outlineWidthForFontSize(size);
     assert.ok(Math.abs(width / size - OUTLINE_RATIO) < Number.EPSILON);
@@ -246,7 +247,7 @@ test("preserves legacy text defaults and boxed contrast", () => {
   assert.equal(textColor({ style: "boxed", background: "white" }), "#111111");
   assert.equal(textColor({ style: "plain" }), "#FFFFFF");
   assert.equal(outlineColorFor("#111111"), "#FFFFFF");
-  assert.equal(outlineColorFor("#FFFFFF"), "#111111");
+  assert.equal(outlineColorFor("#FFFFFF"), "#000000");
   const lightBox = { style: "boxed", background: "white", color: "#FFFFFF" };
   const darkBox = { style: "boxed", background: "black", color: "#111111" };
   ensureBoxedTextContrast(lightBox);

--- a/test/editor-projects.test.mjs
+++ b/test/editor-projects.test.mjs
@@ -232,7 +232,7 @@ test("restores every legacy text default while preserving valid values", () => {
     rotation: 0,
     z: 2,
     fontFamily: "TikTok Sans",
-    fontWeight: 500,
+    fontWeight: 535,
     fontStyle: "normal",
   });
   assert.equal(legacyBoxed.color, "#FFFFFF");
@@ -254,7 +254,7 @@ test("restores every legacy text default while preserving valid values", () => {
     rotation: 25,
     z: 40,
     fontFamily: "TikTok Sans",
-    fontWeight: 500,
+    fontWeight: 535,
     fontStyle: "normal",
   });
   assert.equal(projects[0].slides[0].imageScale, 0);

--- a/test/project-fonts.test.mjs
+++ b/test/project-fonts.test.mjs
@@ -120,7 +120,7 @@ test("normalizes legacy text to CarouselBot's actual bundled default", () => {
     fontStyle: DEFAULT_FONT_STYLE,
   });
   assert.equal(DEFAULT_FONT_FAMILY, "TikTok Sans");
-  assert.equal(DEFAULT_FONT_WEIGHT, 500);
+  assert.equal(DEFAULT_FONT_WEIGHT, 535);
   assert.equal(project.slides[0].texts[1].fontFamily, DEFAULT_FONT_FAMILY);
   assert.equal(project.slides[0].texts[1].fontWeight, 725);
   assert.equal(project.slides[0].texts[1].fontStyle, "italic");
@@ -270,7 +270,7 @@ test("registers exact stored bytes once and waits for the bundled default font",
     assert.equal(environment.constructed[0].family, font.cssFamily);
     assert.deepEqual(environment.constructed[0].descriptors, { weight: "400", style: "normal" });
     assert.deepEqual([...new Uint8Array(environment.constructed[0].source)], [0, 1, 2, 3, 255]);
-    assert.ok(environment.defaultLoads.every((value) => value === '500 64px "TikTok Sans"'));
+    assert.ok(environment.defaultLoads.every((value) => value === '535 64px "TikTok Sans"'));
     assert.equal(isTextFontAvailable(project, customText), true);
     assert.equal(isTextFontLoaded(project, customText), true);
   } finally {

--- a/test/slide-renderer.test.mjs
+++ b/test/slide-renderer.test.mjs
@@ -24,8 +24,8 @@ const { drawTextLayer, renderSlideCanvas } = await import("../src/slide-renderer
 const { OUTLINE_RATIO, outlineWidthForFontSize } = await import("../src/editor-model.mjs");
 const { canonicalSolidBackgroundColor, solidBackgroundDataUrl } = await import("../src/slide-background.mjs");
 
-function recordedOutlineWidths(size, outlineWidth = undefined, canvasWidth = 1080) {
-  const widths = [];
+function recordedOutlines(size, outlineWidth = undefined, canvasWidth = 1080) {
+  const outlines = [];
   const context = {
     save() {},
     translate() {},
@@ -35,7 +35,7 @@ function recordedOutlineWidths(size, outlineWidth = undefined, canvasWidth = 108
       return { width: String(value).length * 10 };
     },
     strokeText() {
-      widths.push(this.lineWidth);
+      outlines.push({ color: this.strokeStyle, width: this.lineWidth });
     },
     fillText() {},
   };
@@ -52,7 +52,7 @@ function recordedOutlineWidths(size, outlineWidth = undefined, canvasWidth = 108
     color: "#FFFFFF",
     align: "center",
   }, canvasWidth, canvasWidth * 16 / 9, { fonts: [] });
-  return widths;
+  return outlines;
 }
 
 test("renders each slide at its own format and scales an omitted height from that format", async () => {
@@ -93,16 +93,16 @@ test("does not accept a project-sized solid payload for a differently sized slid
 });
 
 test("renders canvas outlines as a stable percentage of the font size", () => {
-  const [small] = recordedOutlineWidths(40);
-  const [large] = recordedOutlineWidths(160);
-  const [scaledExport] = recordedOutlineWidths(160, undefined, 270);
-  const [custom] = recordedOutlineWidths(160, 24);
+  const [small] = recordedOutlines(40);
+  const [large] = recordedOutlines(160);
+  const [scaledExport] = recordedOutlines(160, undefined, 270);
+  const [custom] = recordedOutlines(160, 24);
 
-  assert.equal(small, outlineWidthForFontSize(40));
-  assert.equal(large, outlineWidthForFontSize(160));
-  assert.ok(Math.abs(small / 40 - OUTLINE_RATIO) < Number.EPSILON);
-  assert.ok(Math.abs(large / 160 - OUTLINE_RATIO) < Number.EPSILON);
-  assert.ok(Math.abs(scaledExport - large / 4) < Number.EPSILON);
-  assert.ok(Math.abs(custom - large * 2) < Number.EPSILON);
-  assert.deepEqual(recordedOutlineWidths(160, 0), []);
+  assert.deepEqual(small, { color: "#000000", width: outlineWidthForFontSize(40) });
+  assert.deepEqual(large, { color: "#000000", width: outlineWidthForFontSize(160) });
+  assert.ok(Math.abs(small.width / 40 - OUTLINE_RATIO) < Number.EPSILON);
+  assert.ok(Math.abs(large.width / 160 - OUTLINE_RATIO) < Number.EPSILON);
+  assert.ok(Math.abs(scaledExport.width - large.width / 4) < Number.EPSILON);
+  assert.ok(Math.abs(custom.width - large.width * 2) < Number.EPSILON);
+  assert.deepEqual(recordedOutlines(160, 0), []);
 });


### PR DESCRIPTION
Calibrates Outline Text against a native TikTok app screenshot. Changes the centered outline ratio from 17% to the measured 14.4%, uses true black, and sets the new/default TikTok Sans weight to the measured 535 while preserving explicitly stored weights. Adds model, canvas, and real-browser regression coverage.\n\nVerified with npm run test:editor, npm test, npm run build, npm run test:editor:browser, npm run test:migration:browser, and npm run test:mcp:browser:local.