### PR TITLE
Add New folder action to dashboard creation tile

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1771,8 +1771,9 @@ try {
   if (Math.abs(folderCreation - 2) > 0.05) throw new Error('New project tile must use a two-thirds split');
   await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/Created empty folder"]')) && !document.querySelector('[data-folder-create-form]')`), 'Empty folder was not created');
   await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/Created empty folder"]').click()`);
+  await evaluate(cdp, `window.__emptyFolderReloadSentinel = true`);
   await cdp.send('Page.reload');
-  await waitFor(() => evaluate(cdp, `window.carouselBotAgent && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'Created empty folder'`), 'Empty folder did not survive reload');
+  await waitFor(() => evaluate(cdp, `document.readyState === "complete" && !window.__emptyFolderReloadSentinel && window.carouselBotAgent && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'Created empty folder'`), 'Empty folder did not survive reload');
   await evaluate(cdp, `document.querySelector('[data-action="open-dashboard-root"]').click()`);
 
   const folderUiProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Folder UI project' })`);

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1748,6 +1748,33 @@ try {
     return this.carouselBotAgent.execute({ type: 'project.delete', projectId });
   }`, [filmstripProject.projectId]);
 
+  const folderCreation = await evaluate(cdp, `(() => {
+    const trigger = document.querySelector('[data-action="new-folder"]');
+    const projectButton = document.querySelector('.new-project-action');
+    const ratio = projectButton.offsetHeight / trigger.offsetHeight;
+    for (const method of ['cancel', 'close', 'outside', 'escape']) {
+      trigger.click();
+      const dialog = document.querySelector('.folder-dialog');
+      if (document.activeElement !== dialog.querySelector('input')) throw new Error('Folder name must receive focus');
+      if (method === 'cancel') dialog.querySelector('[data-cancel]').click();
+      if (method === 'close') dialog.querySelector('[aria-label="Close"]').click();
+      if (method === 'outside') dialog.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      if (method === 'escape') dialog.querySelector('input').dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      if (document.querySelector('.folder-dialog') || document.activeElement !== trigger) throw new Error('Folder dismissal failed: ' + method);
+    }
+    trigger.click();
+    const form = document.querySelector('[data-folder-create-form]');
+    form.elements.folderName.value = 'Created empty folder';
+    form.requestSubmit();
+    return ratio;
+  })()`);
+  if (Math.abs(folderCreation - 2) > 0.05) throw new Error('New project tile must use a two-thirds split');
+  await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/Created empty folder"]')) && !document.querySelector('[data-folder-create-form]')`), 'Empty folder was not created');
+  await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/Created empty folder"]').click()`);
+  await cdp.send('Page.reload');
+  await waitFor(() => evaluate(cdp, `window.carouselBotAgent && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'Created empty folder'`), 'Empty folder did not survive reload');
+  await evaluate(cdp, `document.querySelector('[data-action="open-dashboard-root"]').click()`);
+
   const folderUiProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Folder UI project' })`);
   const folderUiSlide = await callPageFunction(cdp, `function(projectId) {
     return this.carouselBotAgent.execute({

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -36,6 +36,8 @@ import {
   projectChannel,
   projectChannelSource,
   getAllProjects,
+  getAllFolders,
+  createFolderInDb,
   getProjectFromDb,
   announceProjectChange,
   putProject,
@@ -112,7 +114,7 @@ export function createEditorProjects({
   }
 
   function folderExists(folderPath) {
-    return Boolean(folderPath && projectsInFolder(folderPath).length);
+    return Boolean(folderPath && (projectsInFolder(folderPath).length || state.folders.some((folder) => folderContains(folderPath, folder.path))));
   }
 
   function clearProjectHistory(projectIds) {
@@ -270,6 +272,11 @@ export function createEditorProjects({
   }
 
   async function handleExternalProjectEvent(data) {
+    if (state.db && data?.type === "folders.updated" && data.source !== projectChannelSource) {
+      state.folders = await getAllFolders();
+      if (!state.activeProjectId) { leaveMissingActiveFolder(); renderDashboard(); }
+      return;
+    }
     if (!data || data.source === projectChannelSource || !data.projectId || !state.db) return;
     const local = state.projects.find((project) => project.id === data.projectId);
     if (data.type === "project.deleted" || !local || Number(data.revision) > (Number(local.revision) || 0) || Number(data.updatedAt) > (Number(local.updatedAt) || 0)) {
@@ -440,6 +447,7 @@ export function createEditorProjects({
     // Persist that edit before the folder transaction reads and rewrites records.
     await flushPendingSave();
     const moved = await moveProjectsFromFolderInDb(sourceFolderPath, destinationFolderPath);
+    state.folders = await getAllFolders();
     replaceMovedProjects(moved);
     if (folderContains(sourceFolderPath, state.activeFolderPath)) {
       state.activeFolderPath = movedFolderPath(state.activeFolderPath, sourceFolderPath, destinationFolderPath);
@@ -450,11 +458,78 @@ export function createEditorProjects({
     return moved;
   }
 
+  function showNewFolderDialog(returnFocus) {
+    closeFolderDialog();
+    const parent = state.activeFolderPath || "";
+    const backdrop = document.createElement("div");
+    backdrop.className = "modal-backdrop folder-dialog";
+    backdrop.innerHTML = `
+      <form class="modal new-folder-modal" data-folder-create-form role="dialog" aria-modal="true" aria-labelledby="folder-create-title">
+        <button class="icon-button folder-modal-close" type="button" aria-label="Close"><span aria-hidden="true">×</span></button>
+        <h2 id="folder-create-title">New folder</h2>
+        <input name="folderName" placeholder="Folder name" maxlength="160" autocomplete="off" aria-label="Folder name" required />
+        <div class="modal-actions">
+          <button class="button button--quiet" type="button" data-cancel>Cancel</button>
+          <button class="button button--primary" type="submit">Create</button>
+        </div>
+      </form>`;
+    const form = backdrop.querySelector("form");
+    const input = form.elements.folderName;
+    let saving = false;
+    const close = () => {
+      if (saving) return;
+      backdrop.remove();
+      (returnFocus?.isConnected ? returnFocus : app.querySelector('[data-action="new-folder"]'))?.focus({ preventScroll: true });
+    };
+    backdrop.querySelector("[data-cancel]").addEventListener("click", close);
+    backdrop.querySelector(".folder-modal-close").addEventListener("click", close);
+    backdrop.addEventListener("pointerdown", (event) => { if (event.target === backdrop) close(); });
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") { event.preventDefault(); close(); }
+      if (event.key === "Tab") {
+        const controls = [...form.querySelectorAll("button, input")].filter((item) => !item.disabled);
+        const first = controls[0], last = controls.at(-1);
+        if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
+        else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
+      }
+    });
+    input.addEventListener("input", () => input.setCustomValidity(""));
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (saving) return;
+      const name = input.value.trim();
+      const path = normalizeFolderPath(`${parent}/${name}`);
+      if (!name || name.includes("/") || !path || folderExists(path)) {
+        input.setCustomValidity(folderExists(path) ? "A folder with this name already exists." : "Enter a folder name. Folders support a maximum of two levels.");
+        input.reportValidity();
+        return;
+      }
+      saving = true;
+      const submit = form.querySelector('[type="submit"]');
+      submit.disabled = true;
+      try {
+        await createFolderInDb(path);
+        state.folders = await getAllFolders();
+        renderDashboard();
+        saving = false;
+        close();
+      } catch (error) {
+        saving = false;
+        submit.disabled = false;
+        input.setCustomValidity(error.name === "ConstraintError" ? "A folder with this name already exists." : "Couldn’t save this folder. Please try again.");
+        input.reportValidity();
+      }
+    });
+    document.body.appendChild(backdrop);
+    input.focus();
+    input.select();
+  }
+
   function showProjectMoveDialog(projectId, returnFocus = null) {
     closeFolderDialog();
     const project = state.projects.find((item) => item.id === projectId);
     if (!project) return;
-    const folderPaths = [...new Set(state.projects.flatMap((item) => folderAncestors(item.folderPath)))]
+    const folderPaths = [...new Set([...state.folders.flatMap((item) => folderAncestors(item.path)), ...state.projects.flatMap((item) => folderAncestors(item.folderPath))])]
       .sort((a, b) => a.localeCompare(b));
     const backdrop = document.createElement("div");
     backdrop.className = "modal-backdrop folder-dialog";
@@ -573,7 +648,7 @@ export function createEditorProjects({
   function showFolderUnfileConfirmation(folderPath, returnFocus = null) {
     closeFolderDialog();
     const projectCount = projectsInFolder(folderPath).length;
-    if (!projectCount) return;
+    if (!folderExists(folderPath)) return;
     const backdrop = document.createElement("div");
     backdrop.className = "modal-backdrop folder-dialog";
     backdrop.innerHTML = `
@@ -915,6 +990,7 @@ export function createEditorProjects({
       event.preventDefault();
       openDashboard();
     });
+    app.querySelectorAll('[data-action="new-folder"]').forEach((button) => button.addEventListener("click", () => showNewFolderDialog(button)));
     app.querySelectorAll('[data-action="new-project"]').forEach((button) => button.addEventListener("click", createProject));
     app.querySelectorAll("[data-project-id]").forEach((link) => {
       link.addEventListener("click", (event) => {

--- a/src/editor-state.mjs
+++ b/src/editor-state.mjs
@@ -11,6 +11,7 @@ import {
 
 export const state = {
   projects: [],
+  folders: [],
   activeFolderPath: null,
   activeProjectId: null,
   activeSlideId: null,

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -492,6 +492,11 @@ export function createEditorUI({ projects, actions, output }) {
     const activeFolderPath = state.activeFolderPath;
     document.title = activeFolderPath ? `${folderDisplayName(activeFolderPath)} · CarouselBot` : "CarouselBot";
     const foldersByPath = new Map();
+    for (const folder of state.folders) {
+      for (const path of folderAncestors(folder.path)) {
+        if (folderParentPath(path) === activeFolderPath) foldersByPath.set(path, []);
+      }
+    }
     for (const project of sortedProjects) {
       if (!project.folderPath) continue;
       for (const path of folderAncestors(project.folderPath)) {
@@ -503,7 +508,7 @@ export function createEditorUI({ projects, actions, output }) {
     const folders = [...foldersByPath.entries()].map(([folderPath, folderProjects]) => ({
       folderPath,
       projects: folderProjects,
-      updatedAt: Math.max(...folderProjects.map((project) => Number(project.updatedAt) || 0)),
+      updatedAt: Math.max(0, ...state.folders.filter((folder) => folder.path === folderPath).map((folder) => folder.updatedAt), ...folderProjects.map((project) => Number(project.updatedAt) || 0)),
     }));
     const visibleProjects = activeFolderPath
       ? sortedProjects.filter((project) => project.folderPath === activeFolderPath)
@@ -598,10 +603,10 @@ export function createEditorUI({ projects, actions, output }) {
             ${activeFolderPath ? "" : `<span>${sortedProjects.length} ${sortedProjects.length === 1 ? "project" : "projects"} · ${folders.length} ${folders.length === 1 ? "folder" : "folders"}</span>`}
           </div>
           <div class="project-grid">
-            <button class="new-project-card" type="button" data-action="new-project">
-              <span>+</span>
-              <span><strong>Start a project</strong><small>${activeFolderPath ? `Create it in ${icon("folder")} ${escapeHtml(folderDisplayName(activeFolderPath))}` : "Add photos when you’re ready"}</small></span>
-            </button>
+            <div class="new-project-card">
+              <button class="new-project-action" type="button" data-action="new-project"><span aria-hidden="true">⊕</span> New project</button>
+              <button class="new-folder-action" type="button" data-action="new-folder">${icon("folder")} New folder</button>
+            </div>
             ${cards}
           </div>
         </section>

--- a/src/project-store.mjs
+++ b/src/project-store.mjs
@@ -1,7 +1,7 @@
 import { uid, folderContains, movedFolderPath, normalizeStoredFolderPath } from "./editor-model.mjs";
 import { state } from "./editor-state.mjs";
 
-export const DB_VERSION = 1;
+export const DB_VERSION = 2;
 
 export const STORE_NAME = "projects";
 
@@ -18,6 +18,7 @@ export function openDatabase(databaseName) {
     const request = indexedDB.open(databaseName, DB_VERSION);
     request.onupgradeneeded = () => {
       const db = request.result;
+      if (!db.objectStoreNames.contains("folders")) db.createObjectStore("folders", { keyPath: "path" });
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         db.createObjectStore(STORE_NAME, { keyPath: "id" });
       }
@@ -27,11 +28,33 @@ export function openDatabase(databaseName) {
   });
 }
 
-export function getAllProjects() {
+export async function getAllProjects() {
+  state.folders = await getAllFolders();
   return new Promise((resolve, reject) => {
     const request = state.db.transaction(STORE_NAME, "readonly").objectStore(STORE_NAME).getAll();
     request.onsuccess = () => resolve(request.result || []);
     request.onerror = () => reject(request.error);
+  });
+}
+
+export function getAllFolders() {
+  return new Promise((resolve, reject) => {
+    const request = state.db.transaction("folders", "readonly").objectStore("folders").getAll();
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export function createFolderInDb(path) {
+  return new Promise((resolve, reject) => {
+    const transaction = state.db.transaction("folders", "readwrite");
+    transaction.objectStore("folders").add({ path, updatedAt: Date.now() });
+    transaction.oncomplete = () => {
+      announceProjectEvent({ type: "folders.updated", source: projectChannelSource });
+      resolve();
+    };
+    transaction.onabort = () => reject(transaction.error || new Error("Couldn’t create this folder."));
+    transaction.onerror = () => {};
   });
 }
 
@@ -114,9 +137,21 @@ export function deleteProjectFromDb(projectId, { expectedRevision = null, broadc
 
 export function moveProjectsFromFolderInDb(sourceFolderPath, destinationFolderPath = null) {
   return new Promise((resolve, reject) => {
-    const transaction = state.db.transaction(STORE_NAME, "readwrite");
+    const transaction = state.db.transaction([STORE_NAME, "folders"], "readwrite");
     const store = transaction.objectStore(STORE_NAME);
     const moved = [];
+    const folders = transaction.objectStore("folders");
+    const folderRead = folders.getAll();
+    folderRead.onsuccess = () => {
+      try {
+        for (const folder of folderRead.result) {
+          const path = movedFolderPath(folder.path, sourceFolderPath, destinationFolderPath);
+          if (!folderContains(sourceFolderPath, folder.path)) continue;
+          folders.delete(folder.path);
+          if (path) folders.put({ ...folder, path, updatedAt: Date.now() });
+        }
+      } catch { transaction.abort(); }
+    };
     const read = store.getAll();
     read.onerror = () => reject(read.error);
     read.onsuccess = () => {
@@ -142,6 +177,7 @@ export function moveProjectsFromFolderInDb(sourceFolderPath, destinationFolderPa
       }
     };
     transaction.oncomplete = () => {
+      announceProjectEvent({ type: "folders.updated", source: projectChannelSource });
       moved.forEach((project) => announceProjectChange("project.updated", project));
       resolve(moved);
     };

--- a/styles.css
+++ b/styles.css
@@ -1291,37 +1291,34 @@ button:disabled {
 
 .new-project-card {
   display: grid;
+  grid-template-rows: 2fr 1fr;
+  padding: 0;
   border-style: dashed;
-  place-items: center;
-  color: var(--muted);
   background: var(--card-wash);
-  text-align: center;
 }
 
-.new-project-card span:first-child {
-  display: grid;
-  width: 54px;
-  height: 54px;
-  margin: 0 auto 14px;
-  place-items: center;
-  border: 1px solid var(--ink);
-  border-radius: 50%;
+.new-project-card button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  background: transparent;
   color: var(--ink);
-  font-size: 30px;
-  font-weight: 300;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.new-project-card strong {
-  display: block;
-  color: var(--ink);
-  font-size: 15px;
-}
-
-.new-project-card small {
-  display: block;
-  margin-top: 5px;
-  font-size: 12px;
-}
+.new-project-card .new-folder-action { border-top: 1px dashed var(--line); }
+.new-project-card button:hover { background: var(--panel); }
+.new-project-card button:focus-visible { outline: 2px solid var(--ink); outline-offset: -5px; }
+.new-project-card svg { width: 21px; height: 21px; }
+.new-project-action span { font-size: 26px; font-weight: 400; }
+.new-folder-modal { position: relative; }
+.new-folder-modal h2 { padding-right: 35px; }
+.folder-modal-close { position: absolute; top: 16px; right: 16px; }
 
 .editor-shell {
   display: grid;

--- a/test/project-store.test.mjs
+++ b/test/project-store.test.mjs
@@ -15,7 +15,7 @@ const {
 test.after(() => projectChannel?.close());
 
 test("keeps stable browser-storage protocol identifiers", () => {
-  assert.equal(DB_VERSION, 1);
+  assert.equal(DB_VERSION, 2);
   assert.equal(STORE_NAME, "projects");
   assert.equal(PROJECT_CHANNEL_NAME, "carouselbot-projects-v1");
   assert.equal(PROJECT_SYNC_STORAGE_KEY, "carouselbot:project-change");


### PR DESCRIPTION
Split the dashboard creation tile into a two-thirds New project button and a one-third New folder button. New folder opens a focused name input with Create, Cancel, close, outside-click, and Escape controls.

Persist empty folders in IndexedDB and include them in folder navigation, rename/move operations, and cross-tab updates. Existing project storage and revision checks are preserved.

Validation: all required editor, unit, build, migration browser, and local MCP browser checks passed. Browser coverage verifies the split ratio, autofocus, dismissal paths, creation, and persistence after reload.
