### PR TITLE
Handle startup queued behind a blocked database upgrade

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -185,6 +185,10 @@ try {
   // Simulate a pre-update tab retaining the v1 database connection.
   const legacySetup = await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: `
     const legacyRequest = indexedDB.open('carouselbot-db', 1);
+    // Queue another upgrade first, as happens when the user already has a blank tab.
+    const queuedUpgrade = indexedDB.open('carouselbot-db', 2);
+    queuedUpgrade.onupgradeneeded = () => queuedUpgrade.result.createObjectStore('folders', { keyPath: 'path' });
+    queuedUpgrade.onsuccess = () => queuedUpgrade.result.close();
     legacyRequest.onupgradeneeded = () => legacyRequest.result.createObjectStore('projects', { keyPath: 'id' });
     legacyRequest.onsuccess = () => {
       window.__legacyDatabase = legacyRequest.result;

--- a/src/project-store.mjs
+++ b/src/project-store.mjs
@@ -16,6 +16,9 @@ export const projectChannelSource = crypto.randomUUID?.() || `${Date.now()}-${Ma
 export function openDatabase(databaseName, { onBlocked = () => {}, beforeVersionChange = async () => {}, onVersionChange = () => {} } = {}) {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(databaseName, DB_VERSION);
+    // A request queued behind another tab's blocked upgrade receives no blocked event.
+    // Surface recovery guidance even when the browser never dispatches that event here.
+    const blockedTimer = setTimeout(onBlocked, 1500);
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains("folders")) db.createObjectStore("folders", { keyPath: "path" });
@@ -25,6 +28,7 @@ export function openDatabase(databaseName, { onBlocked = () => {}, beforeVersion
     };
     request.onblocked = () => onBlocked();
     request.onsuccess = () => {
+      clearTimeout(blockedTimer);
       const db = request.result;
       db.onversionchange = async () => {
         try {
@@ -38,7 +42,7 @@ export function openDatabase(databaseName, { onBlocked = () => {}, beforeVersion
       };
       resolve(db);
     };
-    request.onerror = () => reject(request.error);
+    request.onerror = () => { clearTimeout(blockedTimer); reject(request.error); };
   });
 }
 


### PR DESCRIPTION
A tab queued behind another tab's blocked IndexedDB upgrade does not receive its own blocked event. After 1.5 seconds, display the same recovery guidance while continuing to wait for storage; clear the timer on success or failure.

Extend the real-browser regression test to queue a second upgrade ahead of app startup, matching the live multi-tab failure. Verify recovery and preservation of existing projects.
