### PR TITLE
Show nested folder collages in dashboard previews

### DIFF
--- a/scripts/test-domain-migration-browser.mjs
+++ b/scripts/test-domain-migration-browser.mjs
@@ -95,7 +95,7 @@ try {
   await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not load.");
 
   await evaluate(legacyCdp, `new Promise((resolve, reject) => {
-    const request = indexedDB.open("slide-studio-db", 1);
+    const request = indexedDB.open("slide-studio-db");
     request.onupgradeneeded = () => request.result.createObjectStore("projects", { keyPath: "id" });
     request.onerror = () => reject(request.error);
     request.onsuccess = () => {
@@ -109,7 +109,10 @@ try {
       transaction.onerror = () => reject(transaction.error);
     };
   })`);
+  await evaluate(legacyCdp, "window.__migrationReloadPending = true");
   await legacyCdp.send("Page.reload");
+  await waitFor(() => evaluate(legacyCdp, "!window.__migrationReloadPending && document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not finish reloading.");
+  await evaluate(legacyCdp, "window.carouselBotReady");
   await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-action=\"migrate-projects\"]')?.textContent.includes('project')"), "Migration prompt did not find the legacy project.");
   const modalState = await evaluate(legacyCdp, `(() => {
     const modal = document.querySelector('[data-migration-modal] [role="dialog"]');
@@ -119,7 +122,10 @@ try {
   if (!modalState.visible || modalState.modal !== "true" || !modalState.hasClose) throw new Error(`Migration notice is not an accessible, closeable modal: ${JSON.stringify(modalState)}`);
   await evaluate(legacyCdp, `document.querySelector('[data-action="close-migration-modal"]').click()`);
   await waitFor(() => evaluate(legacyCdp, `!document.querySelector('[data-migration-modal]')`), "Migration modal did not close.");
+  await evaluate(legacyCdp, "window.__migrationReloadPending = true");
   await legacyCdp.send("Page.reload");
+  await waitFor(() => evaluate(legacyCdp, "!window.__migrationReloadPending && document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not finish reloading.");
+  await evaluate(legacyCdp, "window.carouselBotReady");
   await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-action=\"migrate-projects\"]')?.textContent.includes('project')"), "Migration modal did not return after a fresh page load.");
   await evaluate(legacyCdp, `(() => {
     document.querySelector('[data-action="migrate-projects"]').scrollIntoView({ block: "center" });

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1774,7 +1774,18 @@ try {
   await evaluate(cdp, `window.__emptyFolderReloadSentinel = true`);
   await cdp.send('Page.reload');
   await waitFor(() => evaluate(cdp, `document.readyState === "complete" && !window.__emptyFolderReloadSentinel && window.carouselBotAgent && document.querySelector('.folder-dashboard-title')?.textContent.trim() === 'Created empty folder'`), 'Empty folder did not survive reload');
+  await evaluate(cdp, `(() => {
+    document.querySelector('[data-action="new-folder"]').click();
+    const form = document.querySelector('[data-folder-create-form]');
+    form.elements.folderName.value = 'Empty child';
+    form.requestSubmit();
+  })()`);
+  await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/Created empty folder/Empty child"]'))`), 'Empty subfolder was not created');
   await evaluate(cdp, `document.querySelector('[data-action="open-dashboard-root"]').click()`);
+  await waitFor(() => evaluate(cdp, `(() => {
+    const tile = document.querySelector('.folder-card[data-folder-path="/Created empty folder"] .folder-preview-subfolder');
+    return tile?.title === 'Empty child' && tile.querySelectorAll('.folder-preview-mini').length === 4 && Boolean(tile.querySelector('.folder-preview-folder-mark svg'));
+  })()`), 'Empty subfolder did not appear in its parent preview');
 
   const folderUiProject = await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.create', name: 'Folder UI project' })`);
   const folderUiSlide = await callPageFunction(cdp, `function(projectId) {

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -432,6 +432,15 @@ try {
   const nestedInspection = (await tool("inspect_editor")).structuredContent;
   if (!nestedInspection.folders.some((folder) => folder.path === "/Client" && folder.projectCount === 1)
     || !nestedInspection.folders.some((folder) => folder.path === "/Client/Account" && folder.parentPath === "/Client")) throw new Error("MCP did not expose the nested hierarchy");
+  await waitFor(() => evaluate(cdp, `(() => {
+    const preview = document.querySelector('.folder-card[data-folder-path="/Client"] .folder-preview');
+    const subfolder = preview?.querySelector('.folder-preview-subfolder');
+    const cover = subfolder?.querySelector('[data-project-cover-id="${createdProject.projectId}"] img[data-composite-cover="true"]');
+    const mark = subfolder?.querySelector('.folder-preview-folder-mark');
+    return preview?.children.length === 8 && subfolder?.querySelectorAll('.folder-preview-mini').length === 4
+      && subfolder.title === 'Account' && mark?.querySelector('svg') && getComputedStyle(mark).color === 'rgb(255, 255, 255)'
+      && Boolean(cover) && !preview?.querySelector(':scope > [data-project-cover-id]');
+  })()`), "Parent folder preview did not group its child into a dimmed 2x2 collage with a white folder icon");
   await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/Client"]').click()`);
   await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/Client/Account"]')) && !document.querySelector('.project-card')`), "Parent folder did not show its account subfolder");
   await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/Client/Account"]').click()`);

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -154,8 +154,13 @@ export function normalizeStoredFolderPath(value) {
   return normalizeFolderPath(parts.length > 2 ? `${parts[0]}/${parts.slice(1).join(" ∕ ")}` : value);
 }
 
-export function folderPreviewItems(projects, folderPath) {
+export function folderPreviewItems(projects, folderPath, folders = []) {
   const children = new Map();
+  for (const folder of folders) {
+    if (folderParentPath(folder.path) === folderPath) {
+      children.set(folder.path, { type: "folder", path: folder.path, projects: [], updatedAt: Number(folder.updatedAt) || 0 });
+    }
+  }
   const direct = [];
   for (const project of projects) {
     if (!folderContains(folderPath, project.folderPath)) continue;

--- a/src/editor-model.mjs
+++ b/src/editor-model.mjs
@@ -154,6 +154,27 @@ export function normalizeStoredFolderPath(value) {
   return normalizeFolderPath(parts.length > 2 ? `${parts[0]}/${parts.slice(1).join(" ∕ ")}` : value);
 }
 
+export function folderPreviewItems(projects, folderPath) {
+  const children = new Map();
+  const direct = [];
+  for (const project of projects) {
+    if (!folderContains(folderPath, project.folderPath)) continue;
+    if (project.folderPath === folderPath) {
+      direct.push({ type: "project", project, updatedAt: Number(project.updatedAt) || 0 });
+      continue;
+    }
+    const path = `${folderPath}/${project.folderPath.slice(folderPath.length + 1).split("/")[0]}`;
+    if (!children.has(path)) children.set(path, { type: "folder", path, projects: [], updatedAt: 0 });
+    const child = children.get(path);
+    child.projects.push(project);
+    child.updatedAt = Math.max(child.updatedAt, Number(project.updatedAt) || 0);
+  }
+  const recentFirst = (a, b) => b.updatedAt - a.updatedAt;
+  for (const child of children.values()) child.projects.sort(recentFirst);
+  // Show subfolders first so their contents cannot crowd them out of the preview.
+  return [...children.values()].sort(recentFirst).concat(direct.sort(recentFirst));
+}
+
 export function folderParentPath(value) {
   const path = String(value || "");
   const index = path.lastIndexOf("/");

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -8,6 +8,7 @@ import {
   folderDisplayName,
   folderParentPath,
   folderAncestors,
+  folderPreviewItems,
   adjacentSlideId,
   escapeHtml,
   normalizeHexColor,
@@ -540,19 +541,35 @@ export function createEditorUI({ projects, actions, output }) {
       `;
     };
 
+    const renderFolderProjectPreview = (project, extraClass = "", more = "") => {
+      if (!project) return `<span class="folder-preview-slot ${extraClass}" aria-hidden="true"></span>`;
+      const slide = project.slides[0];
+      const cover = slide ? state.projectCoverUrls.get(project.id) || slide.imageData : null;
+      return `
+        <span class="folder-preview-slot ${extraClass}" data-project-cover-id="${project.id}" aria-hidden="true">
+          ${cover ? `<img src="${cover}" alt=""${state.projectCoverUrls.has(project.id) ? ' data-composite-cover="true"' : ""} />` : ""}
+          ${more}
+        </span>
+      `;
+    };
+
     const renderFolderCard = (folder) => {
-      const overflow = Math.max(0, folder.projects.length - 8);
+      const items = folderPreviewItems(folder.projects, folder.folderPath);
+      const overflow = Math.max(0, items.length - 8);
       const slots = Array.from({ length: 8 }, (_, index) => {
-        const project = folder.projects[index];
-        if (!project) return '<span class="folder-preview-slot" aria-hidden="true"></span>';
-        const slide = project.slides[0];
-        const cover = slide ? state.projectCoverUrls.get(project.id) || slide.imageData : null;
-        return `
-          <span class="folder-preview-slot" data-project-cover-id="${project.id}" aria-hidden="true">
-            ${cover ? `<img src="${cover}" alt=""${state.projectCoverUrls.has(project.id) ? " data-composite-cover=\"true\"" : ""} />` : ""}
-            ${overflow && index === 7 ? `<span class="folder-preview-more">+${overflow}</span>` : ""}
-          </span>
-        `;
+        const item = items[index];
+        const more = overflow && index === 7 ? `<span class="folder-preview-more">+${overflow}</span>` : "";
+        if (item?.type === "folder") {
+          const name = item.path.split("/").at(-1);
+          return `
+            <span class="folder-preview-slot folder-preview-subfolder" title="${escapeHtml(name)}" aria-hidden="true">
+              <span class="folder-preview-collage">${Array.from({ length: 4 }, (_, cell) => renderFolderProjectPreview(item.projects[cell], "folder-preview-mini")).join("")}</span>
+              <span class="folder-preview-folder-mark">${icon("folder")}<span>${escapeHtml(name)}</span></span>
+              ${more}
+            </span>
+          `;
+        }
+        return renderFolderProjectPreview(item?.project, "", more);
       }).join("");
       return `
         <a class="folder-card" href="${folderRoutePath(folder.folderPath)}" data-folder-path="${escapeHtml(folder.folderPath)}" aria-haspopup="menu" aria-label="Open folder ${escapeHtml(folder.folderPath.split("/").at(-1))}. Right-click for actions." title="Right-click for actions">

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -559,7 +559,7 @@ export function createEditorUI({ projects, actions, output }) {
     };
 
     const renderFolderCard = (folder) => {
-      const items = folderPreviewItems(folder.projects, folder.folderPath);
+      const items = folderPreviewItems(folder.projects, folder.folderPath, state.folders);
       const overflow = Math.max(0, items.length - 8);
       const slots = Array.from({ length: 8 }, (_, index) => {
         const item = items[index];

--- a/styles.css
+++ b/styles.css
@@ -1196,6 +1196,53 @@ button:disabled {
   font-size: 0;
 }
 
+.folder-preview-collage {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 2px;
+  filter: grayscale(0.45);
+}
+
+.folder-preview-mini {
+  border-radius: 2px;
+}
+
+.folder-preview-folder-mark {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 5px;
+  color: #fff;
+  background: rgba(32, 34, 32, 0.48);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+.folder-preview-folder-mark svg {
+  width: 52%;
+  height: auto;
+  max-width: 44px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
+}
+
+.folder-preview-folder-mark > span {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  font-size: 10px;
+  font-weight: 750;
+  line-height: 1.2;
+}
+
 .folder-preview-more {
   position: absolute;
   inset: 0;

--- a/styles.css
+++ b/styles.css
@@ -1235,8 +1235,9 @@ button:disabled {
 .folder-preview-folder-mark > span {
   width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   text-align: center;
   font-size: 10px;
   font-weight: 750;

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -493,4 +493,8 @@ test("folder previews represent direct children without flattening subfolder pro
   assert.deepEqual(items[0].projects.map(project => project.id), ["a2", "a1"]);
   assert.deepEqual(folderPreviewItems(projects, "/Client/A").map(item => item.project.id), ["a2", "a1"]);
   assert.equal(projects[1].id, "a1");
+  const empty = folderPreviewItems([], "/Client", [{ path: "/Client/Empty", updatedAt: 4 }, { path: "/Other/Empty", updatedAt: 5 }]);
+  assert.equal(empty.length, 1);
+  assert.equal(empty[0].path, "/Client/Empty");
+  assert.deepEqual(empty[0].projects, []);
 });

--- a/test/editor-model.test.mjs
+++ b/test/editor-model.test.mjs
@@ -19,6 +19,7 @@ import {
   duplicateProjectData,
   folderParentPath,
   folderAncestors,
+  folderPreviewItems,
   folderContains,
   movedFolderPath,
   normalizeStoredFolderPath,
@@ -476,4 +477,20 @@ test("duplicates entire projects with independent IDs and preserved content", ()
   assert.equal(duplicateProjectData(source).folderPath, "/Client");
   assert.equal(duplicateProjectData(source, { folderPath: null }).folderPath, null);
   assert.throws(() => duplicateProjectData(source, { folderPath: "/a/b/c" }), /two folder levels/);
+});
+
+
+test("folder previews represent direct children without flattening subfolder projects", () => {
+  const projects = [
+    { id: "direct", folderPath: "/Client", updatedAt: 99 },
+    { id: "a1", folderPath: "/Client/A", updatedAt: 1 },
+    { id: "a2", folderPath: "/Client/A", updatedAt: 3 },
+    { id: "b1", folderPath: "/Client/B", updatedAt: 2 },
+    { id: "other", folderPath: "/Client2", updatedAt: 100 },
+  ];
+  const items = folderPreviewItems(projects, "/Client");
+  assert.deepEqual(items.map(item => item.path || item.project.id), ["/Client/A", "/Client/B", "direct"]);
+  assert.deepEqual(items[0].projects.map(project => project.id), ["a2", "a1"]);
+  assert.deepEqual(folderPreviewItems(projects, "/Client/A").map(item => item.project.id), ["a2", "a1"]);
+  assert.equal(projects[1].id, "a1");
 });


### PR DESCRIPTION
Home folder previews now represent immediate contents instead of flattening every descendant carousel. Empty and populated subfolders appear first as dimmed 2×2 cover collages with a large white folder icon and a small name label, making A/B folders easy to distinguish. Direct projects retain their existing cover tiles, and overflow counts hidden preview items.

Reuse the existing asynchronous project-cover rendering for each collage cell. No storage, MCP protocol, or package changes.

Validation: model coverage checks grouping and ordering; real-browser coverage checks the four collage cells, folder icon, and fully rendered nested cover. Full repository and browser gates passed. Updated the migration test fixture to open the existing database version and wait for a fresh page after reload, following the concurrent folder-storage upgrade.
