### PR TITLE
Restore connected agent button styling

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -190,6 +190,31 @@ try {
   );
   await evaluate(cdp, "window.carouselBotReady");
 
+  const connectedPill = await evaluate(cdp, `(() => {
+    const button = document.querySelector('.home-agent-connect .agent-connect-button');
+    const previousStatus = button.getAttribute('data-mcp-status');
+    const idle = getComputedStyle(button);
+    const idleBackground = idle.backgroundColor;
+    button.dataset.mcpStatus = 'connected';
+    // Disable transitions so the final connected-state colors can be checked immediately.
+    button.style.transition = 'none';
+    const style = getComputedStyle(button);
+    const result = {
+      border: style.borderTopColor,
+      width: parseFloat(style.borderTopWidth),
+      backgroundChanged: style.backgroundColor !== idleBackground,
+      cloudsHidden: getComputedStyle(button.querySelector('.agent-color-clouds')).display === 'none',
+      calloutHidden: getComputedStyle(document.querySelector('.agent-callout')).display === 'none',
+    };
+    if (previousStatus === null) button.removeAttribute('data-mcp-status');
+    else button.setAttribute('data-mcp-status', previousStatus);
+    button.style.removeProperty('transition');
+    return result;
+  })()`);
+  if (connectedPill.border === 'rgba(0, 0, 0, 0)' || connectedPill.border === 'transparent' || connectedPill.width < 1 || !connectedPill.backgroundChanged || !connectedPill.cloudsHidden || !connectedPill.calloutHidden) {
+    throw new Error(`Connected home button lost its visible pill styling: ${JSON.stringify(connectedPill)}`);
+  }
+
   const initial = await evaluate(cdp, `({
     title: document.title,
     dashboard: Boolean(document.querySelector('.dashboard')),

--- a/styles.css
+++ b/styles.css
@@ -4070,7 +4070,8 @@ input[type="range"]::-webkit-slider-thumb {
 }
 /* Home-screen agent invitation. Decorative motion stays inside the button. */
 .home-agent-connect { position: relative; }
-.home-agent-connect .agent-connect-button { isolation: isolate; overflow: hidden; border-color: transparent; background: #f4efeb; color: #25232b; }
+.home-agent-connect .agent-connect-button { isolation: isolate; overflow: hidden; }
+.home-agent-connect .agent-connect-button:not([data-mcp-status="connected"]) { border-color: transparent; background: #f4efeb; color: #25232b; }
 .agent-color-clouds { position: absolute; inset: 0; z-index: -1; overflow: hidden; border-radius: inherit; pointer-events: none; }
 .agent-color-clouds i { position: absolute; inset: -75% -35%; opacity: .65; filter: blur(7px); background: radial-gradient(ellipse at center,#db946af0 0%,#ecb591c9 25%,#efd0b960 46%,transparent 68%); animation: agent-copper-cloud 19s ease-in-out infinite; }
 .agent-color-clouds i:nth-child(2) { inset: -90% -40%; background: radial-gradient(ellipse at center,#9585e8eb 0%,#b6a5f2ba 24%,#cfc7f960 46%,transparent 69%); animation: agent-violet-cloud 23s ease-in-out infinite; }


### PR DESCRIPTION
The home-screen animation style overrode the connected button background and border, leaving its contents visually unframed. Scope that style to non-connected buttons so the existing green pill styling applies again. Adds a browser regression check for the connected border, background, and hidden decorative elements.