### PR TITLE
Make folder back link navigate to the parent

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1805,7 +1805,12 @@ try {
     form.requestSubmit();
   })()`);
   await waitFor(() => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/Created empty folder/Empty child"]'))`), 'Empty subfolder was not created');
-  await evaluate(cdp, `document.querySelector('[data-action="open-dashboard-root"]').click()`);
+  await evaluate(cdp, `document.querySelector('.folder-card[data-folder-path="/Created empty folder/Empty child"]').click()`);
+  await waitFor(() => evaluate(cdp, `location.pathname === '/folders/Created%20empty%20folder%2FEmpty%20child' && document.querySelectorAll('.folder-breadcrumb').length === 1 && document.querySelector('.folder-breadcrumb')?.textContent.trim() === 'Created empty folder' && document.querySelector('.folder-breadcrumb')?.getAttribute('href') === '/folders/Created%20empty%20folder'`), 'Nested folder must show one back link named for its parent');
+  await evaluate(cdp, `document.querySelector('.folder-breadcrumb').click()`);
+  await waitFor(() => evaluate(cdp, `location.pathname === '/folders/Created%20empty%20folder' && document.querySelectorAll('.folder-breadcrumb').length === 1 && document.querySelector('.folder-breadcrumb')?.textContent.trim() === 'Home'`), 'Back from a nested folder must open its parent and show Home');
+  await evaluate(cdp, `document.querySelector('.folder-breadcrumb').click()`);
+  await waitFor(() => evaluate(cdp, `location.pathname === '/' && !document.querySelector('.folder-dashboard-title')`), 'Second back click must open Home');
   await waitFor(() => evaluate(cdp, `(() => {
     const tile = document.querySelector('.folder-card[data-folder-path="/Created empty folder"] .folder-preview-subfolder');
     return tile?.title === 'Empty child' && tile.querySelectorAll('.folder-preview-mini').length === 4 && Boolean(tile.querySelector('.folder-preview-folder-mark svg'));

--- a/scripts/test-mcp-browser-local.mjs
+++ b/scripts/test-mcp-browser-local.mjs
@@ -448,6 +448,8 @@ try {
   await evaluate(cdp, `window.__nestedFolderReload = true`);
   await cdp.send("Page.reload");
   await waitFor(() => evaluate(cdp, `Boolean(!window.__nestedFolderReload && document.readyState === "complete" && window.carouselBotAgent && document.querySelector('.folder-breadcrumb[data-folder-path="/Client"]'))`), "Nested folder reload failed");
+  await evaluate(cdp, `document.querySelector('.folder-breadcrumb[data-folder-path="/Client"]').click()`);
+  await waitFor(() => evaluate(cdp, `location.pathname === '/folders/Client' && document.querySelector('.folder-breadcrumb')?.textContent.trim() === 'Home'`), "Nested folder back link did not return to its parent");
   await evaluate(cdp, `document.querySelector('[data-action="open-dashboard-root"]').click()`);
   await evaluate(cdp, `(() => {
     document.querySelector('.folder-card[data-folder-path="/Client"]').dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -611,8 +611,9 @@ export function createEditorUI({ projects, actions, output }) {
         ${activeFolderPath ? `
           <section class="folder-dashboard-header">
             <div>
-              <a class="folder-breadcrumb" href="/" data-action="open-dashboard-root">${icon("back")} Home</a>
-              ${folderParentPath(activeFolderPath) ? `<a class="folder-breadcrumb" href="${folderRoutePath(folderParentPath(activeFolderPath))}" data-folder-path="${escapeHtml(folderParentPath(activeFolderPath))}"> / ${escapeHtml(folderDisplayName(folderParentPath(activeFolderPath)))}</a>` : ""}
+              ${folderParentPath(activeFolderPath)
+                ? `<a class="folder-breadcrumb" href="${folderRoutePath(folderParentPath(activeFolderPath))}" data-folder-path="${escapeHtml(folderParentPath(activeFolderPath))}">${icon("back")} ${escapeHtml(folderDisplayName(folderParentPath(activeFolderPath)))}</a>`
+                : `<a class="folder-breadcrumb" href="/" data-action="open-dashboard-root">${icon("back")} Home</a>`}
               <h1 class="folder-dashboard-title">${icon("folder")}<span>${escapeHtml(activeFolderPath.split("/").at(-1))}</span></h1>
             </div>
           </section>


### PR DESCRIPTION
Replace the separate Home and parent links with one back link. Subfolders show their parent name; top-level folders show Home, so two clicks in the same position return from a subfolder to Home.

Validation: editor unit tests, full npm test, build, editor browser tests, migration browser tests, and local MCP browser tests passed. Browser coverage verifies the two-click navigation.