### PR TITLE
Add shared formatting and resizing for selected layers

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -779,6 +779,76 @@ try {
     "Pointer interaction changes were not persisted.",
   );
 
+  await evaluate(cdp, `(async () => {
+    const agent = window.carouselBotAgent;
+    const original = agent.inspect({ includeAllProjects: false });
+    const scope = { projectId: original.project.id, slideId: original.slide.id };
+    const run = (operation) => agent.execute({ ...scope, ...operation });
+    const assert = (condition, message) => { if (!condition) throw new Error(message); };
+    const a = (await run({ type: 'text.add', text: 'First', size: 50, width: 0.3, height: 0.15 })).createdTextId;
+    const b = (await run({ type: 'text.add', text: 'Second', size: 60, color: '#000000', width: 0.5, height: 0.2 })).createdTextId;
+    const box = (id) => document.querySelector('[data-text-id="' + id + '"]');
+    const selectBoth = () => {
+      if (box(a).classList.contains("is-selected") && box(b).classList.contains("is-selected")) return;
+      box(a).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 301 }));
+      window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 301 }));
+      box(b).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 302, ctrlKey: true }));
+    };
+    const selected = () => agent.inspect({ includeAllProjects: false }).slide.texts.filter((text) => [a, b].includes(text.id));
+    const input = (selector, value) => {
+      const element = document.querySelector(selector);
+      element.focus(); element.value = value;
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+      element.blur();
+    };
+    try {
+      selectBoth();
+      assert(document.querySelector('#font-size-number').value === '', 'Mixed font sizes must be blank');
+      assert(document.querySelector('#font-size').dataset.mixed === 'true', 'Mixed size slider must have no representative thumb');
+      assert(!document.querySelector('[data-text-color].is-active'), 'Mixed colors must not activate a preset');
+      assert(!document.querySelector('#text-value'), 'Bulk formatting must preserve individual words');
+      input('#font-size-number', '56');
+      assert(selected().every((text) => text.size === 56), 'Number input must set both text sizes');
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      assert(selected().map((text) => text.size).join(',') === '50,60', 'Bulk size must undo in one step');
+      selectBoth();
+      input('#font-size-number', '56');
+      selectBoth();
+      assert(document.querySelector('#font-size-number').value === '56', 'Equal sizes must show the shared number');
+      input('#font-size', '50');
+      assert(selected()[0].size === selected()[1].size, 'Slider must apply to all texts');
+      document.querySelector('[data-text-color="#FFFFFF"]').click();
+      assert(selected().every((text) => text.color === '#FFFFFF'), 'Preset color must apply to all texts');
+      document.querySelector('[data-text-align="left"]').click();
+      assert(selected().every((text) => text.align === 'left'), 'Alignment must apply to all texts');
+      document.querySelector('[data-text-style="boxed"]').click();
+      document.querySelector('[data-background-shape="full"]').click();
+      document.querySelector('[data-background-tone="white"]').click();
+      assert(selected().every((text) => text.style === 'boxed' && text.backgroundShape === 'full' && text.background === 'white'), 'Box formatting must apply to all texts');
+      const font = document.querySelector('#text-font');
+      font.value = ''; font.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert(selected().every((text) => !text.fontId), 'Shared default font must apply to all texts');
+      const before = selected();
+      for (const id of [a, b]) assert(getComputedStyle(box(id).querySelector('[data-corner="se"]')).display !== 'none', 'Each selected layer needs resize handles');
+      box(a).querySelector('[data-corner="se"]').dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 303, clientX: 100, clientY: 100 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 303, clientX: 130, clientY: 120 }));
+      window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 303, clientX: 130, clientY: 120 }));
+      const after = selected();
+      assert(after.every((text, i) => text.width > before[i].width && text.height > before[i].height), 'Resizing one selected text must resize both');
+      assert(Math.abs(after[0].width / before[0].width - after[1].width / before[1].width) < 0.00001, 'Selection must share proportional resizing');
+      input('#shared-rotation', '25');
+      assert(selected().every((text) => text.rotation === 25), 'Shared rotation must apply to all texts');
+      const untouched = agent.inspect({ includeAllProjects: false }).slide.texts.find((text) => text.id === original.slide.texts[0].id);
+      assert(JSON.stringify(untouched) === JSON.stringify(original.slide.texts[0]), 'Unselected text must stay unchanged');
+    } finally {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      await run({ type: 'layer.delete', layerIds: [a, b] });
+    }
+  })()`);
+
   const imagePasteBefore = await evaluate(cdp, `(() => {
     const inspected = window.carouselBotAgent.inspect({ includeAllProjects: false });
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="160" height="100"><rect width="160" height="100" fill="#FE2C55"/></svg>';
@@ -829,6 +899,54 @@ try {
   if (Object.values(assetPreview).some(value => !value)) {
     throw new Error(`Asset preview regression: ${JSON.stringify(assetPreview)}`);
   }
+
+  await evaluate(cdp, `(async () => {
+    const agent = window.carouselBotAgent;
+    const original = agent.inspect({ includeAllProjects: false });
+    const scope = { projectId: original.project.id, slideId: original.slide.id };
+    const run = (operation) => agent.execute({ ...scope, ...operation });
+    const assert = (condition, message) => { if (!condition) throw new Error(message); };
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const textId = (await run({ type: 'text.add', text: 'Mixed resize', width: 0.4, height: 0.2, rotation: 15 })).createdTextId;
+    const imageId = (await run({ type: 'image.add', assetId: ${JSON.stringify(imagePaste.asset.id)}, width: 0.3, height: 0.15, rotation: 30 })).createdImageId;
+    const secondId = (await run({ type: 'image.add', assetId: ${JSON.stringify(imagePaste.asset.id)}, width: 0.6, height: 0.3, rotation: 30 })).createdImageId;
+    const box = (id) => document.querySelector('[data-text-id="' + id + '"], [data-overlay-id="' + id + '"]');
+    const click = (id, ctrlKey = false) => {
+      box(id).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 310, ctrlKey }));
+      window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 310 }));
+    };
+    const inspect = (ids) => { const slide = agent.inspect({ includeAllProjects: false }).slide; return [...slide.texts, ...slide.images].filter((item) => ids.includes(item.id)); };
+    const resize = (id, handle) => {
+      box(id).querySelector(handle).dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 311, clientX: 100, clientY: 100 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 311, clientX: 135, clientY: 135 }));
+      window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 311, clientX: 135, clientY: 135 }));
+    };
+    try {
+      click(imageId, true);
+      assert(!document.querySelector('#text-font') && !document.querySelector('#text-value'), 'Image selection must show only shared image controls');
+      assert(document.querySelector('#shared-rotation').value === '30', 'Equal image rotations must show their value');
+      const beforeImages = inspect([imageId, secondId]);
+      resize(secondId, '[data-corner="se"]');
+      const afterImages = inspect([imageId, secondId]);
+      assert(afterImages.every((item, i) => item.width > beforeImages[i].width && Math.abs(item.width / item.height - beforeImages[i].width / beforeImages[i].height) < 0.00001), 'Bulk image corner resize must preserve each aspect ratio');
+      click(textId);
+      click(imageId, true);
+      assert(!document.querySelector('#text-font') && !document.querySelector('[data-text-color]'), 'Mixed text and image selection must hide text-only controls');
+      assert(document.querySelector('#shared-rotation').value === '', 'Mixed rotations must be blank');
+      const beforeMixed = inspect([textId, imageId]);
+      resize(textId, '[data-edge="e"]');
+      const afterMixed = inspect([textId, imageId]);
+      assert(afterMixed.every((item, i) => item.width > beforeMixed[i].width && Math.abs(item.height - beforeMixed[i].height) < 0.00001), 'Mixed edge resize must change widths only');
+      assert(Math.abs(afterMixed[0].width / beforeMixed[0].width - afterMixed[1].width / beforeMixed[1].width) < 0.00001, 'Mixed resize must share the same scale');
+      const width = document.querySelector('#shared-width');
+      width.focus(); width.value = '45'; width.dispatchEvent(new Event('input', { bubbles: true })); width.blur();
+      assert(inspect([textId, imageId]).every((item) => item.width === 0.45), 'Shared width must set both text and image dimensions');
+    } finally {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      await run({ type: 'layer.delete', layerIds: [textId, imageId, secondId] });
+      click(original.slide.images[0].id);
+    }
+  })()`);
 
   const layerCopy = await evaluate(cdp, `(() => {
     const before = structuredClone(window.carouselBotAgent.inspect({ includeAllProjects: false }));
@@ -1715,6 +1833,8 @@ try {
     directUiTextEditing: true,
     outlineWidthRendering: true,
     pointerDragResize: true,
+    sharedSelectionFormatting: true,
+    sharedSelectionResizing: true,
     undoRedo: true,
     nativeClipboard: true,
     imageUpload: true,

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -35,6 +35,7 @@ import {
   setLayerSelection,
   selectOnlyLayer,
   projectAsset,
+  getOverlayMetrics,
   constrainImagePosition,
 } from "./editor-state.mjs";
 import {
@@ -288,16 +289,20 @@ export function createEditorUI({ projects, actions, output }) {
   async function applyFontToSelectedText(fontId) {
     const project = activeProject();
     const text = selectedText();
+    const targets = selectedLayers().filter(({ kind }) => kind === "text").map(({ item }) => item);
+    const selection = selectedLayerKeys().join("|");
     if (!project || !text) return;
     const next = { ...text };
     applyProjectFontToText(project, next, fontId);
     await ensureProjectFontsLoaded(project, [next]);
-    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id) return;
+    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id || selectedLayerKeys().join("|") !== selection) return;
     recordHistory(project);
-    Object.assign(text, next);
+    targets.forEach((item) => {
+      applyProjectFontToText(project, item, fontId);
+      updateTextBox(item);
+      ensureTextFits(item, { force: true });
+    });
     refreshSelection();
-    updateTextBox(text);
-    ensureTextFits(text, { force: true });
     scheduleSave();
     const font = fontId ? project.fonts.find((item) => item.id === fontId) : null;
     if (font?.localFontId) {
@@ -310,6 +315,8 @@ export function createEditorUI({ projects, actions, output }) {
   async function addLocalFontToSelectedText(face) {
     const project = activeProject();
     const text = selectedText();
+    const targets = selectedLayers().filter(({ kind }) => kind === "text").map(({ item }) => item);
+    const selection = selectedLayerKeys().join("|");
     const bridge = window.carouselBotLocalMcpBridge;
     if (!project || !text || !bridge) return;
     const existing = (project.fonts || []).find((item) => item.localFontId === face.localFontId) || null;
@@ -343,15 +350,17 @@ export function createEditorUI({ projects, actions, output }) {
     const next = { ...text };
     applyProjectFontToText(candidateProject, next, font.id);
     await ensureProjectFontsLoaded(candidateProject, [next]);
-    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id) return;
+    if (activeProject()?.id !== project.id || selectedText()?.id !== text.id || selectedLayerKeys().join("|") !== selection) return;
     recordHistory(project);
     if (existing && repaired) project.fonts.splice(project.fonts.findIndex((item) => item.id === existing.id), 1, font);
     else if (!existing) (project.fonts ||= []).push(font);
-    Object.assign(text, next);
+    targets.forEach((item) => {
+      applyProjectFontToText(project, item, font.id);
+      updateTextBox(item);
+      ensureTextFits(item, { force: true });
+    });
     closeFontPicker();
     refreshSelection();
-    updateTextBox(text);
-    ensureTextFits(text, { force: true });
     scheduleSave();
     await bridge.markFontUsed?.(font.localFontId).catch((error) => {
       console.warn(`Could not update recent font usage for ${font.localFontId}:`, error);
@@ -856,6 +865,34 @@ export function createEditorUI({ projects, actions, output }) {
   }
 
   function bindInspectorControls() {
+    const geometryInputs = app.querySelectorAll("[data-shared-property]");
+    const updateSharedGeometryControls = () => {
+      const layers = selectedLayers();
+      geometryInputs.forEach((input) => {
+        if (input === document.activeElement) return;
+        const property = input.dataset.sharedProperty;
+        const values = layers.map(({ kind, item }) => property === "height" && kind === "overlay" ? getOverlayMetrics(item).height : item[property] || 0);
+        input.value = values.length && values.every((value) => value === values[0])
+          ? Math.round(values[0] * (property === "rotation" ? 10 : 1000)) / 10
+          : "";
+      });
+    };
+    geometryInputs.forEach((input) => {
+      input.addEventListener("focus", recordHistory);
+      input.addEventListener("input", () => {
+        if (input.value === "" || !Number.isFinite(Number(input.value))) return;
+        const property = input.dataset.sharedProperty;
+        const value = Number(input.value);
+        if (property !== "rotation" && value <= 0) return;
+        selectedLayers().forEach(({ kind, item }) => {
+          item[property] = property === "rotation" ? ((value % 360) + 360) % 360 : value / 100;
+          if (kind === "text") updateTextBox(item);
+          else updateOverlayBox(item);
+        });
+        updateSharedGeometryControls();
+        scheduleSave();
+      });
+    });
     const textarea = app.querySelector("#text-value");
     textarea?.addEventListener("input", () => {
       const text = selectedText();
@@ -869,7 +906,7 @@ export function createEditorUI({ projects, actions, output }) {
     const fontSelect = app.querySelector("#text-font");
     fontSelect?.addEventListener("change", async () => {
       if (fontSelect.value === "__add_local_font__") {
-        fontSelect.value = selectedText()?.fontId || "";
+        refreshSelection();
         openFontPicker();
         return;
       }
@@ -879,72 +916,77 @@ export function createEditorUI({ projects, actions, output }) {
       } catch (error) {
         console.error(error);
         toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "That font couldn’t be applied.");
-        fontSelect.value = selectedText()?.fontId || "";
+        refreshSelection();
       } finally {
         fontSelect.disabled = false;
       }
     });
 
-    app.querySelectorAll("[data-text-style]").forEach((button) => {
-      button.addEventListener("click", () => {
-        const text = selectedText();
-        if (!text) return;
-        recordHistory();
-        text.style = button.dataset.textStyle;
-        ensureBoxedTextContrast(text);
-        scheduleSave();
-        refreshSelection();
-        updateTextBox(text);
-        ensureTextFits(text);
+    const editSelectedTexts = (edit, { fit = false } = {}) => {
+      selectedLayers().filter(({ kind }) => kind === "text").forEach(({ item }) => {
+        edit(item);
+        updateTextBox(item);
+        if (fit) ensureTextFits(item);
       });
-    });
-
-    app.querySelectorAll("[data-text-align]").forEach((button) => {
-      button.addEventListener("click", () => {
-        const text = selectedText();
-        if (!text) return;
-        recordHistory();
-        text.align = button.dataset.textAlign;
-        app.querySelectorAll("[data-text-align]").forEach((item) => {
-          const active = item === button;
-          item.classList.toggle("is-active", active);
-          item.setAttribute("aria-pressed", String(active));
+      updateSharedGeometryControls();
+      scheduleSave();
+    };
+    const bindTextButtons = (selector, edit, options) => {
+      app.querySelectorAll(selector).forEach((button) => {
+        button.addEventListener("click", () => {
+          recordHistory();
+          editSelectedTexts((text) => edit(text, button), options);
+          refreshSelection();
         });
-        updateTextBox(text);
-        scheduleSave();
       });
-    });
+    };
+    bindTextButtons("[data-text-style]", (text, button) => {
+      text.style = button.dataset.textStyle;
+      ensureBoxedTextContrast(text);
+    }, { fit: true });
+    bindTextButtons("[data-text-align]", (text, button) => { text.align = button.dataset.textAlign; });
 
     const range = app.querySelector("#font-size");
     const number = app.querySelector("#font-size-number");
     const setSize = (value, { fromSlider = false } = {}) => {
-      const text = selectedText();
-      if (!text) return;
-      text.size = fromSlider
+      if (value === "" || !Number.isFinite(Number(value))) return;
+      const size = fromSlider
         ? fontSizeFromSliderPosition(value)
-        : Math.round(clamp(Number(value) || FONT_SIZE_MIN, FONT_SIZE_MIN, FONT_SIZE_MAX) * 2) / 2;
-      if (range) range.value = sliderPositionFromFontSize(text.size);
-      if (range) range.setAttribute("aria-valuetext", `${formatFontSize(text.size)} pixels`);
-      if (number) number.value = formatFontSize(text.size);
-      const output = app.querySelector(".control-label output");
-      if (output) output.textContent = `${formatFontSize(text.size)} px`;
-      updateTextBox(text);
-      ensureTextFits(text);
-      scheduleSave();
+        : Math.round(clamp(Number(value), FONT_SIZE_MIN, FONT_SIZE_MAX) * 2) / 2;
+      editSelectedTexts((text) => { text.size = size; }, { fit: true });
+      if (range) {
+        range.value = sliderPositionFromFontSize(size);
+        range.dataset.mixed = "false";
+        range.setAttribute("aria-valuetext", `${formatFontSize(size)} pixels`);
+      }
+      if (number) number.value = formatFontSize(size);
+      const output = app.querySelector('[for="font-size"] output');
+      if (output) output.textContent = `${formatFontSize(size)} px`;
     };
     range?.addEventListener("pointerdown", recordHistory);
+    range?.addEventListener("keydown", (event) => { if (!event.repeat && ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"].includes(event.key)) recordHistory(); });
     range?.addEventListener("input", () => setSize(range.value, { fromSlider: true }));
-    number?.addEventListener("pointerdown", recordHistory);
+    range?.addEventListener("pointerup", () => {
+      if (range.dataset.mixed === "true") setSize(range.value, { fromSlider: true });
+    });
+    number?.addEventListener("focus", recordHistory);
     number?.addEventListener("input", () => setSize(number.value));
 
     const colorPicker = app.querySelector("#text-color-picker");
     const hexInput = app.querySelector("#text-color-hex");
     const rgbInput = app.querySelector("#text-color-rgb");
+    const sharedTextColor = () => {
+      const colors = selectedLayers().filter(({ kind }) => kind === "text").map(({ item }) => textColor(item));
+      return colors.every((color) => color === colors[0]) ? colors[0] || "" : "";
+    };
     const setTextColor = (value, { source = null } = {}) => {
       const text = selectedText();
       const color = normalizeHexColor(value);
       if (!text || !color) return false;
-      text.color = color;
+      editSelectedTexts((item) => { item.color = color; });
+      const colorLabel = app.querySelector(".color-picker-wrap span");
+      if (colorLabel) colorLabel.textContent = "Color wheel";
+      app.querySelectorAll("[data-copy-color]").forEach((button) => { button.disabled = false; });
       if (colorPicker && source !== "picker") colorPicker.value = color;
       if (hexInput && source !== "hex") hexInput.value = color;
       if (rgbInput && source !== "rgb") rgbInput.value = formatRgb(color);
@@ -966,7 +1008,7 @@ export function createEditorUI({ projects, actions, output }) {
     });
     colorPicker?.addEventListener("pointerdown", recordHistory);
     colorPicker?.addEventListener("input", () => setTextColor(colorPicker.value, { source: "picker" }));
-    hexInput?.addEventListener("focus", recordHistory, { once: true });
+    hexInput?.addEventListener("focus", recordHistory);
     hexInput?.addEventListener("input", () => {
       const fullHex = hexInput.value.trim().replace(/^#/, "");
       if (/^[0-9a-f]{6}$/i.test(fullHex)) setTextColor(fullHex, { source: "hex" });
@@ -974,9 +1016,9 @@ export function createEditorUI({ projects, actions, output }) {
     hexInput?.addEventListener("change", () => {
       const color = normalizeHexColor(hexInput.value);
       if (color) setTextColor(color);
-      else hexInput.value = textColor(selectedText());
+      else hexInput.value = sharedTextColor();
     });
-    rgbInput?.addEventListener("focus", recordHistory, { once: true });
+    rgbInput?.addEventListener("focus", recordHistory);
     rgbInput?.addEventListener("input", () => {
       const color = rgbToHex(rgbInput.value);
       if (color) setTextColor(color, { source: "rgb" });
@@ -984,7 +1026,7 @@ export function createEditorUI({ projects, actions, output }) {
     rgbInput?.addEventListener("change", () => {
       const color = rgbToHex(rgbInput.value);
       if (color) setTextColor(color);
-      else rgbInput.value = formatRgb(textColor(selectedText()));
+      else rgbInput.value = sharedTextColor() ? formatRgb(sharedTextColor()) : "";
     });
     app.querySelectorAll("[data-copy-color]").forEach((button) => {
       button.addEventListener("click", () => {
@@ -993,31 +1035,13 @@ export function createEditorUI({ projects, actions, output }) {
       });
     });
 
-    app.querySelectorAll("[data-background-tone]").forEach((button) => {
-      button.addEventListener("click", () => {
-        const text = selectedText();
-        if (!text) return;
-        recordHistory();
-        text.background = button.dataset.backgroundTone;
-        ensureBoxedTextContrast(text);
-        refreshSelection();
-        updateTextBox(text);
-        scheduleSave();
-      });
+    bindTextButtons("[data-background-tone]", (text, button) => {
+      text.background = button.dataset.backgroundTone;
+      ensureBoxedTextContrast(text);
     });
-
-    app.querySelectorAll("[data-background-shape]").forEach((button) => {
-      button.addEventListener("click", () => {
-        const text = selectedText();
-        if (!text) return;
-        recordHistory();
-        text.backgroundShape = button.dataset.backgroundShape;
-        app.querySelectorAll("[data-background-shape]").forEach((item) => item.classList.toggle("is-active", item === button));
-        updateTextBox(text);
-        ensureTextFits(text);
-        scheduleSave();
-      });
-    });
+    bindTextButtons("[data-background-shape]", (text, button) => {
+      text.backgroundShape = button.dataset.backgroundShape;
+    }, { fit: true });
 
     const photoZoom = app.querySelector("#photo-zoom");
     photoZoom?.addEventListener("pointerdown", recordHistory);

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -413,15 +413,19 @@ export function renderTextBox(text) {
 }
 
 export function renderInspector() {
-  const text = selectedText();
+  const layers = selectedLayers();
+  const texts = layers.filter(({ kind }) => kind === "text").map(({ item }) => item);
+  const text = texts.length === layers.length ? (texts[0] || selectedText()) : null;
+  const shared = (read) => layers.length && layers.every((entry) => Object.is(read(entry.item, entry.kind), read(layers[0].item, layers[0].kind))) ? read(layers[0].item, layers[0].kind) : null;
+  const commonText = (read) => !multiMode || texts.every((item) => Object.is(read(item), read(text)));
   const overlay = selectedOverlay();
-  const selectionCount = selectedLayers().length;
+  const selectionCount = layers.length;
   const multiMode = selectionCount > 1;
   const overlayAsset = overlay ? projectAsset(overlay.assetId) : null;
   const slide = activeSlide();
   const photoMode = Boolean(state.photoAdjustMode && slide);
   const overlayMode = Boolean(!photoMode && !multiMode && overlay);
-  const color = textColor(text);
+  const color = commonText(textColor) ? textColor(text) : "";
   return `
     <aside class="inspector ${state.mobileInspectorOpen ? "is-mobile-open" : ""}">
       <div class="inspector-header">
@@ -436,7 +440,7 @@ export function renderInspector() {
           </div>
           <button class="button button--quiet reset-photo-button" type="button" data-action="reset-photo">Reset photo</button>
         </div>
-      ` : multiMode ? "" : overlayMode && state.croppingOverlayId === overlay.id ? `
+      ` : overlayMode && state.croppingOverlayId === overlay.id ? `
         <div class="inspector-body">
           <button class="button button--primary" type="button" data-action="done-crop">Done</button>
         </div>
@@ -456,15 +460,16 @@ export function renderInspector() {
         </div>
       ` : text ? `
         <div class="inspector-body">
-          <div class="control-group">
+          ${!multiMode ? `<div class="control-group">
             <label class="control-label" for="text-value">Words</label>
             <textarea id="text-value" class="text-input" maxlength="500" placeholder="Type something…">${escapeHtml(text.text)}</textarea>
-          </div>
+          </div>` : ""}
           <div class="control-group">
             <label class="control-label" for="text-font">Font</label>
             <select id="text-font" class="font-select" aria-label="Text font">
-              <option value="" ${text.fontId ? "" : "selected"}>TikTok Sans</option>
-              ${(activeProject()?.fonts || []).map((font) => `<option value="${escapeHtml(font.id)}" ${text.fontId === font.id ? "selected" : ""}>${escapeHtml(font.fullName || `${font.family} ${font.subfamily || ""}`.trim())}</option>`).join("")}
+              ${!commonText((item) => item.fontId || "") ? `<option value="__mixed__" selected disabled>— Mixed fonts</option>` : ""}
+              <option value="" ${commonText((item) => item.fontId || "") && !text.fontId ? "selected" : ""}>TikTok Sans</option>
+              ${(activeProject()?.fonts || []).map((font) => `<option value="${escapeHtml(font.id)}" ${commonText((item) => item.fontId || "") && text.fontId === font.id ? "selected" : ""}>${escapeHtml(font.fullName || `${font.family} ${font.subfamily || ""}`.trim())}</option>`).join("")}
               <option value="__add_local_font__">Add font from Mac…</option>
             </select>
             ${text.fontId && !isTextFontAvailable(activeProject(), text) ? `<p class="font-warning">${escapeHtml(textFontLabel(activeProject(), text))} is unavailable on this device.</p>` : ""}
@@ -472,22 +477,22 @@ export function renderInspector() {
           <div class="control-group">
             <div class="control-label">Style</div>
             <div class="style-options">
-              <button class="style-option ${text.style === "plain" ? "is-active" : ""}" type="button" data-text-style="plain">
+              <button class="style-option ${commonText((item) => item.style) && text.style === "plain" ? "is-active" : ""}" type="button" data-text-style="plain">
                 <span class="style-preview">Aa</span><small>Clean</small>
               </button>
-              <button class="style-option ${text.style === "outline" ? "is-active" : ""}" type="button" data-text-style="outline">
+              <button class="style-option ${commonText((item) => item.style) && text.style === "outline" ? "is-active" : ""}" type="button" data-text-style="outline">
                 <span class="style-preview style-preview--outline">Aa</span><small>Outline</small>
               </button>
-              <button class="style-option ${text.style === "boxed" ? "is-active" : ""}" type="button" data-text-style="boxed">
+              <button class="style-option ${commonText((item) => item.style) && text.style === "boxed" ? "is-active" : ""}" type="button" data-text-style="boxed">
                 <span class="style-preview style-preview--boxed">Aa</span><small>Box</small>
               </button>
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label" for="font-size">Size <output>${formatFontSize(text.size)} px</output></label>
+            <label class="control-label" for="font-size">Size <output>${commonText((item) => item.size) ? `${formatFontSize(text.size)} px` : "—"}</output></label>
             <div class="range-wrap">
-              <input id="font-size" type="range" min="0" max="${FONT_SIZE_SLIDER_MAX}" step="${FONT_SIZE_SLIDER_STEP}" value="${sliderPositionFromFontSize(text.size)}" aria-valuetext="${formatFontSize(text.size)} pixels" />
-              <input id="font-size-number" class="number-input" type="number" min="${FONT_SIZE_MIN}" max="${FONT_SIZE_MAX}" step="0.5" value="${formatFontSize(text.size)}" aria-label="Font size in pixels" />
+              <input id="font-size" data-mixed="${!commonText((item) => item.size)}" type="range" min="0" max="${FONT_SIZE_SLIDER_MAX}" step="${FONT_SIZE_SLIDER_STEP}" value="${sliderPositionFromFontSize(text.size)}" aria-valuetext="${commonText((item) => item.size) ? `${formatFontSize(text.size)} pixels` : "Mixed sizes"}" />
+              <input placeholder="—" id="font-size-number" class="number-input" type="number" min="${FONT_SIZE_MIN}" max="${FONT_SIZE_MAX}" step="0.5" value="${commonText((item) => item.size) ? formatFontSize(text.size) : ""}" aria-label="Font size in pixels" />
             </div>
           </div>
           <div class="control-group color-control">
@@ -506,19 +511,19 @@ export function renderInspector() {
             </div>
             <div class="color-custom">
               <label class="color-picker-wrap" for="text-color-picker">
-                <input id="text-color-picker" type="color" value="${color}" aria-label="Choose a custom text color" />
-                <span>Color wheel</span>
+                <input id="text-color-picker" type="color" value="${color || "#ffffff"}" aria-label="Choose a custom text color" />
+                <span>${color ? "Color wheel" : "— Mixed colors"}</span>
               </label>
               <div class="color-values">
                 <div class="color-value-row">
                   <label for="text-color-hex">Hex</label>
-                  <input id="text-color-hex" type="text" value="${color}" maxlength="7" spellcheck="false" aria-label="Text color hex value" />
-                  <button type="button" data-copy-color="hex" aria-label="Copy hex color">Copy</button>
+                  <input id="text-color-hex" placeholder="—" type="text" value="${color}" maxlength="7" spellcheck="false" aria-label="Text color hex value" />
+                  <button type="button" data-copy-color="hex" ${color ? "" : "disabled"} aria-label="Copy hex color">Copy</button>
                 </div>
                 <div class="color-value-row">
                   <label for="text-color-rgb">RGB</label>
-                  <input id="text-color-rgb" type="text" value="${formatRgb(color)}" spellcheck="false" aria-label="Text color RGB value" />
-                  <button type="button" data-copy-color="rgb" aria-label="Copy RGB color">Copy</button>
+                  <input id="text-color-rgb" type="text" placeholder="—" value="${color ? formatRgb(color) : ""}" spellcheck="false" aria-label="Text color RGB value" />
+                  <button type="button" data-copy-color="rgb" ${color ? "" : "disabled"} aria-label="Copy RGB color">Copy</button>
                 </div>
               </div>
             </div>
@@ -526,29 +531,37 @@ export function renderInspector() {
           <div class="control-group">
             <div class="control-label">Alignment</div>
             <div class="alignment-options" role="group" aria-label="Text alignment">
-              ${["left", "center", "right"].map((align) => `<button class="alignment-option ${textAlignment(text) === align ? "is-active" : ""}" type="button" data-text-align="${align}" aria-label="Align text ${align}" aria-pressed="${textAlignment(text) === align}">${icon(`align-${align}`)}</button>`).join("")}
+              ${["left", "center", "right"].map((align) => `<button class="alignment-option ${commonText(textAlignment) && textAlignment(text) === align ? "is-active" : ""}" type="button" data-text-align="${align}" aria-label="Align text ${align}" aria-pressed="${commonText(textAlignment) && textAlignment(text) === align}">${icon(`align-${align}`)}</button>`).join("")}
             </div>
           </div>
-          ${text.style === "boxed" ? `
+          ${commonText((item) => item.style) && text.style === "boxed" ? `
             <div class="control-group">
               <div class="control-label">Background</div>
               <div class="tone-options">
-                <button class="tone-option ${text.background !== "black" ? "is-active" : ""}" type="button" data-background-tone="white"><span class="tone-swatch tone-swatch--white">Aa</span>White</button>
-                <button class="tone-option ${text.background === "black" ? "is-active" : ""}" type="button" data-background-tone="black"><span class="tone-swatch tone-swatch--black">Aa</span>Black</button>
+                <button class="tone-option ${commonText((item) => item.background || "white") && text.background !== "black" ? "is-active" : ""}" type="button" data-background-tone="white"><span class="tone-swatch tone-swatch--white">Aa</span>White</button>
+                <button class="tone-option ${commonText((item) => item.background) && text.background === "black" ? "is-active" : ""}" type="button" data-background-tone="black"><span class="tone-swatch tone-swatch--black">Aa</span>Black</button>
               </div>
             </div>
             <div class="control-group">
               <div class="control-label">Shape</div>
               <div class="shape-options">
-                <button class="shape-option ${text.backgroundShape !== "full" ? "is-active" : ""}" type="button" data-background-shape="lines"><span class="shape-preview shape-preview--lines"><i>Text line</i><i>Shorter</i></span><small>Per line</small></button>
-                <button class="shape-option ${text.backgroundShape === "full" ? "is-active" : ""}" type="button" data-background-shape="full"><span class="shape-preview shape-preview--full">Text box</span><small>Full box</small></button>
+                <button class="shape-option ${commonText((item) => item.backgroundShape || "lines") && text.backgroundShape !== "full" ? "is-active" : ""}" type="button" data-background-shape="lines"><span class="shape-preview shape-preview--lines"><i>Text line</i><i>Shorter</i></span><small>Per line</small></button>
+                <button class="shape-option ${commonText((item) => item.backgroundShape) && text.backgroundShape === "full" ? "is-active" : ""}" type="button" data-background-shape="full"><span class="shape-preview shape-preview--full">Text box</span><small>Full box</small></button>
               </div>
             </div>
           ` : ""}
         </div>
-      ` : `
+      ` : multiMode ? "" : `
         <div class="inspector-empty"><span>T</span><p>${slide ? "Select text or an overlay, or add one to this photo." : "Add a photo to start placing text."}</p></div>
       `}
+      ${multiMode && !photoMode ? `<div class="inspector-body">
+        ${["width", "height", "rotation"].map((property) => {
+          const rotation = property === "rotation";
+          const value = shared((item, kind) => property === "height" && kind === "overlay" ? getOverlayMetrics(item).height : item[property] || 0);
+          const display = value === null ? "" : Math.round(value * (rotation ? 10 : 1000)) / 10;
+          return `<div class="control-group"><label class="control-label" for="shared-${property}">${rotation ? "Rotation (°)" : property === "width" ? "Width (% of slide)" : "Height (% of slide)"}</label><input id="shared-${property}" class="number-input" type="number" step="${rotation ? 1 : 0.1}" ${rotation ? "" : 'min="0.1"'} placeholder="—" value="${display}" data-shared-property="${property}" /></div>`;
+        }).join("")}
+      </div>` : ""}
     </aside>
   `;
 }

--- a/src/layer-interactions.mjs
+++ b/src/layer-interactions.mjs
@@ -258,6 +258,7 @@ export function createLayerInteractions({
   }
 
   function beginOverlayResize(event, box, handle, { preserveAspect = true } = {}) {
+    if (selectedLayers().length > 1) return beginSelectionResize(event, box, handle, preserveAspect);
     event.preventDefault();
     event.stopPropagation();
     const overlay = selectedOverlay();
@@ -355,7 +356,7 @@ export function createLayerInteractions({
       if (box.classList.contains("is-editing")) {
         if (contentTarget && !corner && !edge && !rotate) return;
         endTextEditing(box);
-      } else if (wasSelected && contentTarget && event.button === 0 && !(event.metaKey || event.ctrlKey)) {
+      } else if (wasSelected && selectedLayers().length === 1 && contentTarget && event.button === 0 && !(event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         event.stopPropagation();
         startTextEditing(box, { clientX: event.clientX, clientY: event.clientY });
@@ -547,7 +548,57 @@ export function createLayerInteractions({
     window.addEventListener("pointercancel", end);
   }
 
+  // Apply the grabbed layer's relative size change around each layer's opposite handle.
+  function beginSelectionResize(event, box, handle, preserveAspect) {
+    event.preventDefault();
+    event.stopPropagation();
+    const entries = selectedLayers().map(({ kind, item }) => {
+      const height = kind === "overlay" ? getOverlayMetrics(item).height : item.height;
+      return { kind, item, start: { ...item, height, rotation: item.rotation || 0,
+        centerX: item.x + item.width / 2, centerY: item.y + height / 2,
+        clientX: event.clientX, clientY: event.clientY } };
+    });
+    const primary = entries.find(({ item }) => item.id === (box.dataset.textId || box.dataset.overlayId));
+    if (!primary) return;
+    recordHistory();
+    try { box.setPointerCapture(event.pointerId); } catch { /* Window tracking is the fallback. */ }
+    const move = (moveEvent) => {
+      const delta = pointerDeltaInLayerAxes(moveEvent, primary.start, primary.start.rotation);
+      const next = resizeLayerRect(primary.start, handle, delta, {
+        minWidth: 0.001, minHeight: 0.001, preserveAspect,
+      });
+      // Clamp the shared scale once so smaller layers keep the same relative change.
+      const minX = Math.max(...entries.map(({ kind, start }) => (kind === "text" ? 0.1 : 0.04) / start.width));
+      const minY = Math.max(...entries.map(({ kind, start }) => (kind === "text" ? 0.045 : 0.025) / start.height));
+      const maxX = Math.min(...entries.map(({ kind, start }) => kind === "overlay" ? 2.4 / start.width : Infinity));
+      const maxY = Math.min(...entries.map(({ kind, start }) => kind === "overlay" ? 2.4 / start.height : Infinity));
+      let scaleX = handle.match(/[ew]/) ? clamp(next.width / primary.start.width, minX, maxX) : 1;
+      let scaleY = handle.match(/[ns]/) ? clamp(next.height / primary.start.height, minY, maxY) : 1;
+      if (preserveAspect) scaleX = scaleY = clamp(next.width / primary.start.width, Math.max(minX, minY), Math.min(maxX, maxY));
+      entries.forEach(({ kind, item, start }) => {
+        const resized = resizeLayerRect(start, handle, {
+          x: start.width * (scaleX - 1) * (handle.includes("w") ? -1 : 1),
+          y: start.height * (scaleY - 1) * (handle.includes("n") ? -1 : 1),
+        }, { minWidth: 0.001, minHeight: 0.001 });
+        Object.assign(item, resized);
+        if (kind === "text") updateTextBox(item);
+        else updateOverlayBox(item);
+      });
+      scheduleSave();
+    };
+    const end = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+      refreshSelection();
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", end);
+    window.addEventListener("pointercancel", end);
+  }
+
   function beginResize(event, box, handle) {
+    if (selectedLayers().length > 1) return beginSelectionResize(event, box, handle, false);
     event.preventDefault();
     event.stopPropagation();
     const text = selectedText();

--- a/styles.css
+++ b/styles.css
@@ -2651,8 +2651,6 @@ button:disabled {
   display: block;
 }
 
-.stage-frame.has-multi-selection .is-selected .resize-handle,
-.stage-frame.has-multi-selection .is-selected .edge-resize-handle,
 .stage-frame.has-multi-selection .is-selected .rotate-handle {
   display: none;
 }
@@ -4041,3 +4039,7 @@ input[type="range"]::-webkit-slider-thumb {
   font-size: 26px;
   cursor: pointer;
 }
+
+/* A mixed range has no representative value until the user chooses one. */
+#font-size[data-mixed="true"]::-webkit-slider-thumb { opacity: 0; }
+#font-size[data-mixed="true"]::-moz-range-thumb { opacity: 0; }

--- a/test/editor-font-view.test.mjs
+++ b/test/editor-font-view.test.mjs
@@ -77,3 +77,27 @@ test("hides a stored project face until its exact bytes finish loading", () => {
   assert.doesNotMatch(html, /is-font-missing/);
   assert.doesNotMatch(html, /missing-font-badge/);
 });
+
+test("shared inspector distinguishes mixed fonts, sizes, and formatting", async () => {
+  const { renderInspector } = await import("../src/editor-view.mjs");
+  const { setLayerSelection } = await import("../src/editor-state.mjs");
+  const first = { ...textLayer(undefined), id: "first", size: 50, align: "left" };
+  const second = { ...textLayer("other-font"), id: "second", size: 60, color: "#000000", align: "right" };
+  state.projects = [{ id: "shared-project", fonts: [{ id: "other-font", family: "Other", fullName: "Other Regular" }], slides: [{ id: "shared-slide", texts: [first, second], overlays: [] }] }];
+  state.activeProjectId = "shared-project";
+  state.activeSlideId = "shared-slide";
+  setLayerSelection(["text:first", "text:second"]);
+  const mixed = renderInspector();
+  assert.match(mixed, /value="__mixed__" selected disabled/);
+  assert.match(mixed, /id="font-size-number"[^>]*value=""/);
+  assert.match(mixed, /id="font-size" data-mixed="true"/);
+  assert.match(mixed, /id="text-color-hex"[^>]*value=""/);
+  assert.doesNotMatch(mixed, /alignment-option is-active/);
+  assert.doesNotMatch(mixed, /id="text-value"/);
+  second.fontId = first.fontId;
+  second.size = first.size = 56;
+  const same = renderInspector();
+  assert.doesNotMatch(same, /value="__mixed__"/);
+  assert.match(same, /id="font-size-number"[^>]*value="56"/);
+  assert.match(same, /value="" selected>TikTok Sans/);
+});


### PR DESCRIPTION
## Summary

Selecting multiple layers now exposes their shared settings. Text selections support fonts, size, color, alignment, style, and applicable box formatting; matching values appear selected and mixed values appear blank or as a dash. All selections expose shared dimensions and rotation.

Every selected layer shows resize handles. Resizing any selected text or image applies the same proportional change to the selection, respecting image corner aspect ratios and rotated layer anchors. Bulk edits preserve unselected layers and support undo.

## Verification

- [x] `npm run test:editor`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run test:editor:browser`
- [x] `npm run test:migration:browser`
- [x] `npm run test:mcp:browser:local`
- [x] No secrets, credentials, generated archives, or local state are included
- [x] No new dependencies or GitHub Actions

Added Node coverage for mixed/shared inspector values and browser coverage for bulk formatting, undo, text/image resizing, shared dimensions, and unchanged unselected layers.
