### PR TITLE
Add project parent navigation and simplify folder header

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1630,6 +1630,24 @@ try {
     () => evaluate(cdp, `location.pathname === '/folders/native-folder' && document.querySelector('.folder-dashboard-title')?.textContent.trim() === '/native-folder'`),
     "Opening the folder card did not show its dashboard route.",
   );
+  const folderHeader = await evaluate(cdp, `({
+    home: document.querySelector('.folder-breadcrumb')?.textContent.trim(),
+    fontSize: parseFloat(getComputedStyle(document.querySelector('.folder-breadcrumb')).fontSize),
+    counts: [...document.querySelectorAll('.dashboard p, .section-heading > span')].filter((item) => item.textContent.trim() === '1 project').length,
+  })`);
+  if (folderHeader.home !== 'Home' || folderHeader.fontSize < 16 || folderHeader.counts !== 1) {
+    throw new Error('The folder header should show a larger Home link and a single project count: ' + JSON.stringify(folderHeader));
+  }
+  await evaluate(cdp, `document.querySelector('.project-card[data-project-id="${folderUiProject.projectId}"]').click()`);
+  await waitFor(
+    () => evaluate(cdp, `document.querySelector('.slide-rail > .slide-rail-back')?.textContent.trim() === '/native-folder' && document.querySelector('.slide-rail-back')?.getAttribute('href') === '/folders/native-folder'`),
+    "The slide sidebar did not show the project's folder link.",
+  );
+  await evaluate(cdp, `document.querySelector('.slide-rail-back').click()`);
+  await waitFor(
+    () => evaluate(cdp, `location.pathname === '/folders/native-folder' && Boolean(document.querySelector('.folder-dashboard-title'))`),
+    "The slide sidebar link did not return to the folder.",
+  );
   await evaluate(cdp, "window.__carouselBotFolderReloadSentinel = true");
   await cdp.send("Page.reload", { ignoreCache: true });
   await waitFor(
@@ -1653,6 +1671,16 @@ try {
         && this.carouselBotAgent.inspect().projects.find((item) => item.id === projectId)?.folderPath === null;
     }`, [folderUiProject.projectId]),
     "Moving the final project out did not remove the implicit folder and return to the dashboard.",
+  );
+  await evaluate(cdp, `document.querySelector('.project-card[data-project-id="${folderUiProject.projectId}"]').click()`);
+  await waitFor(
+    () => evaluate(cdp, `document.querySelector('.slide-rail > .slide-rail-back')?.textContent.trim() === 'Home' && document.querySelector('.slide-rail-back')?.getAttribute('href') === '/' && Boolean(document.querySelector('.slide-rail-back svg'))`),
+    "The slide sidebar did not show Home for an unfiled project.",
+  );
+  await evaluate(cdp, `document.querySelector('.slide-rail-back').click()`);
+  await waitFor(
+    () => evaluate(cdp, `location.pathname === '/' && Boolean(document.querySelector('.dashboard'))`),
+    "The slide sidebar Home link did not return home.",
   );
   await callPageFunction(cdp, `function(projectId) {
     return this.carouselBotAgent.execute({ type: 'project.delete', projectId });

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -968,6 +968,13 @@ export function createEditorProjects({
   }
 
   function bindGlobalActions() {
+    app.querySelector('[data-action="open-project-parent"]')?.addEventListener("click", (event) => {
+      if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
+      event.preventDefault();
+      const folderPath = activeProject()?.folderPath;
+      if (folderPath) openFolder(folderPath);
+      else openDashboard();
+    });
     if (!app.querySelector(".dashboard")) clearDashboardPreviewResizeTracking();
     const homeLink = app.querySelector('[data-action="home"]');
     homeLink?.addEventListener("click", (event) => {

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -565,10 +565,9 @@ export function createEditorUI({ projects, actions, output }) {
         ${activeFolderPath ? `
           <section class="folder-dashboard-header">
             <div>
-              <a class="folder-breadcrumb" href="/" data-action="open-dashboard-root">${icon("back")} All projects</a>
+              <a class="folder-breadcrumb" href="/" data-action="open-dashboard-root">${icon("back")} Home</a>
               <h1 class="folder-dashboard-title">${icon("folder")}<span>${escapeHtml(activeFolderPath)}</span></h1>
             </div>
-            <p class="folder-dashboard-summary">${projectCountLabel}</p>
           </section>
         ` : `
           <section class="dashboard-hero">

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -14,6 +14,7 @@ import {
   FONT_SIZE_SLIDER_STEP,
   TEXT_COLOR_PRESETS,
   escapeHtml,
+  folderRoutePath,
   textColor,
   formatRgb,
   outlineColorFor,
@@ -66,6 +67,7 @@ export function formatDate(timestamp) {
 
 export function icon(name) {
   const icons = {
+    home: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 10 9-7 9 7v10a1 1 0 0 1-1 1h-5v-8H9v8H4a1 1 0 0 1-1-1Z"/></svg>',
     back: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
     forward: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>',
     download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>',
@@ -168,6 +170,7 @@ export function renderLegacyMigrationNotice(projects, migrationController, dismi
 export function renderSlideRail(project) {
   return `
     <aside class="slide-rail">
+      <a class="slide-rail-back" data-action="open-project-parent" href="${project.folderPath ? folderRoutePath(project.folderPath) : "/"}" title="${escapeHtml(project.folderPath || "Home")}">${icon(project.folderPath ? "back" : "home")}<span>${escapeHtml(project.folderPath || "Home")}</span></a>
       <div class="rail-heading"><h2>Slides</h2><span>${project.slides.length}</span></div>
       <div class="slide-list">
         ${project.slides.map((slide, index) => {

--- a/styles.css
+++ b/styles.css
@@ -953,7 +953,7 @@ button:disabled {
   color: var(--muted);
   background: transparent;
   font: inherit;
-  font-size: 12px;
+  font-size: 16px;
   font-weight: 750;
   text-decoration: none;
   cursor: pointer;
@@ -965,8 +965,8 @@ button:disabled {
 }
 
 .folder-breadcrumb svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
 }
 
 .dashboard h1.folder-dashboard-title {
@@ -992,13 +992,6 @@ button:disabled {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.folder-dashboard-summary {
-  margin: 0 0 5px;
-  color: var(--muted);
-  font-size: 13px;
   white-space: nowrap;
 }
 
@@ -1364,6 +1357,40 @@ button:disabled {
   font-weight: 800;
   text-align: center;
   pointer-events: none;
+}
+
+.slide-rail-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  margin: 12px 12px 0;
+  padding: 6px 4px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.slide-rail-back:hover {
+  color: var(--ink);
+}
+
+.slide-rail-back svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.slide-rail-back span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slide-rail-back + .rail-heading {
+  padding-top: 12px;
 }
 
 .rail-heading {
@@ -3964,10 +3991,6 @@ input[type="range"]::-webkit-slider-thumb {
   .folder-dashboard-header {
     display: block;
     margin-bottom: 24px;
-  }
-
-  .folder-dashboard-summary {
-    margin-top: 12px;
   }
 
   .dashboard h1.folder-dashboard-title {


### PR DESCRIPTION
Adds a link at the top of the existing Slides sidebar that returns to the project's folder, or shows a Home icon and Home for unfiled projects. The folder dashboard now uses a larger Home back link and displays its project count once.

Validation: editor tests, full test suite, production build, editor browser smoke test, migration browser test, and local MCP browser test all passed. Browser coverage checks both sidebar destinations and the folder header.
