### PR TITLE
Move asset removal into right-click menu

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -848,6 +848,35 @@ try {
       await run({ type: 'layer.delete', layerIds: [a, b] });
     }
   })()`);
+  const assetMenu = await evaluate(cdp, `(async () => {
+    const agent = window.carouselBotAgent;
+    const projectId = agent.inspect({ includeAllProjects: false }).project.id;
+    const bridge = window.carouselBotLocalMcpBridge;
+    const originalFetchMedia = bridge.fetchMedia;
+    bridge.fetchMedia = async () => ({ file: new File(['<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#123456"/></svg>'], 'context-menu.svg', { type: 'image/svg+xml' }), name: 'context-menu.svg' });
+    let asset;
+    try {
+      asset = await agent.execute({ type: 'asset.import', projectId, mediaId: 'context-menu', name: 'Context menu asset' });
+    } finally {
+      bridge.fetchMedia = originalFetchMedia;
+    }
+    const item = [...document.querySelectorAll('.asset-item')].find(item => item.dataset.assetId === asset.assetId);
+    const noRemoveButton = !document.querySelector('.asset-remove');
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 200 });
+    item.dispatchEvent(event);
+    const menu = document.querySelector('.layer-menu');
+    const button = menu?.querySelector('[role="menuitem"]');
+    const opened = event.defaultPrevented && button?.textContent.trim() === 'Remove';
+    const noPreview = !document.querySelector('.asset-preview-modal');
+    button.click();
+    const removed = ![...document.querySelectorAll('.asset-item')].some(item => item.dataset.assetId === asset.assetId);
+    return { noRemoveButton, opened, noPreview, removed, closed: !document.querySelector('.layer-menu') };
+  })()`);
+  if (Object.values(assetMenu).some(value => !value)) {
+    throw new Error(`Asset context menu regression: ${JSON.stringify(assetMenu)}`);
+  }
+
+  await evaluate(cdp, "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
 
   const imagePasteBefore = await evaluate(cdp, `(() => {
     const inspected = window.carouselBotAgent.inspect({ includeAllProjects: false });

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -192,7 +192,7 @@ export function createEditorUI({ projects, actions, output }) {
     positionLayerMenu(menu, event.clientX, event.clientY);
   }
 
-  function showAssetDeleteMenu(event, assetId) {
+  function showAssetMenu(event, assetId) {
     event.preventDefault();
     event.stopPropagation();
     closeLayerMenu();
@@ -204,14 +204,14 @@ export function createEditorUI({ projects, actions, output }) {
     const menu = document.createElement("div");
     menu.className = "layer-menu layer-menu--confirm";
     menu.setAttribute("role", "menu");
-    menu.setAttribute("aria-label", `Delete ${asset.name}?`);
+    menu.setAttribute("aria-label", `Actions for ${asset.name}`);
 
     const button = document.createElement("button");
     button.type = "button";
     button.className = "layer-menu-item is-danger";
     button.setAttribute("role", "menuitem");
-    button.setAttribute("aria-label", `Delete ${asset.name}`);
-    button.innerHTML = `${icon("trash")}<span>Delete?</span>`;
+    button.setAttribute("aria-label", `Remove ${asset.name}`);
+    button.innerHTML = `${icon("trash")}<span>Remove</span>`;
     button.addEventListener("click", (clickEvent) => {
       clickEvent.stopPropagation();
       closeLayerMenu();
@@ -1361,6 +1361,7 @@ export function createEditorUI({ projects, actions, output }) {
     app.querySelectorAll(".asset-item").forEach((item) => {
       const assetId = item.dataset.assetId;
       const previewSrc = item.querySelector("img")?.src;
+      item.addEventListener("contextmenu", (event) => showAssetMenu(event, assetId));
       item.addEventListener("click", (event) => {
         if (event.target.closest("button") || state.draggingAssetId) return;
         openAssetPreview(assetId);
@@ -1395,11 +1396,6 @@ export function createEditorUI({ projects, actions, output }) {
         hideAssetPreview();
       });
     });
-    app.querySelectorAll('[data-action="delete-asset"]').forEach((button) => {
-      button.addEventListener("click", (event) => {
-        showAssetDeleteMenu(event, button.dataset.assetId);
-      });
-    });
     bindAssetTrash();
   }
 
@@ -1432,6 +1428,7 @@ export function createEditorUI({ projects, actions, output }) {
   }
 
   function showAssetPreview(src, clientX, clientY) {
+    if (document.querySelector(".layer-menu")) return;
     let preview = document.querySelector(".asset-hover-preview");
     if (!preview) {
       preview = document.createElement("img");

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -200,7 +200,6 @@ export function renderAssetRail(project) {
         ${assets.length ? assets.map((asset) => `
           <div class="asset-item" tabindex="0" aria-label="Preview ${escapeHtml(asset.name)}" data-asset-id="${asset.id}" draggable="true" title="${escapeHtml(asset.name)}">
             <img src="${asset.imageData}" alt="${escapeHtml(asset.name)}" draggable="false" />
-            <button class="asset-remove" type="button" data-action="delete-asset" data-asset-id="${asset.id}" aria-label="Remove ${escapeHtml(asset.name)}">×</button>
           </div>
         `).join("") : `<p class="asset-empty">Upload logos, stickers, or extra photos. Drag them onto a photo to place them.</p>`}
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1594,29 +1594,6 @@ button:disabled {
   pointer-events: none;
 }
 
-.asset-remove {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  display: grid;
-  width: 20px;
-  height: 20px;
-  place-items: center;
-  border: 0;
-  border-radius: 50%;
-  color: #fff;
-  background: rgba(21, 21, 21, 0.72);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  opacity: 0;
-}
-
-.asset-item:hover .asset-remove,
-.asset-remove:focus-visible {
-  opacity: 1;
-}
-
 .overlay-asset-name {
   margin: 0;
   overflow: hidden;
@@ -3786,10 +3763,6 @@ input[type="range"]::-webkit-slider-thumb {
   .asset-grid {
     grid-template-columns: 1fr;
     padding: 4px 6px 10px;
-  }
-
-  .asset-remove {
-    opacity: 1;
   }
 
   .asset-trash {


### PR DESCRIPTION
Asset previews now offer Remove through a right-click menu matching the slide sidebar. Removes the preview X and keeps hover previews out of the open menu. Adds browser coverage for the menu and removal. Validation: all six required local checks pass.