### PR TITLE
Fix blank startup when old tabs block storage upgrade

### DIFF
--- a/scripts/test-domain-migration-browser.mjs
+++ b/scripts/test-domain-migration-browser.mjs
@@ -94,6 +94,8 @@ try {
   await legacyCdp.send("Page.navigate", { url: legacyUrl });
   await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not load.");
 
+  await evaluate(legacyCdp, "window.carouselBotReady");
+
   await evaluate(legacyCdp, `new Promise((resolve, reject) => {
     const request = indexedDB.open("slide-studio-db");
     request.onupgradeneeded = () => request.result.createObjectStore("projects", { keyPath: "id" });
@@ -109,7 +111,10 @@ try {
       transaction.onerror = () => reject(transaction.error);
     };
   })`);
+  await evaluate(legacyCdp, "window.__migrationReloadPending = true");
   await legacyCdp.send("Page.reload");
+  await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && !window.__migrationReloadPending && Boolean(window.carouselBotReady)"), "Migration page did not reload.");
+  await evaluate(legacyCdp, "window.carouselBotReady");
   await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-action=\"migrate-projects\"]')?.textContent.includes('project')"), "Migration prompt did not find the legacy project.");
   const modalState = await evaluate(legacyCdp, `(() => {
     const modal = document.querySelector('[data-migration-modal] [role="dialog"]');
@@ -119,7 +124,10 @@ try {
   if (!modalState.visible || modalState.modal !== "true" || !modalState.hasClose) throw new Error(`Migration notice is not an accessible, closeable modal: ${JSON.stringify(modalState)}`);
   await evaluate(legacyCdp, `document.querySelector('[data-action="close-migration-modal"]').click()`);
   await waitFor(() => evaluate(legacyCdp, `!document.querySelector('[data-migration-modal]')`), "Migration modal did not close.");
+  await evaluate(legacyCdp, "window.__migrationReloadPending = true");
   await legacyCdp.send("Page.reload");
+  await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && !window.__migrationReloadPending && Boolean(window.carouselBotReady)"), "Migration page did not reload.");
+  await evaluate(legacyCdp, "window.carouselBotReady");
   await waitFor(() => evaluate(legacyCdp, "document.querySelector('[data-action=\"migrate-projects\"]')?.textContent.includes('project')"), "Migration modal did not return after a fresh page load.");
   await evaluate(legacyCdp, `(() => {
     document.querySelector('[data-action="migrate-projects"]').scrollIntoView({ block: "center" });

--- a/scripts/test-domain-migration-browser.mjs
+++ b/scripts/test-domain-migration-browser.mjs
@@ -95,7 +95,7 @@ try {
   await waitFor(() => evaluate(legacyCdp, "document.readyState === 'complete' && Boolean(window.carouselBotReady)"), "Legacy editor did not load.");
 
   await evaluate(legacyCdp, `new Promise((resolve, reject) => {
-    const request = indexedDB.open("slide-studio-db", 1);
+    const request = indexedDB.open("slide-studio-db");
     request.onupgradeneeded = () => request.result.createObjectStore("projects", { keyPath: "id" });
     request.onerror = () => reject(request.error);
     request.onsuccess = () => {
@@ -105,7 +105,7 @@ try {
         assets: [{ id: "asset-1", name: "Pixel", imageData: "data:image/png;base64,iVBORw0KGgo=", width: 1, height: 1 }],
         slides: [{ id: "slide-1", name: "Slide 1", width: 1080, height: 1920, imageData: null, texts: [], overlays: [] }]
       });
-      transaction.oncomplete = () => resolve(true);
+      transaction.oncomplete = () => { request.result.close(); resolve(true); };
       transaction.onerror = () => reject(transaction.error);
     };
   })`);
@@ -166,5 +166,5 @@ try {
   chrome.kill("SIGTERM");
   legacyWeb.kill("SIGTERM");
   canonicalWeb.kill("SIGTERM");
-  await rm(profile, { recursive: true, force: true });
+  await rm(profile, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 }

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -182,13 +182,33 @@ try {
   await cdp.send("Runtime.enable");
   await cdp.send("Log.enable");
   await cdp.send("Page.enable");
+  // Simulate a pre-update tab retaining the v1 database connection.
+  const legacySetup = await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: `
+    const legacyRequest = indexedDB.open('carouselbot-db', 1);
+    legacyRequest.onupgradeneeded = () => legacyRequest.result.createObjectStore('projects', { keyPath: 'id' });
+    legacyRequest.onsuccess = () => {
+      window.__legacyDatabase = legacyRequest.result;
+      const transaction = legacyRequest.result.transaction('projects', 'readwrite');
+      transaction.objectStore('projects').put({ id: 'upgrade-preserved', name: 'Upgrade preserved project', slides: [], assets: [], revision: 1 });
+    };
+  ` });
   await cdp.send("Page.navigate", { url: pageUrl });
+  await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('[data-storage-blocked]'))`),
+    'An older tab blocking the database upgrade left the app blank.');
+  await evaluate(cdp, `window.__legacyDatabase.close()`);
+  await cdp.send('Page.removeScriptToEvaluateOnNewDocument', { identifier: legacySetup.identifier });
+
 
   await waitFor(
     () => evaluate(cdp, "document.readyState === 'complete' && Boolean(window.carouselBotAgent) && Boolean(window.carouselBotReady)"),
     "The modular editor did not finish loading.",
   );
   await evaluate(cdp, "window.carouselBotReady");
+  const preserved = await evaluate(cdp, `window.carouselBotAgent.inspect().projects.some((project) => project.id === 'upgrade-preserved' && project.name === 'Upgrade preserved project')`);
+  if (!preserved) throw new Error('Database upgrade lost the existing project');
+  await evaluate(cdp, `window.carouselBotAgent.execute({ type: 'project.delete', projectId: 'upgrade-preserved' })`);
+  if (await evaluate(cdp, `Boolean(document.querySelector('[data-storage-blocked]'))`)) throw new Error('Startup did not recover after closing the older connection');
+
 
   const connectedPill = await evaluate(cdp, `(() => {
     const button = document.querySelector('.home-agent-connect .agent-connect-button');

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -483,6 +483,17 @@ export function createEditorUI({ projects, actions, output }) {
     showInstalledFontBrowser(backdrop);
   }
 
+  function renderStorageBlocked() {
+    app.innerHTML = `
+      <main class="dashboard" data-storage-blocked role="status">
+        <section class="modal">
+          <h2>Close your other CarouselBot tabs</h2>
+          <p>Save your work and close the other CarouselBot tabs in this browser so this update can finish. This page will continue automatically.</p>
+          <p>Your projects are still stored in this browser. Do not clear your browser data.</p>
+        </section>
+      </main>`;
+  }
+
   function renderDashboard() {
     hideAssetPreview();
     state.activeProjectId = null;
@@ -1565,6 +1576,7 @@ export function createEditorUI({ projects, actions, output }) {
   return {
     toast,
     renderDashboard,
+    renderStorageBlocked,
     renderEditor,
     navigateSlides,
     refreshSelection,

--- a/src/editor.mjs
+++ b/src/editor.mjs
@@ -64,7 +64,11 @@ export const fileToDataUrl = editorActions.fileToDataUrl;
 
 export async function init() {
   try {
-    state.db = await openDatabase(DB_NAME);
+    state.db = await openDatabase(DB_NAME, {
+      onBlocked: editorUI.renderStorageBlocked,
+      beforeVersionChange: () => editorProjects.flushPendingSave(),
+      onVersionChange: () => window.location.reload(),
+    });
     state.projects = await getAllProjects();
     normalizeLoadedProjects(state.projects);
   } catch (error) {

--- a/src/project-store.mjs
+++ b/src/project-store.mjs
@@ -13,7 +13,7 @@ export const projectChannel = typeof BroadcastChannel === "function" ? new Broad
 
 export const projectChannelSource = crypto.randomUUID?.() || `${Date.now()}-${Math.random()}`;
 
-export function openDatabase(databaseName) {
+export function openDatabase(databaseName, { onBlocked = () => {}, beforeVersionChange = async () => {}, onVersionChange = () => {} } = {}) {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(databaseName, DB_VERSION);
     request.onupgradeneeded = () => {
@@ -23,7 +23,21 @@ export function openDatabase(databaseName) {
         db.createObjectStore(STORE_NAME, { keyPath: "id" });
       }
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onblocked = () => onBlocked();
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = async () => {
+        try {
+          await beforeVersionChange();
+          db.close();
+          onVersionChange();
+        } catch (error) {
+          // Keep the connection and unsaved edits available if flushing fails.
+          console.error("Could not save before updating browser storage", error);
+        }
+      };
+      resolve(db);
+    };
     request.onerror = () => reject(request.error);
   });
 }


### PR DESCRIPTION
Opening the updated app while an older CarouselBot tab holds the previous IndexedDB version could block startup indefinitely and leave the page blank. Show a recovery message while the upgrade is blocked, then continue automatically once the older tabs close. Future version changes flush pending edits, release the database connection, and reload the tab.

The browser regression test holds a v1 connection open, verifies the recovery screen, closes it, and verifies startup resumes with the existing project preserved. The migration fixture opens the current schema and closes its seed connection; profile cleanup retries Chrome shutdown writes.
