### PR TITLE
Clarify folder and project navigation and labels

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1547,7 +1547,7 @@ try {
     const previous = shell?.querySelector('[data-project-preview-direction="previous"]');
     const next = shell?.querySelector('[data-project-preview-direction="next"]');
     const meta = card?.querySelector('.project-meta');
-    const title = meta?.querySelector('strong');
+    const title = meta?.querySelector('.project-meta-name > span');
     const details = meta?.lastElementChild;
     if (!card || !shell || !strip || slides.length !== 8 || slides.some((slide) => !slide.querySelector('img'))) return false;
     const stripRect = strip.getBoundingClientRect();
@@ -1679,7 +1679,7 @@ try {
     strip.dispatchEvent(new Event('scroll'));
     const next = shell.querySelector('[data-project-preview-direction="next"]');
     const meta = shell.querySelector('.project-meta');
-    const title = meta?.querySelector('strong');
+    const title = meta?.querySelector('.project-meta-name > span');
     const details = meta?.lastElementChild;
     return !next.hidden ? {
       viewportWidth: innerWidth,
@@ -1762,7 +1762,7 @@ try {
     };
   })()`), "Moving a project into a new folder did not render its eight-slot folder card.");
   if (
-    nativeFolderCard.name !== "/native-folder"
+    nativeFolderCard.name !== "native-folder"
     || nativeFolderCard.href !== "/folders/native-folder"
     || nativeFolderCard.gap !== 6
     || nativeFolderCard.padding !== 8
@@ -1774,22 +1774,32 @@ try {
   );
   await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/native-folder"]').click()`);
   await waitFor(
-    () => evaluate(cdp, `location.pathname === '/folders/native-folder' && document.querySelector('.folder-dashboard-title')?.textContent.trim() === '/native-folder'`),
+    () => evaluate(cdp, `location.pathname === '/folders/native-folder' && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'native-folder'`),
     "Opening the folder card did not show its dashboard route.",
   );
+  const projectCardIcon = await evaluate(cdp, `Boolean(document.querySelector('.project-card .project-meta-name svg rect[x="14"][y="14"]'))`);
+  if (!projectCardIcon) throw new Error('Project cards must show the square-stack icon.');
   const folderHeader = await evaluate(cdp, `({
     home: document.querySelector('.folder-breadcrumb')?.textContent.trim(),
     fontSize: parseFloat(getComputedStyle(document.querySelector('.folder-breadcrumb')).fontSize),
-    counts: [...document.querySelectorAll('.dashboard p, .section-heading > span')].filter((item) => item.textContent.trim() === '1 project').length,
+    heading: document.querySelector('.section-heading h2')?.textContent.trim(),
+    rightCount: Boolean(document.querySelector('.section-heading > span')),
   })`);
-  if (folderHeader.home !== 'Home' || folderHeader.fontSize < 16 || folderHeader.counts !== 1) {
+  if (folderHeader.home !== 'Home' || folderHeader.fontSize < 16 || folderHeader.heading !== '1 project' || folderHeader.rightCount) {
     throw new Error('The folder header should show a larger Home link and a single project count: ' + JSON.stringify(folderHeader));
   }
   await evaluate(cdp, `document.querySelector('.project-card[data-project-id="${folderUiProject.projectId}"]').click()`);
   await waitFor(
-    () => evaluate(cdp, `document.querySelector('.slide-rail > .slide-rail-back')?.textContent.trim() === '/native-folder' && document.querySelector('.slide-rail-back')?.getAttribute('href') === '/folders/native-folder'`),
+    () => evaluate(cdp, `document.querySelector('.slide-rail > .slide-rail-back')?.textContent.trim() === 'native-folder' && document.querySelector('.slide-rail-back')?.getAttribute('href') === '/folders/native-folder'`),
     "The slide sidebar did not show the project's folder link.",
   );
+  const parentLinkSize = await evaluate(cdp, `(() => {
+    const link = document.querySelector('.slide-rail-back');
+    return { fontSize: parseFloat(getComputedStyle(link).fontSize), height: link.getBoundingClientRect().height, iconWidth: link.querySelector('svg').getBoundingClientRect().width };
+  })()`);
+  if (parentLinkSize.fontSize < 18 || parentLinkSize.height < 48 || parentLinkSize.iconWidth < 24) {
+    throw new Error('The folder link must remain large and easy to click: ' + JSON.stringify(parentLinkSize));
+  }
   await evaluate(cdp, `document.querySelector('.slide-rail-back').click()`);
   await waitFor(
     () => evaluate(cdp, `location.pathname === '/folders/native-folder' && Boolean(document.querySelector('.folder-dashboard-title'))`),
@@ -1798,7 +1808,7 @@ try {
   await evaluate(cdp, "window.__carouselBotFolderReloadSentinel = true");
   await cdp.send("Page.reload", { ignoreCache: true });
   await waitFor(
-    () => evaluate(cdp, `document.readyState === 'complete' && !window.__carouselBotFolderReloadSentinel && window.carouselBotAgent && location.pathname === '/folders/native-folder' && document.querySelector('.folder-dashboard-title')?.textContent.trim() === '/native-folder' && [...document.querySelectorAll('.project-card .project-meta strong')].some((item) => item.textContent === 'Folder UI project')`),
+    () => evaluate(cdp, `document.readyState === 'complete' && !window.__carouselBotFolderReloadSentinel && window.carouselBotAgent && location.pathname === '/folders/native-folder' && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'native-folder' && [...document.querySelectorAll('.project-card .project-meta strong')].some((item) => item.textContent === 'Folder UI project')`),
     "The folder deep route did not survive a reload.",
   );
   await evaluate(cdp, `(() => {

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -412,7 +412,7 @@ try {
     folderSlots: document.querySelector('.folder-card[data-folder-path="/mcp-folder"]')?.querySelectorAll('.folder-preview-slot').length,
     folderIcon: Boolean(document.querySelector('.folder-card[data-folder-path="/mcp-folder"] .folder-meta-name svg'))
   })`);
-  if (!dashboardUpdated.dashboardVisible || dashboardUpdated.projectNames.includes("Full MCP browser test") || !dashboardUpdated.folderNames.includes("/mcp-folder") || dashboardUpdated.folderSlots !== 8 || !dashboardUpdated.folderIcon || createdProject.folderPath !== "/mcp-folder") throw new Error(`Dashboard folder did not update live: ${JSON.stringify({ createdProject, dashboardUpdated })}`);
+  if (!dashboardUpdated.dashboardVisible || dashboardUpdated.projectNames.includes("Full MCP browser test") || !dashboardUpdated.folderNames.includes("mcp-folder") || dashboardUpdated.folderSlots !== 8 || !dashboardUpdated.folderIcon || createdProject.folderPath !== "/mcp-folder") throw new Error(`Dashboard folder did not update live: ${JSON.stringify({ createdProject, dashboardUpdated })}`);
   const folderInspection = (await tool("inspect_editor")).structuredContent;
   const inspectedFolder = folderInspection.folders.find((folder) => folder.path === "/mcp-folder");
   if (folderInspection.projects.find((project) => project.id === createdProject.projectId)?.folderPath !== "/mcp-folder" || inspectedFolder?.projectCount !== 1 || inspectedFolder.projectIds[0] !== createdProject.projectId) throw new Error(`Folder membership was not inspectable: ${JSON.stringify(folderInspection)}`);

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -115,6 +115,10 @@ export function projectPath(projectId) {
   return `/projects/${encodeURIComponent(projectId)}`;
 }
 
+export function folderDisplayName(value) {
+  return String(value ?? "").replace(/^\/+/, "");
+}
+
 export function normalizeFolderPath(value) {
   if (value == null) return null;
   let content = String(value).trim();

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -5,6 +5,7 @@ import {
   uid,
   projectPath,
   folderRoutePath,
+  folderDisplayName,
   routeFromPathname,
   escapeHtml,
   normalizeAspectRatio,
@@ -417,7 +418,7 @@ export function createEditorProjects({
       clearProjectHistory([projectId]);
       leaveMissingActiveFolder();
       renderDashboard();
-      toast(folderPath ? `Moved to ${folderPath}` : "Moved to all projects");
+      toast(folderPath ? `Moved to ${folderDisplayName(folderPath)}` : "Moved to all projects");
       return updated;
     } catch (error) {
       if (error.code === "STALE_PROJECT") await reloadProjectFromDb(projectId);
@@ -456,12 +457,12 @@ export function createEditorProjects({
     backdrop.innerHTML = `
       <form class="modal" data-folder-move-form role="dialog" aria-modal="true" aria-labelledby="folder-move-title" aria-describedby="folder-move-description">
         <h2 id="folder-move-title">Move project</h2>
-        <p id="folder-move-description">Enter a folder path such as <strong>/my-folder</strong>. Leave it empty to show the project on the home screen.</p>
-        <input name="folderPath" value="${escapeHtml(project.folderPath || "")}" placeholder="/my-folder" maxlength="160" list="folder-path-options" autocomplete="off" aria-label="Folder path" />
+        <p id="folder-move-description">Enter a folder name such as <strong>${icon("folder")} my-folder</strong>. Leave it empty to show the project on the home screen.</p>
+        <input name="folderPath" value="${escapeHtml(folderDisplayName(project.folderPath))}" placeholder="my-folder" maxlength="160" list="folder-path-options" autocomplete="off" aria-label="Folder name" />
         <datalist id="folder-path-options">
-          ${folderPaths.map((folderPath) => `<option value="${escapeHtml(folderPath)}"></option>`).join("")}
+          ${folderPaths.map((folderPath) => `<option value="${escapeHtml(folderDisplayName(folderPath))}"></option>`).join("")}
         </datalist>
-        <p class="folder-path-hint">A new path creates the folder automatically.</p>
+        <p class="folder-path-hint">A new name creates the folder automatically.</p>
         <div class="modal-actions">
           <button class="button button--quiet" type="button" data-action="cancel-folder-dialog">Cancel</button>
           <button class="button button--primary" type="submit">Move project</button>
@@ -483,7 +484,7 @@ export function createEditorProjects({
       event.preventDefault();
       const folderPath = normalizeFolderPath(input.value);
       if (input.value.trim() && !folderPath) {
-        input.setCustomValidity("Enter a folder name after the slash. /. and /.. are not folder names.");
+        input.setCustomValidity("Enter a folder name. A dot or double dot is not a folder name.");
         input.reportValidity();
         return;
       }
@@ -515,9 +516,9 @@ export function createEditorProjects({
     backdrop.innerHTML = `
       <form class="modal" data-folder-rename-form role="dialog" aria-modal="true" aria-labelledby="folder-rename-title" aria-describedby="folder-rename-description">
         <h2 id="folder-rename-title">Rename folder</h2>
-        <p id="folder-rename-description">Changing the path moves every project in <strong>${escapeHtml(sourceFolderPath)}</strong> together.</p>
-        <input name="folderPath" value="${escapeHtml(sourceFolderPath)}" placeholder="/my-folder" maxlength="160" autocomplete="off" aria-label="Folder path" required />
-        <p class="folder-path-hint">Using an existing path merges the two folders.</p>
+        <p id="folder-rename-description">Changing the name moves every project in <strong>${icon("folder")} ${escapeHtml(folderDisplayName(sourceFolderPath))}</strong> together.</p>
+        <input name="folderPath" value="${escapeHtml(folderDisplayName(sourceFolderPath))}" placeholder="my-folder" maxlength="160" autocomplete="off" aria-label="Folder name" required />
+        <p class="folder-path-hint">Using an existing name merges the two folders.</p>
         <div class="modal-actions">
           <button class="button button--quiet" type="button" data-action="cancel-folder-dialog">Cancel</button>
           <button class="button button--primary" type="submit">Rename folder</button>
@@ -539,7 +540,7 @@ export function createEditorProjects({
       event.preventDefault();
       const folderPath = normalizeFolderPath(input.value);
       if (!folderPath) {
-        input.setCustomValidity("Enter a folder name after the slash. /. and /.. are not folder names.");
+        input.setCustomValidity("Enter a folder name. A dot or double dot is not a folder name.");
         input.reportValidity();
         return;
       }
@@ -551,7 +552,7 @@ export function createEditorProjects({
       try {
         const moved = await moveFolderProjects(sourceFolderPath, folderPath);
         close();
-        toast(`Moved ${moved.length} ${moved.length === 1 ? "project" : "projects"} to ${folderPath}`);
+        toast(`Moved ${moved.length} ${moved.length === 1 ? "project" : "projects"} to ${folderDisplayName(folderPath)}`);
       } catch (error) {
         console.error(error);
         cancelButton.disabled = false;
@@ -668,7 +669,7 @@ export function createEditorProjects({
     const menu = document.createElement("div");
     menu.className = "layer-menu";
     menu.setAttribute("role", "menu");
-    menu.setAttribute("aria-label", `Actions for ${folderPath}`);
+    menu.setAttribute("aria-label", `Actions for ${folderDisplayName(folderPath)}`);
 
     const renameButton = document.createElement("button");
     renameButton.type = "button";

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -5,6 +5,7 @@ import {
   CANVAS_ZOOM_MAX,
   projectPath,
   folderRoutePath,
+  folderDisplayName,
   adjacentSlideId,
   escapeHtml,
   normalizeHexColor,
@@ -487,7 +488,7 @@ export function createEditorUI({ projects, actions, output }) {
     clearLayerSelection();
     const sortedProjects = [...state.projects].sort((a, b) => b.updatedAt - a.updatedAt);
     const activeFolderPath = state.activeFolderPath;
-    document.title = activeFolderPath ? `${activeFolderPath} · CarouselBot` : "CarouselBot";
+    document.title = activeFolderPath ? `${folderDisplayName(activeFolderPath)} · CarouselBot` : "CarouselBot";
     const foldersByPath = new Map();
     for (const project of sortedProjects) {
       if (!project.folderPath) continue;
@@ -522,7 +523,7 @@ export function createEditorUI({ projects, actions, output }) {
               ${slides || `<span class="project-preview-empty">No slides yet</span>`}
             </span>
             <span class="project-meta">
-              <strong>${escapeHtml(project.name)}</strong>
+              <strong class="project-meta-name">${icon("square-stack")}<span>${escapeHtml(project.name)}</span></strong>
               <span>${project.slides.length} ${project.slides.length === 1 ? "slide" : "slides"} · ${formatDate(project.updatedAt)}</span>
             </span>
           </a>
@@ -549,10 +550,10 @@ export function createEditorUI({ projects, actions, output }) {
         `;
       }).join("");
       return `
-        <a class="folder-card" href="${folderRoutePath(folder.folderPath)}" data-folder-path="${escapeHtml(folder.folderPath)}" aria-haspopup="menu" aria-label="Open folder ${escapeHtml(folder.folderPath)}. Right-click for actions." title="Right-click for actions">
+        <a class="folder-card" href="${folderRoutePath(folder.folderPath)}" data-folder-path="${escapeHtml(folder.folderPath)}" aria-haspopup="menu" aria-label="Open folder ${escapeHtml(folderDisplayName(folder.folderPath))}. Right-click for actions." title="Right-click for actions">
           <span class="folder-preview">${slots}</span>
           <span class="project-meta">
-            <strong class="folder-meta-name">${icon("folder")}<span>${escapeHtml(folder.folderPath)}</span></strong>
+            <strong class="folder-meta-name">${icon("folder")}<span>${escapeHtml(folderDisplayName(folder.folderPath))}</span></strong>
             <span>${folder.projects.length} ${folder.projects.length === 1 ? "project" : "projects"}</span>
           </span>
         </a>
@@ -575,7 +576,7 @@ export function createEditorUI({ projects, actions, output }) {
           <section class="folder-dashboard-header">
             <div>
               <a class="folder-breadcrumb" href="/" data-action="open-dashboard-root">${icon("back")} Home</a>
-              <h1 class="folder-dashboard-title">${icon("folder")}<span>${escapeHtml(activeFolderPath)}</span></h1>
+              <h1 class="folder-dashboard-title">${icon("folder")}<span>${escapeHtml(folderDisplayName(activeFolderPath))}</span></h1>
             </div>
           </section>
         ` : `
@@ -589,13 +590,13 @@ export function createEditorUI({ projects, actions, output }) {
         `}
         <section>
           <div class="section-heading">
-            <h2>${activeFolderPath ? "Projects" : "Your projects"}</h2>
-            <span>${activeFolderPath ? projectCountLabel : `${sortedProjects.length} ${sortedProjects.length === 1 ? "project" : "projects"} · ${folders.length} ${folders.length === 1 ? "folder" : "folders"}`}</span>
+            <h2>${activeFolderPath ? projectCountLabel : "Your projects"}</h2>
+            ${activeFolderPath ? "" : `<span>${sortedProjects.length} ${sortedProjects.length === 1 ? "project" : "projects"} · ${folders.length} ${folders.length === 1 ? "folder" : "folders"}</span>`}
           </div>
           <div class="project-grid">
             <button class="new-project-card" type="button" data-action="new-project">
               <span>+</span>
-              <span><strong>Start a project</strong><small>${activeFolderPath ? `Create it in ${escapeHtml(activeFolderPath)}` : "Add photos when you’re ready"}</small></span>
+              <span><strong>Start a project</strong><small>${activeFolderPath ? `Create it in ${icon("folder")} ${escapeHtml(folderDisplayName(activeFolderPath))}` : "Add photos when you’re ready"}</small></span>
             </button>
             ${cards}
           </div>

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -15,6 +15,7 @@ import {
   TEXT_COLOR_PRESETS,
   escapeHtml,
   folderRoutePath,
+  folderDisplayName,
   textColor,
   formatRgb,
   outlineColorFor,
@@ -67,6 +68,7 @@ export function formatDate(timestamp) {
 
 export function icon(name) {
   const icons = {
+    "square-stack": '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 10c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2"/><path d="M10 16c-1.1 0-2-.9-2-2v-4c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2"/><rect width="8" height="8" x="14" y="14" rx="2"/></svg>',
     home: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 10 9-7 9 7v10a1 1 0 0 1-1 1h-5v-8H9v8H4a1 1 0 0 1-1-1Z"/></svg>',
     back: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>',
     forward: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>',
@@ -170,7 +172,7 @@ export function renderLegacyMigrationNotice(projects, migrationController, dismi
 export function renderSlideRail(project) {
   return `
     <aside class="slide-rail">
-      <a class="slide-rail-back" data-action="open-project-parent" href="${project.folderPath ? folderRoutePath(project.folderPath) : "/"}" title="${escapeHtml(project.folderPath || "Home")}">${icon(project.folderPath ? "back" : "home")}<span>${escapeHtml(project.folderPath || "Home")}</span></a>
+      <a class="slide-rail-back" data-action="open-project-parent" href="${project.folderPath ? folderRoutePath(project.folderPath) : "/"}" title="${escapeHtml(folderDisplayName(project.folderPath) || "Home")}">${icon(project.folderPath ? "folder" : "home")}<span>${escapeHtml(folderDisplayName(project.folderPath) || "Home")}</span></a>
       <div class="rail-heading"><h2>Slides</h2><span>${project.slides.length}</span></div>
       <div class="slide-list">
         ${project.slides.map((slide, index) => {

--- a/styles.css
+++ b/styles.css
@@ -1255,6 +1255,16 @@ button:disabled {
   white-space: nowrap;
 }
 
+.project-meta .project-meta-name {
+  align-items: baseline;
+  font-weight: 650;
+}
+
+.project-meta .folder-meta-name {
+  font-weight: 800;
+}
+
+.project-meta-name,
 .folder-meta-name {
   display: flex !important;
   gap: 7px;
@@ -1262,12 +1272,14 @@ button:disabled {
   align-items: center;
 }
 
+.project-meta-name svg,
 .folder-meta-name svg {
   width: 17px;
   height: 17px;
   flex: 0 0 auto;
 }
 
+.project-meta .project-meta-name > span,
 .project-meta .folder-meta-name > span {
   min-width: 0;
   overflow: hidden;
@@ -1362,24 +1374,30 @@ button:disabled {
 .slide-rail-back {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
   min-width: 0;
+  min-height: 48px;
   margin: 12px 12px 0;
-  padding: 6px 4px;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
+  padding: 10px 8px;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 750;
   text-decoration: none;
-  border-radius: 4px;
+  border-radius: 8px;
 }
 
 .slide-rail-back:hover {
-  color: var(--ink);
+  background: var(--panel);
+}
+
+.slide-rail-back:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
 }
 
 .slide-rail-back svg {
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   flex-shrink: 0;
 }
 
@@ -4039,3 +4057,14 @@ input[type="range"]::-webkit-slider-thumb {
 /* A mixed range has no representative value until the user chooses one. */
 #font-size[data-mixed="true"]::-webkit-slider-thumb { opacity: 0; }
 #font-size[data-mixed="true"]::-moz-range-thumb { opacity: 0; }
+
+.new-project-card small svg,
+.folder-dialog strong svg {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.15em;
+}
+
+.project-meta-name svg {
+  align-self: center;
+}

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -15,6 +15,7 @@ import {
   ensureBoxedTextContrast,
   escapeHtml,
   folderRoutePath,
+  folderDisplayName,
   fontSizeFromSliderPosition,
   formatFontSize,
   formatRgb,
@@ -417,4 +418,11 @@ test("recognizes image MIME types and supported filename extensions", () => {
   assert.equal(isImageFile({ type: "", name: "photo.AVIF" }), true);
   assert.equal(isImageFile({ type: "text/plain", name: "notes.txt" }), false);
   assert.equal(isImageFile(null), false);
+});
+
+test("folder display names omit the canonical prefix without changing stored paths", () => {
+  assert.equal(folderDisplayName("/Newly"), "Newly");
+  assert.equal(folderDisplayName("///Campaign"), "Campaign");
+  assert.equal(folderDisplayName(null), "");
+  assert.equal(folderDisplayName("/Client/Campaign"), "Client/Campaign");
 });


### PR DESCRIPTION
Makes the Slides sidebar parent link larger and easier to click, with a folder icon and a folder name without the leading slash. Folder screens show the project count once in the left heading.

Folder labels omit their canonical slash prefix throughout the UI while storage and routes retain their existing format. Project cards use Lucide’s square-stack icon, and folder names use a slightly heavier weight than project names.

Validation: editor tests, full test suite, build, editor browser smoke test, migration browser test, and local MCP browser test passed. Browser coverage verifies folder labels, navigation, click-target size, project icons, and card title truncation.
