### PR TITLE
Show full folder names and add ordered All downloads

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1412,7 +1412,7 @@ try {
     const activation = {};
     Object.defineProperty(activation, 'isActive', { get: () => output.activation });
     Object.defineProperty(navigator, 'userActivation', { configurable: true, value: activation });
-    const labels = Object.fromEntries(['export', 'share', 'share-all'].map((action) => {
+    const labels = Object.fromEntries(['export', 'export-all', 'share', 'share-all'].map((action) => {
       const button = document.querySelector('[data-action="' + action + '"]');
       return [action, button.innerHTML];
     }));
@@ -1422,6 +1422,20 @@ try {
   await waitFor(
     () => evaluate(cdp, `window.__browserOutput.downloads[0]?.width === 1080 && !document.querySelector('[data-action="export"]').disabled`),
     "Downloading from the native toolbar did not finish.",
+  );
+  const allDownloadButton = await evaluate(cdp, `(() => {
+    const button = document.querySelector('[data-action="export-all"]');
+    const result = { label: button.textContent.trim(), icon: Boolean(button.querySelector('svg')), previous: button.previousElementSibling?.dataset.action };
+    button.click();
+    button.click();
+    return result;
+  })()`);
+  if (allDownloadButton.label !== 'All' || !allDownloadButton.icon || allDownloadButton.previous !== 'export') {
+    throw new Error('The All download button must follow PNG and include the download icon.');
+  }
+  await waitFor(
+    () => evaluate(cdp, `window.__browserOutput.downloads.length === 3 && window.__browserOutput.downloads.every((item) => item.width) && !document.querySelector('[data-action="export-all"]').disabled`),
+    "Downloading all slides did not finish exactly once.",
   );
   await evaluate(cdp, `document.querySelector('[data-action="share"]').click()`);
   await waitFor(
@@ -1442,7 +1456,7 @@ try {
   const nativeOutput = await waitFor(
     () => evaluate(cdp, `window.__browserOutput.shares.length === 2 ? ({
       ...window.__browserOutput,
-      buttons: Object.fromEntries(['export', 'share', 'share-all'].map((action) => {
+      buttons: Object.fromEntries(['export', 'export-all', 'share', 'share-all'].map((action) => {
         const button = document.querySelector('[data-action="' + action + '"]');
         return [action, { disabled: button.disabled, html: button.innerHTML }];
       })),
@@ -1461,6 +1475,8 @@ try {
     || !nativeOutput.downloads[0].href.startsWith("blob:")
     || nativeOutput.downloads[0].width !== 1080
     || nativeOutput.downloads[0].height !== 1080
+    || JSON.stringify(nativeOutput.downloads.slice(1).map((item) => item.download)) !== JSON.stringify(['browser-regression-project-slide-01.png', 'browser-regression-project-slide-02.png'])
+    || JSON.stringify(nativeOutput.downloads.slice(1).map((item) => [item.width, item.height])) !== JSON.stringify([[1080, 1080], [1080, 1620]])
     || nativeOutput.shares[0].title !== "Browser regression project"
     || nativeOutput.shares[0].files.length !== 1
     || nativeOutput.shares[0].files[0].name !== expectedSingleName

--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1894,6 +1894,24 @@ try {
   if (parentLinkSize.fontSize < 18 || parentLinkSize.height < 48 || parentLinkSize.iconWidth < 24) {
     throw new Error('The folder link must remain large and easy to click: ' + JSON.stringify(parentLinkSize));
   }
+  const wrappedFolderNames = await evaluate(cdp, `(() => {
+    const link = document.querySelector('.slide-rail-back');
+    const label = link.querySelector('span');
+    const original = label.textContent;
+    const singleLineHeight = label.getBoundingClientRect().height;
+    const results = ['Newly/AI Slide Projects with a long folder name', 'A'.repeat(100)].map((name) => {
+      label.textContent = name;
+      const bounds = label.getBoundingClientRect();
+      const linkBounds = link.getBoundingClientRect();
+      return bounds.height > singleLineHeight && label.scrollWidth <= label.clientWidth + 1
+        && bounds.right <= linkBounds.right && bounds.bottom <= linkBounds.bottom;
+    });
+    label.textContent = original;
+    return results;
+  })()`);
+  if (!wrappedFolderNames.every(Boolean)) {
+    throw new Error('Long folder names must wrap fully inside the slide sidebar link.');
+  }
   await evaluate(cdp, `document.querySelector('.slide-rail-back').click()`);
   await waitFor(
     () => evaluate(cdp, `location.pathname === '/folders/native-folder' && Boolean(document.querySelector('.folder-dashboard-title'))`),

--- a/src/editor-output.mjs
+++ b/src/editor-output.mjs
@@ -349,6 +349,44 @@ export function createEditorOutput({ toast }) {
     }
   }
 
+  let exportingAll = false;
+
+  async function exportAllSlides() {
+    if (exportingAll || !activeProject()?.slides.length) return;
+    const project = structuredClone(activeProject());
+    const button = app.querySelector('[data-action="export-all"]');
+    const oldLabel = button?.innerHTML;
+    exportingAll = true;
+    if (button) button.disabled = true;
+    try {
+      const digits = Math.max(2, String(project.slides.length).length);
+      for (const [index, slide] of project.slides.entries()) {
+        if (button) button.textContent = `Rendering ${index + 1}/${project.slides.length}…`;
+        const blob = await renderSlideBlob(slide, project);
+        if (!blob) throw new Error(`Could not create PNG for slide ${index + 1}`);
+        const url = URL.createObjectURL(blob);
+        try {
+          const anchor = document.createElement("a");
+          anchor.href = url;
+          anchor.download = `${safeFilename(project.name)}-slide-${String(index + 1).padStart(digits, "0")}.png`;
+          anchor.click();
+        } finally {
+          setTimeout(() => URL.revokeObjectURL(url), 1000);
+        }
+      }
+      toast("All PNG downloads started in slide order");
+    } catch (error) {
+      console.error(error);
+      toast(error.code === "FONT_UNAVAILABLE" ? error.message.replace(/^\[FONT_UNAVAILABLE\]\s*/, "") : "Couldn’t download all slides. Please try again.");
+    } finally {
+      exportingAll = false;
+      if (button) {
+        button.disabled = false;
+        button.innerHTML = oldLabel;
+      }
+    }
+  }
+
   async function shareActiveSlide() {
     const slide = activeSlide();
     if (!slide) return;
@@ -448,6 +486,7 @@ export function createEditorOutput({ toast }) {
     clearSlideThumbnail,
     pruneSlideThumbnails,
     exportActiveSlide,
+    exportAllSlides,
     shareActiveSlide,
     shareAllSlides,
   };

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -101,6 +101,7 @@ export function createEditorUI({ projects, actions, output }) {
     refreshDashboardSlideThumbnails,
     disconnectDashboardSlideThumbnails,
     exportActiveSlide,
+    exportAllSlides,
     shareActiveSlide,
     shareAllSlides,
   } = output;
@@ -781,6 +782,7 @@ export function createEditorUI({ projects, actions, output }) {
     app.querySelector('[data-action="delete-selection"]')?.addEventListener("click", deleteSelectedLayers);
     app.querySelector('[data-action="done-crop"]')?.addEventListener("click", finishCrop);
     app.querySelector('[data-action="export"]')?.addEventListener("click", exportActiveSlide);
+    app.querySelector('[data-action="export-all"]')?.addEventListener("click", exportAllSlides);
     app.querySelector('[data-action="share"]')?.addEventListener("click", shareActiveSlide);
     app.querySelector('[data-action="share-all"]')?.addEventListener("click", shareAllSlides);
     app.querySelector('[data-action="toggle-inspector"]')?.addEventListener("click", () => {

--- a/src/editor-view.mjs
+++ b/src/editor-view.mjs
@@ -132,6 +132,9 @@ export function renderHeader({ editor = false } = {}) {
           <button class="button button--quiet" type="button" data-action="export" aria-label="Download current slide as PNG" title="Download PNG" ${activeSlide() ? "" : "disabled"}>
             ${icon("download")} <span>PNG</span>
           </button>
+          <button class="button button--quiet" type="button" data-action="export-all" aria-label="Download all slides as PNG" title="Download all slides" ${project.slides.length ? "" : "disabled"}>
+            ${icon("download")} <span>All</span>
+          </button>
         ` : `<div class="home-agent-connect">${agentConnectButton}<span class="agent-callout" aria-hidden="true"><span>Connect your agent</span><svg viewBox="0 0 110 90" fill="none"><path d="M5 80 C63 89 97 45 98 7 M88 18 L98 7 L106 20" /></svg></span></div><button class="button button--primary" type="button" data-action="new-project">New project</button>`}
         <a class="icon-button github-link" href="https://github.com/alexgusevski/carouselbot" target="_blank" rel="noopener noreferrer" aria-label="Open CarouselBot on GitHub" title="Open GitHub repository"><img class="github-mark" src="/assets/Octicons-mark-github.svg" alt="" /></a>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1418,6 +1418,7 @@ button:disabled {
 
 .slide-rail-back {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 10px;
   min-width: 0;
@@ -1447,9 +1448,9 @@ button:disabled {
 }
 
 .slide-rail-back span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .slide-rail-back + .rail-heading {


### PR DESCRIPTION
Folder names above the slides now wrap fully instead of truncating. A download-icon All button immediately after PNG downloads every slide in sidebar order, using project-name-slide-01.png filenames so files sort correctly. Rendering uses a project snapshot and runs sequentially. Browser regressions cover long folder names, toolbar placement, download order, dimensions, and repeated clicks. All six required local verification commands passed.