### PR TITLE
Clarify folder deletion and align creation icons

### DIFF
--- a/scripts/test-editor-browser.mjs
+++ b/scripts/test-editor-browser.mjs
@@ -1771,6 +1771,15 @@ try {
   const folderCreation = await evaluate(cdp, `(() => {
     const trigger = document.querySelector('[data-action="new-folder"]');
     const projectButton = document.querySelector('.new-project-action');
+    const projectIcon = projectButton.querySelector('svg');
+    const folderIcon = trigger.querySelector('svg');
+    if (!projectIcon || projectButton.textContent.includes('⊕') || projectIcon.querySelector('circle')) throw new Error('New project must use a plain plus icon');
+    for (const property of ['width', 'height']) {
+      if (getComputedStyle(projectIcon)[property] !== getComputedStyle(folderIcon)[property]) throw new Error('Creation icons must have matching ' + property);
+    }
+    for (const property of ['fontSize', 'fontWeight']) {
+      if (getComputedStyle(projectButton)[property] !== getComputedStyle(trigger)[property]) throw new Error('Creation labels must have matching ' + property);
+    }
     const ratio = projectButton.offsetHeight / trigger.offsetHeight;
     for (const method of ['cancel', 'close', 'outside', 'escape']) {
       trigger.click();
@@ -1853,6 +1862,15 @@ try {
     || nativeFolderCard.padding !== 8
     || nativeFolderCard.slotRadii.some((radius) => radius !== 7)
   ) throw new Error(`Folder card metadata or preview styling was incorrect: ${JSON.stringify(nativeFolderCard)}`);
+  await evaluate(cdp, `(() => {
+    const card = document.querySelector('.folder-card[data-folder-path="/native-folder"]');
+    card.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 200 }));
+    const action = [...document.querySelectorAll('.layer-menu-item')].find((item) => item.textContent === 'Move projects out and delete folder…');
+    if (!action?.querySelector('svg path[d="M4 7h16"]')) throw new Error('Folder removal must explain deletion and show a trash icon');
+    action.click();
+    if (document.querySelector('#unfile-folder-title')?.textContent !== 'Move projects out and delete folder?' || !document.querySelector('#unfile-folder-description')?.textContent.includes('the folder will be deleted')) throw new Error('Folder confirmation must explain deletion');
+    document.querySelector('[data-action="cancel-folder-dialog"]').click();
+  })()`);
   await waitFor(
     () => evaluate(cdp, `Boolean(document.querySelector('.folder-card[data-folder-path="/native-folder"] [data-project-cover-id="${folderUiProject.projectId}"] img[data-composite-cover="true"]'))`),
     "The folder card did not compose the first slide into its mosaic.",

--- a/src/editor-projects.mjs
+++ b/src/editor-projects.mjs
@@ -653,11 +653,11 @@ export function createEditorProjects({
     backdrop.className = "modal-backdrop folder-dialog";
     backdrop.innerHTML = `
       <section class="modal modal--confirm" role="alertdialog" aria-modal="true" aria-labelledby="unfile-folder-title" aria-describedby="unfile-folder-description">
-        <h2 id="unfile-folder-title">Move projects out?</h2>
-        <p id="unfile-folder-description">${projectCount} ${projectCount === 1 ? "project" : "projects"} will return to the home screen. No projects or slides will be deleted.</p>
+        <h2 id="unfile-folder-title">Move projects out and delete folder?</h2>
+        <p id="unfile-folder-description">${projectCount} ${projectCount === 1 ? "project" : "projects"} will return to the home screen, and the folder will be deleted. No projects or slides will be deleted.</p>
         <div class="modal-actions">
           <button class="button button--quiet" type="button" data-action="cancel-folder-dialog">Cancel</button>
-          <button class="button button--primary" type="button" data-action="confirm-folder-unfile">Move projects out</button>
+          <button class="button button--primary" type="button" data-action="confirm-folder-unfile">Delete folder</button>
         </div>
       </section>
     `;
@@ -682,7 +682,7 @@ export function createEditorProjects({
         console.error(error);
         cancelButton.disabled = false;
         confirmButton.disabled = false;
-        confirmButton.textContent = "Move projects out";
+        confirmButton.textContent = "Delete folder";
         toast("Couldn’t move these projects in your browser.");
       }
     });
@@ -766,7 +766,7 @@ export function createEditorProjects({
     unfileButton.type = "button";
     unfileButton.className = "layer-menu-item";
     unfileButton.setAttribute("role", "menuitem");
-    unfileButton.innerHTML = `${icon("back")}<span>Move projects out…</span>`;
+    unfileButton.innerHTML = `${icon("trash")}<span>Move projects out and delete folder…</span>`;
     unfileButton.addEventListener("click", (clickEvent) => {
       clickEvent.stopPropagation();
       closeLayerMenu();

--- a/src/editor-ui.mjs
+++ b/src/editor-ui.mjs
@@ -632,7 +632,7 @@ export function createEditorUI({ projects, actions, output }) {
           </div>
           <div class="project-grid">
             <div class="new-project-card">
-              <button class="new-project-action" type="button" data-action="new-project"><span aria-hidden="true">⊕</span> New project</button>
+              <button class="new-project-action" type="button" data-action="new-project">${icon("plus")} New project</button>
               <button class="new-folder-action" type="button" data-action="new-folder">${icon("folder")} New folder</button>
             </div>
             ${cards}

--- a/styles.css
+++ b/styles.css
@@ -1363,7 +1363,6 @@ button:disabled {
 .new-project-card button:hover { background: var(--panel); }
 .new-project-card button:focus-visible { outline: 2px solid var(--ink); outline-offset: -5px; }
 .new-project-card svg { width: 21px; height: 21px; }
-.new-project-action span { font-size: 26px; font-weight: 400; }
 .new-folder-modal { position: relative; }
 .new-folder-modal h2 { padding-right: 35px; }
 .folder-modal-close { position: absolute; top: 16px; right: 16px; }


### PR DESCRIPTION
## Summary

Replace the circled new-project glyph with a plain plus using the same icon dimensions and label typography as New folder. Clarify the folder context menu with a trash icon and “Move projects out and delete folder…”; the confirmation explains that projects are preserved.

## Verification

- [x] `npm test`
- [x] `npm run build`
- [x] `npm run test:editor`
- [x] `npm run test:editor:browser`
- [x] `npm run test:migration:browser`
- [x] `npm run test:mcp:browser:local`
- [x] No secrets, credentials, generated archives, or local state are included
- [x] No new dependencies or GitHub Actions
